### PR TITLE
Block Query by hash Fixed

### DIFF
--- a/balance-transfer/app/query.js
+++ b/balance-transfer/app/query.js
@@ -115,7 +115,7 @@ var getBlockByHash = async function(peer, channelName, hash, username, org_name)
 			throw new Error(message);
 		}
 
-		let response_payload = await channel.queryBlockByHash(Buffer.from(hash), peer);
+		let response_payload = await channel.queryBlockByHash(Buffer.from(hash,'hex'), peer);
 		if (response_payload) {
 			logger.debug(response_payload);
 			return response_payload;

--- a/balance-transfer/testAPIs.sh
+++ b/balance-transfer/testAPIs.sh
@@ -209,11 +209,13 @@ echo
 
 echo "GET query Block by blockNumber"
 echo
-curl -s -X GET \
+BLOCK_INFO=$(curl -s -X GET \
   "http://localhost:4000/channels/mychannel/blocks/1?peer=peer0.org1.example.com" \
   -H "authorization: Bearer $ORG1_TOKEN" \
-  -H "content-type: application/json"
-echo
+  -H "content-type: application/json")
+echo $BLOCK_INFO
+# Assign previvious block hash to HASH 
+HASH=$(echo $BLOCK_INFO | jq ".header.previous_hash" | sed "s/\"//g")
 echo
 
 echo "GET query Transaction by TransactionID"
@@ -224,20 +226,17 @@ curl -s -X GET http://localhost:4000/channels/mychannel/transactions/$TRX_ID?pee
 echo
 echo
 
-############################################################################
-### TODO: What to pass to fetch the Block information
-############################################################################
-#echo "GET query Block by Hash"
-#echo
-#hash=????
-#curl -s -X GET \
-#  "http://localhost:4000/channels/mychannel/blocks?hash=$hash&peer=peer1" \
-#  -H "authorization: Bearer $ORG1_TOKEN" \
-#  -H "cache-control: no-cache" \
-#  -H "content-type: application/json" \
-#  -H "x-access-token: $ORG1_TOKEN"
-#echo
-#echo
+
+echo "GET query Block by Hash | Hash is $HASH"
+echo
+curl -s -X GET \
+  "http://localhost:4000/channels/mychannel/blocks?hash=$HASH&peer=peer0.org1.example.com" \
+  -H "authorization: Bearer $ORG1_TOKEN" \
+  -H "cache-control: no-cache" \
+  -H "content-type: application/json" \
+  -H "x-access-token: $ORG1_TOKEN"
+echo
+echo
 
 echo "GET query ChainInfo"
 echo


### PR DESCRIPTION
**### Block Query by hash Fixed in balance transfer app.**

changes 
1.
file path
fabric-samples/**### balance-transfer/app/query.js**
L 118
let response_payload = await channel.queryBlockByHash(Buffer.from(hash,'**hex**'), peer);

2.
file path
fabric-samples/**### balance-transfer/testAPIs.sh**
Assigned block info to variable BLOCK_INFO, assign previous block hash to variable HASH and pass it to query block by hash endpoint

