### PR TITLE
Fix port numbers for peers in high-throughput

### DIFF
--- a/high-throughput/scripts/channel-setup.sh
+++ b/high-throughput/scripts/channel-setup.sh
@@ -22,7 +22,7 @@ peer channel update -o orderer.example.com:7050 -c $CHANNEL_NAME -f ../channel-a
 # peer1.org1 channel join
 echo "========== Joining peer1.org1.example.com to channel mychannel =========="
 export CORE_PEER_MSPCONFIGPATH=/opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp
-export CORE_PEER_ADDRESS=peer1.org1.example.com:7051
+export CORE_PEER_ADDRESS=peer1.org1.example.com:8051
 export CORE_PEER_LOCALMSPID="Org1MSP"
 export CORE_PEER_TLS_ROOTCERT_FILE=/opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/peerOrganizations/org1.example.com/peers/peer1.org1.example.com/tls/ca.crt
 peer channel join -b ${CHANNEL_NAME}.block
@@ -30,7 +30,7 @@ peer channel join -b ${CHANNEL_NAME}.block
 # peer0.org2 channel join
 echo "========== Joining peer0.org2.example.com to channel mychannel =========="
 export CORE_PEER_MSPCONFIGPATH=/opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp
-export CORE_PEER_ADDRESS=peer0.org2.example.com:7051
+export CORE_PEER_ADDRESS=peer0.org2.example.com:9051
 export CORE_PEER_LOCALMSPID="Org2MSP"
 export CORE_PEER_TLS_ROOTCERT_FILE=/opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/peerOrganizations/org2.example.com/peers/peer1.org2.example.com/tls/ca.crt
 peer channel join -b ${CHANNEL_NAME}.block
@@ -39,7 +39,7 @@ peer channel update -o orderer.example.com:7050 -c $CHANNEL_NAME -f ../channel-a
 # peer1.org2 channel join
 echo "========== Joining peer1.org2.example.com to channel mychannel =========="
 export CORE_PEER_MSPCONFIGPATH=/opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp
-export CORE_PEER_ADDRESS=peer1.org2.example.com:7051
+export CORE_PEER_ADDRESS=peer1.org2.example.com:10051
 export CORE_PEER_LOCALMSPID="Org2MSP"
 export CORE_PEER_TLS_ROOTCERT_FILE=/opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/peerOrganizations/org2.example.com/peers/peer1.org2.example.com/tls/ca.crt
 peer channel join -b ${CHANNEL_NAME}.block

--- a/high-throughput/scripts/install-chaincode.sh
+++ b/high-throughput/scripts/install-chaincode.sh
@@ -13,21 +13,21 @@ peer chaincode install -n $CC_NAME -v $1 -p github.com/hyperledger/fabric/exampl
 
 echo "========== Installing chaincode on peer1.org1 =========="
 export CORE_PEER_MSPCONFIGPATH=/opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp
-export CORE_PEER_ADDRESS=peer1.org1.example.com:7051
+export CORE_PEER_ADDRESS=peer1.org1.example.com:8051
 export CORE_PEER_LOCALMSPID="Org1MSP"
 export CORE_PEER_TLS_ROOTCERT_FILE=/opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/peerOrganizations/org1.example.com/peers/peer1.org1.example.com/tls/ca.crt
 peer chaincode install -n $CC_NAME -v $1 -p github.com/hyperledger/fabric/examples/chaincode/go
 
 echo "========== Installing chaincode on peer0.org2 =========="
 export CORE_PEER_MSPCONFIGPATH=/opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp
-export CORE_PEER_ADDRESS=peer0.org2.example.com:7051
+export CORE_PEER_ADDRESS=peer0.org2.example.com:9051
 export CORE_PEER_LOCALMSPID="Org2MSP"
 export CORE_PEER_TLS_ROOTCERT_FILE=/opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/peerOrganizations/org2.example.com/peers/peer0.org2.example.com/tls/ca.crt
 peer chaincode install -n $CC_NAME -v $1 -p github.com/hyperledger/fabric/examples/chaincode/go
 
 echo "========== Installing chaincode on peer1.org2 =========="
 export CORE_PEER_MSPCONFIGPATH=/opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp
-export CORE_PEER_ADDRESS=peer1.org2.example.com:7051
+export CORE_PEER_ADDRESS=peer1.org2.example.com:10051
 export CORE_PEER_LOCALMSPID="Org2MSP"
 export CORE_PEER_TLS_ROOTCERT_FILE=/opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/peerOrganizations/org2.example.com/peers/peer1.org2.example.com/tls/ca.crt
 peer chaincode install -n $CC_NAME -v $1 -p github.com/hyperledger/fabric/examples/chaincode/go


### PR DESCRIPTION
Updated ports number for peers connection to match the new docker setup used in version 1.4 (first-network sample)

![image](https://user-images.githubusercontent.com/10712269/68205674-283c5f80-ffcb-11e9-90bf-70ca33fcc5a8.png)
