### PR TITLE
Added user1 role to fix registration error

### DIFF
--- a/fabcar/registerUser.js
+++ b/fabcar/registerUser.js
@@ -53,7 +53,7 @@ Fabric_Client.newDefaultKeyValueStore({ path: store_path
 
     // at this point we should have the admin user
     // first need to register the user with the CA server
-    return fabric_ca_client.register({enrollmentID: 'user1', affiliation: 'org1.department1'}, admin_user);
+    return fabric_ca_client.register({enrollmentID: 'user1', affiliation: 'org1.department1', role: 'client'}, admin_user);
 }).then((secret) => {
     // next we need to enroll the user with CA server
     console.log('Successfully registered user1 - secret:'+ secret);


### PR DESCRIPTION
Without the role specified in the call to the register function, an error is returned, demanding an identity type be provided in the call.
`Failed to register: Error: fabric-ca request register failed with errors [[{"code":0,"message":"No identity type provided. Please provide identity type"}]]
`
Adding `role: 'client'` in the register function call fixes this.

Signed-off-by: Kartik Shah krtk.6160@gmail.com