### PR TITLE
byfn.sh: CURRENT_DIR issue with long paths fixed

### DIFF
--- a/first-network/byfn.sh
+++ b/first-network/byfn.sh
@@ -152,11 +152,11 @@ function replacePrivateKey () {
   CURRENT_DIR=$PWD
   cd crypto-config/peerOrganizations/org1.example.com/ca/
   PRIV_KEY=$(ls *_sk)
-  cd $CURRENT_DIR
+  cd "$CURRENT_DIR"
   sed $OPTS "s/CA1_PRIVATE_KEY/${PRIV_KEY}/g" docker-compose-e2e.yaml
   cd crypto-config/peerOrganizations/org2.example.com/ca/
   PRIV_KEY=$(ls *_sk)
-  cd $CURRENT_DIR
+  cd "$CURRENT_DIR"
   sed $OPTS "s/CA2_PRIVATE_KEY/${PRIV_KEY}/g" docker-compose-e2e.yaml
   # If MacOSX, remove the temporary backup of the docker-compose file
   if [ "$ARCH" == "Darwin" ]; then


### PR DESCRIPTION
Double quoted CURRENT_DIR var to allow right expansion for long paths. Before it caused a "too many arguments" for cd command