### PR TITLE
Added stop script to remove `fabcar` chaincode containers and images.

### DIFF
--- a/fabcar/stopFabric.sh
+++ b/fabcar/stopFabric.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+#
+# Copyright The Linux Foundation All Rights Reserved
+#
+# SPDX-License-Identifier: Apache-2.0
+#
 set -e
 
 function clearContainers() {

--- a/fabcar/stopFabric.sh
+++ b/fabcar/stopFabric.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -e
+
+function clearContainers() {
+  CONTAINER_IDS=$(docker ps -a | awk '($2 ~ /dev-peer.*.fabcar.*/) {print $1}')
+  if [ -z "$CONTAINER_IDS" -o "$CONTAINER_IDS" == " " ]; then
+    echo "---- No containers available for deletion ----"
+  else
+    docker rm -f $CONTAINER_IDS
+  fi
+}
+
+function removeUnwantedImages() {
+  DOCKER_IMAGE_IDS=$(docker images | awk '($1 ~ /dev-peer.*.fabcar.*/) {print $3}')
+  if [ -z "$DOCKER_IMAGE_IDS" -o "$DOCKER_IMAGE_IDS" == " " ]; then
+    echo "---- No images available for deletion ----"
+  else
+    docker rmi -f $DOCKER_IMAGE_IDS
+  fi
+}
+
+cd ../first-network
+echo y | ./byfn.sh down
+clearContainers
+removeUnwantedImages


### PR DESCRIPTION
`byfn.sh` can only remove chaincode containers and images for `mycc`. Thus `byfn.sh down`, nor a future `byfn.sh up`, on its own, does not do a complete teardown of the `fabcar` network, the suggested script does.

The functions `clearContainers` and `removeUnwantedImages` have been copied from `first-network`'s `byfn.sh` and have only been modified to address the `fabcar` chaincode instead of the `mycc` chaincode.

In order not to overload this PR, no attempts of making `byfn.sh` parameterizable in respect of the chaincode to install or to use during teardown have been made.