### PR TITLE
balance transfer: fix register response error

### DIFF
--- a/balance-transfer/app/helper.js
+++ b/balance-transfer/app/helper.js
@@ -92,6 +92,8 @@ var getRegisteredUser = async function(username, userOrg, isJson) {
 			}, adminUserObj);
 			logger.debug('Successfully got the secret for user %s',username);
 			user = await client.setUserContext({username:username, password:secret});
+			user._enrollmentSecret = secret;
+            		await client.setUserContext(user);
 			logger.debug('Successfully enrolled username %s  and setUserContext on the client object', username);
 		}
 		if(user && user.isEnrolled) {


### PR DESCRIPTION
It responses empty secret value after successfully register and enroll, and the value of "enrollmentSecret" in persistence is also empty string. The added code set the "_enrollmentSecret" value of the User object and update the user context in persistence again.
