### PR TITLE
solve the warning in the first-network project

### DIFF
--- a/first-network/byfn.sh
+++ b/first-network/byfn.sh
@@ -383,7 +383,7 @@ function generateChannelArtifacts() {
   # Note: For some unknown reason (at least for now) the block file can't be
   # named orderer.genesis.block or the orderer will fail to launch!
   set -x
-  configtxgen -profile TwoOrgsOrdererGenesis -outputBlock ./channel-artifacts/genesis.block
+  configtxgen -profile TwoOrgsOrdererGenesis -channelID testchainid -outputBlock ./channel-artifacts/genesis.block
   res=$?
   set +x
   if [ $res -ne 0 ]; then

--- a/first-network/org3-artifacts/configtx.yaml
+++ b/first-network/org3-artifacts/configtx.yaml
@@ -23,6 +23,17 @@ Organizations:
 
         MSPDir: crypto-config/peerOrganizations/org3.example.com/msp
 
+        Policies:
+            Readers:
+                Type: Signature
+                Rule: "OR('Org3MSP.admin', 'Org3MSP.peer', 'Org3MSP.client')"
+            Writers:
+                Type: Signature
+                Rule: "OR('Org3MSP.admin', 'Org3MSP.client')"
+            Admins:
+                Type: Signature
+                Rule: "OR('Org3MSP.admin')"
+
         AnchorPeers:
             # AnchorPeers defines the location of peers which can be used
             # for cross org gossip communication.  Note, this value is only


### PR DESCRIPTION
1.Add the policy in the `first-network/org3-artifacts/configtx.yaml` to solve the problem of warning.
2.Add the channelID when generate the gensis file.
