### PR TITLE
Add script to install chaincode peer1.org1

### DIFF
--- a/first-network/scripts/script.sh
+++ b/first-network/scripts/script.sh
@@ -104,6 +104,10 @@ if [ "${NO_CHAINCODE}" != "true" ]; then
 	echo "Sending invoke transaction on peer0.org1 peer0.org2..."
 	chaincodeInvoke 0 1 0 2
 	
+	## Install chaincode on peer1.org1
+	echo "Installing chaincode on peer1.org1..."
+	installChaincode 1 1
+
 	## Install chaincode on peer1.org2
 	echo "Installing chaincode on peer1.org2..."
 	installChaincode 1 2


### PR DESCRIPTION
The first-network consists of four nodes. However, since the `byfn` script installs chaincode for test only on 3 peers. So, an error occurs when invoking the 4 peers from the HLF client.

Of course, you do not need to get success from 4 peers, 
but I think you should install all for the convenience of the beginners.
