### PR TITLE
 Increase Delay for BYFN CouchDB tests.

### DIFF
--- a/scripts/Jenkins_Scripts/byfn_eyfn.sh
+++ b/scripts/Jenkins_Scripts/byfn_eyfn.sh
@@ -40,9 +40,9 @@ fi
 
  echo "############### BYFN,EYFN CUSTOM CHANNEL WITH COUCHDB TEST ##############"
  echo "#########################################################################"
- echo y | ./byfn.sh -m up -c custom-channel-couchdb -s couchdb -t 60
+ echo y | ./byfn.sh -m up -c custom-channel-couchdb -s couchdb -t 60 -d 15
  err_Check $? custom-channel-couch couchdb
- echo y | ./eyfn.sh -m up -c custom-channel-couchdb -s couchdb -t 60
+ echo y | ./eyfn.sh -m up -c custom-channel-couchdb -s couchdb -t 60 -d 15
  err_Check $? custom-channel-couch
  echo y | ./eyfn.sh -m down
  echo


### PR DESCRIPTION
After Baseimage 0.4.11, the BYFN CouchDB tests are timing out with the default 3 second delay. This change is to increase the delay time to 15 seconds.