### PR TITLE
[FAB-17268] Move fabcar sample to test network

### DIFF
--- a/fabcar/java/pom.xml
+++ b/fabcar/java/pom.xml
@@ -4,7 +4,7 @@
    <modelVersion>4.0.0</modelVersion>
    <groupId>fabcar-java</groupId>
    <artifactId>fabcar-java</artifactId>
-   <version>1.4.0-SNAPSHOT</version>
+   <version>2.0.0-SNAPSHOT</version>
    <build>
       <plugins>
          <plugin>

--- a/fabcar/java/src/main/java/org/example/ClientApp.java
+++ b/fabcar/java/src/main/java/org/example/ClientApp.java
@@ -22,12 +22,11 @@ public class ClientApp {
 		// Load a file system based wallet for managing identities.
 		Path walletPath = Paths.get("wallet");
 		Wallet wallet = Wallet.createFileSystemWallet(walletPath);
-
 		// load a CCP
-		Path networkConfigPath = Paths.get("..", "..", "first-network", "connection-org1.yaml");
+		Path networkConfigPath = Paths.get("..", "..", "test-network", "organizations", "peerOrganizations", "org1.example.com", "connection-org1.yaml");
 
 		Gateway.Builder builder = Gateway.createBuilder();
-		builder.identity(wallet, "user1").networkConfig(networkConfigPath).discovery(true);
+		builder.identity(wallet, "appUser").networkConfig(networkConfigPath).discovery(true);
 
 		// create a gateway connection
 		try (Gateway gateway = builder.connect()) {

--- a/fabcar/java/src/main/java/org/example/EnrollAdmin.java
+++ b/fabcar/java/src/main/java/org/example/EnrollAdmin.java
@@ -26,7 +26,7 @@ public class EnrollAdmin {
 		// Create a CA client for interacting with the CA.
 		Properties props = new Properties();
 		props.put("pemFile",
-			"../../first-network/crypto-config/peerOrganizations/org1.example.com/ca/ca.org1.example.com-cert.pem");
+			"../../test-network/organizations/peerOrganizations/org1.example.com/ca/ca.org1.example.com-cert.pem");
 		props.put("allowAllHostNames", "true");
 		HFCAClient caClient = HFCAClient.createNewInstance("https://localhost:7054", props);
 		CryptoSuite cryptoSuite = CryptoSuiteFactory.getDefault().getCryptoSuite();

--- a/fabcar/java/src/main/java/org/example/RegisterUser.java
+++ b/fabcar/java/src/main/java/org/example/RegisterUser.java
@@ -29,7 +29,7 @@ public class RegisterUser {
 		// Create a CA client for interacting with the CA.
 		Properties props = new Properties();
 		props.put("pemFile",
-			"../../first-network/crypto-config/peerOrganizations/org1.example.com/ca/ca.org1.example.com-cert.pem");
+			"../../test-network/organizations/peerOrganizations/org1.example.com/ca/ca.org1.example.com-cert.pem");
 		props.put("allowAllHostNames", "true");
 		HFCAClient caClient = HFCAClient.createNewInstance("https://localhost:7054", props);
 		CryptoSuite cryptoSuite = CryptoSuiteFactory.getDefault().getCryptoSuite();
@@ -39,9 +39,9 @@ public class RegisterUser {
 		Wallet wallet = Wallet.createFileSystemWallet(Paths.get("wallet"));
 
 		// Check to see if we've already enrolled the user.
-		boolean userExists = wallet.exists("user1");
+		boolean userExists = wallet.exists("appUser");
 		if (userExists) {
-			System.out.println("An identity for the user \"user1\" already exists in the wallet");
+			System.out.println("An identity for the user \"appUser\" already exists in the wallet");
 			return;
 		}
 
@@ -98,14 +98,14 @@ public class RegisterUser {
 		};
 
 		// Register the user, enroll the user, and import the new identity into the wallet.
-		RegistrationRequest registrationRequest = new RegistrationRequest("user1");
+		RegistrationRequest registrationRequest = new RegistrationRequest("appUser");
 		registrationRequest.setAffiliation("org1.department1");
-		registrationRequest.setEnrollmentID("user1");
+		registrationRequest.setEnrollmentID("appUser");
 		String enrollmentSecret = caClient.register(registrationRequest, admin);
-		Enrollment enrollment = caClient.enroll("user1", enrollmentSecret);
+		Enrollment enrollment = caClient.enroll("appUser", enrollmentSecret);
 		Identity user = Identity.createIdentity("Org1MSP", enrollment.getCert(), enrollment.getKey());
-		wallet.put("user1", user);
-		System.out.println("Successfully enrolled user \"user1\" and imported it into the wallet");
+		wallet.put("appUser", user);
+		System.out.println("Successfully enrolled user \"appUser\" and imported it into the wallet");
 	}
 
 }

--- a/fabcar/javascript/enrollAdmin.js
+++ b/fabcar/javascript/enrollAdmin.js
@@ -12,7 +12,7 @@ const path = require('path');
 async function main() {
     try {
         // load the network configuration
-        const ccpPath = path.resolve(__dirname, '..', '..', 'first-network', 'connection-org1.json');
+        const ccpPath = path.resolve(__dirname, '..', '..', 'test-network', 'organizations', 'peerOrganizations', 'org1.example.com', 'connection-org1.json');
         const ccp = JSON.parse(fs.readFileSync(ccpPath, 'utf8'));
 
         // Create a new CA client for interacting with the CA.

--- a/fabcar/javascript/invoke.js
+++ b/fabcar/javascript/invoke.js
@@ -11,7 +11,7 @@ const path = require('path');
 async function main() {
     try {
         // load the network configuration
-        const ccpPath = path.resolve(__dirname, '..', '..', 'first-network', 'connection-org1.json');
+        const ccpPath = path.resolve(__dirname, '..', '..', 'test-network', 'organizations', 'peerOrganizations', 'org1.example.com', 'connection-org1.json');
         let ccp = JSON.parse(fs.readFileSync(ccpPath, 'utf8'));
 
         // Create a new file system based wallet for managing identities.
@@ -20,16 +20,16 @@ async function main() {
         console.log(`Wallet path: ${walletPath}`);
 
         // Check to see if we've already enrolled the user.
-        const identity = await wallet.get('user1');
+        const identity = await wallet.get('appUser');
         if (!identity) {
-            console.log('An identity for the user "user1" does not exist in the wallet');
+            console.log('An identity for the user "appUser" does not exist in the wallet');
             console.log('Run the registerUser.js application before retrying');
             return;
         }
 
         // Create a new gateway for connecting to our peer node.
         const gateway = new Gateway();
-        await gateway.connect(ccp, { wallet, identity: 'user1', discovery: { enabled: true, asLocalhost: true } });
+        await gateway.connect(ccp, { wallet, identity: 'appUser', discovery: { enabled: true, asLocalhost: true } });
 
         // Get the network (channel) our contract is deployed to.
         const network = await gateway.getNetwork('mychannel');
@@ -39,7 +39,7 @@ async function main() {
 
         // Submit the specified transaction.
         // createCar transaction - requires 5 argument, ex: ('createCar', 'CAR12', 'Honda', 'Accord', 'Black', 'Tom')
-        // changeCarOwner transaction - requires 2 args , ex: ('changeCarOwner', 'CAR10', 'Dave')
+        // changeCarOwner transaction - requires 2 args , ex: ('changeCarOwner', 'CAR12', 'Dave')
         await contract.submitTransaction('createCar', 'CAR12', 'Honda', 'Accord', 'Black', 'Tom');
         console.log('Transaction has been submitted');
 

--- a/fabcar/javascript/query.js
+++ b/fabcar/javascript/query.js
@@ -12,7 +12,7 @@ const fs = require('fs');
 async function main() {
     try {
         // load the network configuration
-        const ccpPath = path.resolve(__dirname, '..', '..', 'first-network', 'connection-org1.json');
+        const ccpPath = path.resolve(__dirname, '..', '..', 'test-network', 'organizations', 'peerOrganizations', 'org1.example.com', 'connection-org1.json');
         const ccp = JSON.parse(fs.readFileSync(ccpPath, 'utf8'));
 
         // Create a new file system based wallet for managing identities.
@@ -21,16 +21,16 @@ async function main() {
         console.log(`Wallet path: ${walletPath}`);
 
         // Check to see if we've already enrolled the user.
-        const identity = await wallet.get('user1');
+        const identity = await wallet.get('appUser');
         if (!identity) {
-            console.log('An identity for the user "user1" does not exist in the wallet');
+            console.log('An identity for the user "appUser" does not exist in the wallet');
             console.log('Run the registerUser.js application before retrying');
             return;
         }
 
         // Create a new gateway for connecting to our peer node.
         const gateway = new Gateway();
-        await gateway.connect(ccp, { wallet, identity: 'user1', discovery: { enabled: true, asLocalhost: true } });
+        await gateway.connect(ccp, { wallet, identity: 'appUser', discovery: { enabled: true, asLocalhost: true } });
 
         // Get the network (channel) our contract is deployed to.
         const network = await gateway.getNetwork('mychannel');

--- a/fabcar/javascript/registerUser.js
+++ b/fabcar/javascript/registerUser.js
@@ -12,7 +12,7 @@ const path = require('path');
 async function main() {
     try {
         // load the network configuration
-        const ccpPath = path.resolve(__dirname, '..', '..', 'first-network', 'connection-org1.json');
+        const ccpPath = path.resolve(__dirname, '..', '..', 'test-network', 'organizations', 'peerOrganizations', 'org1.example.com', 'connection-org1.json');
         const ccp = JSON.parse(fs.readFileSync(ccpPath, 'utf8'));
 
         // Create a new CA client for interacting with the CA.
@@ -25,9 +25,9 @@ async function main() {
         console.log(`Wallet path: ${walletPath}`);
 
         // Check to see if we've already enrolled the user.
-        const userIdentity = await wallet.get('user1');
+        const userIdentity = await wallet.get('appUser');
         if (userIdentity) {
-            console.log('An identity for the user "user1" already exists in the wallet');
+            console.log('An identity for the user "appUser" already exists in the wallet');
             return;
         }
 
@@ -46,11 +46,11 @@ async function main() {
         // Register the user, enroll the user, and import the new identity into the wallet.
         const secret = await ca.register({
             affiliation: 'org1.department1',
-            enrollmentID: 'user1',
+            enrollmentID: 'appUser',
             role: 'client'
         }, adminUser);
         const enrollment = await ca.enroll({
-            enrollmentID: 'user1',
+            enrollmentID: 'appUser',
             enrollmentSecret: secret
         });
         const x509Identity = {
@@ -61,11 +61,11 @@ async function main() {
             mspId: 'Org1MSP',
             type: 'X.509',
         };
-        await wallet.put('user1', x509Identity);
-        console.log('Successfully registered and enrolled admin user "user1" and imported it into the wallet');
+        await wallet.put('appUser', x509Identity);
+        console.log('Successfully registered and enrolled admin user "appUser" and imported it into the wallet');
 
     } catch (error) {
-        console.error(`Failed to register user "user1": ${error}`);
+        console.error(`Failed to register user "appUser": ${error}`);
         process.exit(1);
     }
 }

--- a/fabcar/networkDown.sh
+++ b/fabcar/networkDown.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+#
+# Copyright IBM Corp All Rights Reserved
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Exit on first error
+set -ex
+
+# Bring the test network down
+pushd ../test-network
+./network.sh down
+popd
+
+# clean out any old identites in the wallets
+rm -rf javascript/wallet/*
+rm -rf java/wallet/*
+rm -rf typescript/wallet/*

--- a/fabcar/startFabric.sh
+++ b/fabcar/startFabric.sh
@@ -5,214 +5,33 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Exit on first error
-set -ex
+set -e
 
 # don't rewrite paths for Windows Git Bash users
 export MSYS_NO_PATHCONV=1
 starttime=$(date +%s)
 CC_SRC_LANGUAGE=${1:-"go"}
 CC_SRC_LANGUAGE=`echo "$CC_SRC_LANGUAGE" | tr [:upper:] [:lower:]`
-if [ "$CC_SRC_LANGUAGE" = "go" -o "$CC_SRC_LANGUAGE" = "golang"  ]; then
-	CC_RUNTIME_LANGUAGE=golang
-	CC_SRC_PATH=github.com/hyperledger/fabric-samples/chaincode/fabcar/go
-	echo Vendoring Go dependencies ...
-	pushd ../chaincode/fabcar/go
-	GO111MODULE=on go mod vendor
-	popd
-	echo Finished vendoring Go dependencies
-elif [ "$CC_SRC_LANGUAGE" = "java" ]; then
-	CC_RUNTIME_LANGUAGE=java
-	CC_SRC_PATH=/opt/gopath/src/github.com/hyperledger/fabric-samples/chaincode/fabcar/java/build/install/fabcar
-  echo Compiling Java code ...
-  pushd ../chaincode/fabcar/java
-  ./gradlew installDist
-  popd
-  echo Finished compiling Java code
-elif [ "$CC_SRC_LANGUAGE" = "javascript" ]; then
-	CC_RUNTIME_LANGUAGE=node # chaincode runtime language is node.js
-	CC_SRC_PATH=/opt/gopath/src/github.com/hyperledger/fabric-samples/chaincode/fabcar/javascript
-elif [ "$CC_SRC_LANGUAGE" = "typescript" ]; then
-	CC_RUNTIME_LANGUAGE=node # chaincode runtime language is node.js
-	CC_SRC_PATH=/opt/gopath/src/github.com/hyperledger/fabric-samples/chaincode/fabcar/typescript
-	echo Compiling TypeScript code into JavaScript ...
-	pushd ../chaincode/fabcar/typescript
-	npm install
-	npm run build
-	popd
-	echo Finished compiling TypeScript code into JavaScript
-else
+if [ "$CC_SRC_LANGUAGE" != "go" -a "$CC_SRC_LANGUAGE" != "golang" -a "$CC_SRC_LANGUAGE" != "java" \
+ -a  "$CC_SRC_LANGUAGE" != "javascript"  -a "$CC_SRC_LANGUAGE" != "typescript" ] ; then
+
 	echo The chaincode language ${CC_SRC_LANGUAGE} is not supported by this script
-	echo Supported chaincode languages are: go, java, javascript, and typescript
-	exit 1
+ 	echo Supported chaincode languages are: go, java, javascript, and typescript
+ 	exit 1
+
 fi
 
-
-# clean the keystore
-rm -rf ./hfc-key-store
+# clean out any old identites in the wallets
+rm -rf javascript/wallet/*
+rm -rf java/wallet/*
+rm -rf typescript/wallet/*
 
 # launch network; create channel and join peer to channel
-pushd ../first-network
-echo y | ./byfn.sh down
-echo y | ./byfn.sh up -a -n -s couchdb
+pushd ../test-network
+./network.sh down
+./network.sh up createChannel -ca -s couchdb
+./network.sh deployCC -l ${CC_SRC_LANGUAGE}
 popd
-
-CONFIG_ROOT=/opt/gopath/src/github.com/hyperledger/fabric/peer
-ORG1_MSPCONFIGPATH=${CONFIG_ROOT}/crypto/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp
-ORG1_TLS_ROOTCERT_FILE=${CONFIG_ROOT}/crypto/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls/ca.crt
-ORG2_MSPCONFIGPATH=${CONFIG_ROOT}/crypto/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp
-ORG2_TLS_ROOTCERT_FILE=${CONFIG_ROOT}/crypto/peerOrganizations/org2.example.com/peers/peer0.org2.example.com/tls/ca.crt
-ORDERER_TLS_ROOTCERT_FILE=${CONFIG_ROOT}/crypto/ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem
-
-PEER0_ORG1="docker exec
--e CORE_PEER_LOCALMSPID=Org1MSP
--e CORE_PEER_ADDRESS=peer0.org1.example.com:7051
--e CORE_PEER_MSPCONFIGPATH=${ORG1_MSPCONFIGPATH}
--e CORE_PEER_TLS_ROOTCERT_FILE=${ORG1_TLS_ROOTCERT_FILE}
-cli
-peer
---tls=true
---cafile=${ORDERER_TLS_ROOTCERT_FILE}
---orderer=orderer.example.com:7050"
-
-PEER1_ORG1="docker exec
--e CORE_PEER_LOCALMSPID=Org1MSP
--e CORE_PEER_ADDRESS=peer1.org1.example.com:8051
--e CORE_PEER_MSPCONFIGPATH=${ORG1_MSPCONFIGPATH}
--e CORE_PEER_TLS_ROOTCERT_FILE=${ORG1_TLS_ROOTCERT_FILE}
-cli
-peer
---tls=true
---cafile=${ORDERER_TLS_ROOTCERT_FILE}
---orderer=orderer.example.com:7050"
-
-PEER0_ORG2="docker exec
--e CORE_PEER_LOCALMSPID=Org2MSP
--e CORE_PEER_ADDRESS=peer0.org2.example.com:9051
--e CORE_PEER_MSPCONFIGPATH=${ORG2_MSPCONFIGPATH}
--e CORE_PEER_TLS_ROOTCERT_FILE=${ORG2_TLS_ROOTCERT_FILE}
-cli
-peer
---tls=true
---cafile=${ORDERER_TLS_ROOTCERT_FILE}
---orderer=orderer.example.com:7050"
-
-PEER1_ORG2="docker exec
--e CORE_PEER_LOCALMSPID=Org2MSP
--e CORE_PEER_ADDRESS=peer1.org2.example.com:10051
--e CORE_PEER_MSPCONFIGPATH=${ORG2_MSPCONFIGPATH}
--e CORE_PEER_TLS_ROOTCERT_FILE=${ORG2_TLS_ROOTCERT_FILE}
-cli
-peer
---tls=true
---cafile=${ORDERER_TLS_ROOTCERT_FILE}
---orderer=orderer.example.com:7050"
-
-echo "Packaging smart contract on peer0.org1.example.com"
-${PEER0_ORG1} lifecycle chaincode package \
-  fabcar.tar.gz \
-  --path "$CC_SRC_PATH" \
-  --lang "$CC_RUNTIME_LANGUAGE" \
-  --label fabcarv1
-
-echo "Installing smart contract on peer0.org1.example.com"
-${PEER0_ORG1} lifecycle chaincode install \
-  fabcar.tar.gz
-
-echo "Installing smart contract on peer1.org1.example.com"
-${PEER1_ORG1} lifecycle chaincode install \
-  fabcar.tar.gz
-
-echo "Determining package ID for smart contract on peer0.org1.example.com"
-REGEX='Package ID: ([^,]*), Label: fabcarv1'
-if [[ `${PEER0_ORG1} lifecycle chaincode queryinstalled` =~ $REGEX ]]; then
-  PACKAGE_ID_ORG1=${BASH_REMATCH[1]}
-else
-  echo Could not find package ID for fabcarv1 chaincode on peer0.org1.example.com
-  exit 1
-fi
-
-echo "Approving smart contract for org1"
-${PEER0_ORG1} lifecycle chaincode approveformyorg \
-  --package-id ${PACKAGE_ID_ORG1} \
-  --channelID mychannel \
-  --name fabcar \
-  --version 1.0 \
-  --signature-policy "AND('Org1MSP.member','Org2MSP.member')" \
-  --sequence 1 \
-  --waitForEvent
-
-echo "Packaging smart contract on peer0.org2.example.com"
-${PEER0_ORG2} lifecycle chaincode package \
-  fabcar.tar.gz \
-  --path "$CC_SRC_PATH" \
-  --lang "$CC_RUNTIME_LANGUAGE" \
-  --label fabcarv1
-
-echo "Installing smart contract on peer0.org2.example.com"
-${PEER0_ORG2} lifecycle chaincode install fabcar.tar.gz
-
-echo "Installing smart contract on peer1.org2.example.com"
-${PEER1_ORG2} lifecycle chaincode install fabcar.tar.gz
-
-echo "Determining package ID for smart contract on peer0.org2.example.com"
-REGEX='Package ID: ([^,]*), Label: fabcarv1'
-if [[ `${PEER0_ORG2} lifecycle chaincode queryinstalled` =~ $REGEX ]]; then
-  PACKAGE_ID_ORG2=${BASH_REMATCH[1]}
-else
-  echo Could not find package ID for fabcarv1 chaincode on peer0.org2.example.com
-  exit 1
-fi
-
-echo "Approving smart contract for org2"
-${PEER0_ORG2} lifecycle chaincode approveformyorg \
-  --package-id ${PACKAGE_ID_ORG2} \
-  --channelID mychannel \
-  --name fabcar \
-  --version 1.0 \
-  --signature-policy "AND('Org1MSP.member','Org2MSP.member')" \
-  --sequence 1 \
-  --waitForEvent
-
-echo "Committing smart contract"
-${PEER0_ORG1} lifecycle chaincode commit \
-  --channelID mychannel \
-  --name fabcar \
-  --version 1.0 \
-  --signature-policy "AND('Org1MSP.member','Org2MSP.member')" \
-  --sequence 1 \
-  --waitForEvent \
-  --peerAddresses peer0.org1.example.com:7051 \
-  --peerAddresses peer0.org2.example.com:9051 \
-  --tlsRootCertFiles ${ORG1_TLS_ROOTCERT_FILE} \
-  --tlsRootCertFiles ${ORG2_TLS_ROOTCERT_FILE}
-
-echo "Submitting initLedger transaction to smart contract on mychannel"
-# echo "The transaction is sent to all of the peers so that chaincode is built before receiving the following requests"
-${PEER0_ORG1} chaincode invoke \
-  -C mychannel \
-  -n fabcar \
-  -c '{"function":"initLedger","Args":[]}' \
-  --waitForEvent \
-  --waitForEventTimeout 300s \
-  --peerAddresses peer0.org1.example.com:7051 \
-  --peerAddresses peer0.org2.example.com:9051 \
-  --tlsRootCertFiles ${ORG1_TLS_ROOTCERT_FILE} \
-  --tlsRootCertFiles ${ORG2_TLS_ROOTCERT_FILE}
-
-# Temporary workaround (see FAB-15897) - cannot invoke across all four peers at the same time, so use a query to build
-# the chaincode across the remaining peers.
-${PEER1_ORG1} chaincode query \
-  -C mychannel \
-  -n fabcar \
-  -c '{"function":"queryAllCars","Args":[]}' \
-  --peerAddresses peer1.org1.example.com:8051 \
-  --tlsRootCertFiles ${ORG1_TLS_ROOTCERT_FILE}
-${PEER1_ORG2} chaincode query \
-  -C mychannel \
-  -n fabcar \
-  -c '{"function":"queryAllCars","Args":[]}' \
-  --peerAddresses peer1.org2.example.com:10051 \
-  --tlsRootCertFiles ${ORG2_TLS_ROOTCERT_FILE}
 
 cat <<EOF
 
@@ -231,7 +50,7 @@ JavaScript:
     npm install
 
   Then run the following applications to enroll the admin user, and register a new user
-  called user1 which will be used by the other applications to interact with the deployed
+  called appUser which will be used by the other applications to interact with the deployed
   FabCar contract:
     node enrollAdmin
     node registerUser
@@ -256,7 +75,7 @@ TypeScript:
     npm run build
 
   Then run the following applications to enroll the admin user, and register a new user
-  called user1 which will be used by the other applications to interact with the deployed
+  called appUser which will be used by the other applications to interact with the deployed
   FabCar contract:
     node dist/enrollAdmin
     node dist/registerUser
@@ -278,7 +97,7 @@ Java:
     mvn test
 
   The test will invoke the sample client app which perform the following:
-    - Enroll admin and user1 and import them into the wallet (if they don't already exist there)
+    - Enroll admin and appUser and import them into the wallet (if they don't already exist there)
     - Submit a transaction to create a new car
     - Evaluate a transaction (query) to return details of this car
     - Submit a transaction to change the owner of this car

--- a/fabcar/typescript/src/enrollAdmin.ts
+++ b/fabcar/typescript/src/enrollAdmin.ts
@@ -10,7 +10,7 @@ import * as path from 'path';
 async function main() {
     try {
         // load the network configuration
-        const ccpPath = path.resolve(__dirname, '..', '..', '..', 'first-network', 'connection-org1.json');
+        const ccpPath = path.resolve(__dirname, '..', '..', '..','test-network','organizations','peerOrganizations','org1.example.com', 'connection-org1.json');
         const ccp = JSON.parse(fs.readFileSync(ccpPath, 'utf8'));
 
         // Create a new CA client for interacting with the CA.

--- a/fabcar/typescript/src/invoke.ts
+++ b/fabcar/typescript/src/invoke.ts
@@ -9,7 +9,7 @@ import * as fs from 'fs';
 async function main() {
     try {
         // load the network configuration
-        const ccpPath = path.resolve(__dirname, '..', '..', '..', 'first-network', 'connection-org1.json');
+        const ccpPath = path.resolve(__dirname, '..', '..', '..','test-network','organizations','peerOrganizations','org1.example.com', 'connection-org1.json');
         const ccp = JSON.parse(fs.readFileSync(ccpPath, 'utf8'));
 
         // Create a new file system based wallet for managing identities.
@@ -18,16 +18,16 @@ async function main() {
         console.log(`Wallet path: ${walletPath}`);
 
         // Check to see if we've already enrolled the user.
-        const identity = await wallet.get('user1');
+        const identity = await wallet.get('appUser');
         if (!identity) {
-            console.log('An identity for the user "user1" does not exist in the wallet');
+            console.log('An identity for the user "appUser" does not exist in the wallet');
             console.log('Run the registerUser.ts application before retrying');
             return;
         }
 
         // Create a new gateway for connecting to our peer node.
         const gateway = new Gateway();
-        await gateway.connect(ccp, { wallet, identity: 'user1', discovery: { enabled: true, asLocalhost: true } });
+        await gateway.connect(ccp, { wallet, identity: 'appUser', discovery: { enabled: true, asLocalhost: true } });
 
         // Get the network (channel) our contract is deployed to.
         const network = await gateway.getNetwork('mychannel');
@@ -37,7 +37,7 @@ async function main() {
 
         // Submit the specified transaction.
         // createCar transaction - requires 5 argument, ex: ('createCar', 'CAR12', 'Honda', 'Accord', 'Black', 'Tom')
-        // changeCarOwner transaction - requires 2 args , ex: ('changeCarOwner', 'CAR10', 'Dave')
+        // changeCarOwner transaction - requires 2 args , ex: ('changeCarOwner', 'CAR12', 'Dave')
         await contract.submitTransaction('createCar', 'CAR12', 'Honda', 'Accord', 'Black', 'Tom');
         console.log(`Transaction has been submitted`);
 

--- a/fabcar/typescript/src/query.ts
+++ b/fabcar/typescript/src/query.ts
@@ -10,7 +10,7 @@ import * as fs from 'fs';
 async function main() {
     try {
         // load the network configuration
-        const ccpPath = path.resolve(__dirname, '..', '..', '..', 'first-network', 'connection-org1.json');
+        const ccpPath = path.resolve(__dirname, '..', '..', '..','test-network','organizations','peerOrganizations','org1.example.com', 'connection-org1.json');
         const ccp = JSON.parse(fs.readFileSync(ccpPath, 'utf8'));
 
         // Create a new file system based wallet for managing identities.
@@ -19,16 +19,16 @@ async function main() {
         console.log(`Wallet path: ${walletPath}`);
 
         // Check to see if we've already enrolled the user.
-        const identity = await wallet.get('user1');
+        const identity = await wallet.get('appUser');
         if (!identity) {
-            console.log('An identity for the user "user1" does not exist in the wallet');
+            console.log('An identity for the user "appUser" does not exist in the wallet');
             console.log('Run the registerUser.ts application before retrying');
             return;
         }
 
         // Create a new gateway for connecting to our peer node.
         const gateway = new Gateway();
-        await gateway.connect(ccp, { wallet, identity: 'user1', discovery: { enabled: true, asLocalhost: true } });
+        await gateway.connect(ccp, { wallet, identity: 'appUser', discovery: { enabled: true, asLocalhost: true } });
 
         // Get the network (channel) our contract is deployed to.
         const network = await gateway.getNetwork('mychannel');

--- a/fabcar/typescript/src/registerUser.ts
+++ b/fabcar/typescript/src/registerUser.ts
@@ -10,7 +10,7 @@ import * as fs from 'fs';
 async function main() {
     try {
         // load the network configuration
-        const ccpPath = path.resolve(__dirname, '..', '..', '..', 'first-network', 'connection-org1.json');
+        const ccpPath = path.resolve(__dirname, '..', '..', '..','test-network','organizations','peerOrganizations','org1.example.com', 'connection-org1.json');
         let ccp = JSON.parse(fs.readFileSync(ccpPath, 'utf8'));
 
         // Create a new CA client for interacting with the CA.
@@ -23,9 +23,9 @@ async function main() {
         console.log(`Wallet path: ${walletPath}`);
 
         // Check to see if we've already enrolled the user.
-        const userIdentity = await wallet.get('user1');
+        const userIdentity = await wallet.get('appUser');
         if (userIdentity) {
-            console.log('An identity for the user "user1" already exists in the wallet');
+            console.log('An identity for the user "appUser" already exists in the wallet');
             return;
         }
 
@@ -42,8 +42,8 @@ async function main() {
        const adminUser = await provider.getUserContext(adminIdentity, 'admin');
 
         // Register the user, enroll the user, and import the new identity into the wallet.
-        const secret = await ca.register({ affiliation: 'org1.department1', enrollmentID: 'user1', role: 'client' }, adminUser);
-        const enrollment = await ca.enroll({ enrollmentID: 'user1', enrollmentSecret: secret });
+        const secret = await ca.register({ affiliation: 'org1.department1', enrollmentID: 'appUser', role: 'client' }, adminUser);
+        const enrollment = await ca.enroll({ enrollmentID: 'appUser', enrollmentSecret: secret });
         const x509Identity: X509Identity = {
             credentials: {
                 certificate: enrollment.certificate,
@@ -52,11 +52,11 @@ async function main() {
             mspId: 'Org1MSP',
             type: 'X.509',
         };
-        await wallet.put('user1', x509Identity);
-        console.log('Successfully registered and enrolled admin user "user1" and imported it into the wallet');
+        await wallet.put('appUser', x509Identity);
+        console.log('Successfully registered and enrolled admin user "appUser" and imported it into the wallet');
 
     } catch (error) {
-        console.error(`Failed to register user "user1": ${error}`);
+        console.error(`Failed to register user "appUser": ${error}`);
         process.exit(1);
     }
 }

--- a/test-network/network.sh
+++ b/test-network/network.sh
@@ -34,7 +34,7 @@ function printHelp() {
   echo "    -s <dbtype> - the database backend to use: goleveldb (default) or couchdb"
   echo "    -r <max retry> - CLI times out after certain number of attempts (defaults to 5)"
   echo "    -d <delay> - delay duration in seconds (defaults to 3)"
-  echo "    -l <language> - the programming language of the chaincode to deploy: go (default), javascript, or java"
+  echo "    -l <language> - the programming language of the chaincode to deploy: go (default), java, javascript, typescript"
   echo "    -v <version>  - chaincode version. Must be a round number, 1, 2, 3, etc"
   echo "    -i <imagetag> - the tag to be used to launch the network (defaults to \"latest\")"
   echo "    -verbose - verbose mode"
@@ -370,7 +370,7 @@ function createChannel() {
 ## Call the script to isntall and instantiate a chaincode on the channel
 function deployCC() {
 
-  scripts/deployCC.sh $CHANNEL_NAME $CC_RUNTIME_LANGUAGE $VERSION $CLI_DELAY $MAX_RETRY $VERBOSE
+  scripts/deployCC.sh $CHANNEL_NAME $CC_SRC_LANGUAGE $VERSION $CLI_DELAY $MAX_RETRY $VERBOSE
 
   if [ $? -ne 0 ]; then
     echo "ERROR !!! Deploying chaincode failed"
@@ -434,7 +434,7 @@ COMPOSE_FILE_COUCH_ORG3=addOrg3/docker/docker-compose-couch-org3.yaml
 COMPOSE_FILE_ORG3=addOrg3/docker/docker-compose-org3.yaml
 #
 # use golang as the default language for chaincode
-CC_RUNTIME_LANGUAGE=golang
+CC_SRC_LANGUAGE=golang
 # Chaincode version
 VERSION=1
 # default image tag
@@ -491,7 +491,7 @@ while [[ $# -ge 1 ]] ; do
     shift
     ;;
   -l )
-    CC_RUNTIME_LANGUAGE="$2"
+    CC_SRC_LANGUAGE="$2"
     shift
     ;;
   -v )

--- a/test-network/scripts/deployCC.sh
+++ b/test-network/scripts/deployCC.sh
@@ -1,21 +1,21 @@
 
 CHANNEL_NAME="$1"
-CC_RUNTIME_LANGUAGE="$2"
+CC_SRC_LANGUAGE="$2"
 VERSION="$3"
 DELAY="$4"
 MAX_RETRY="$5"
 VERBOSE="$6"
 : ${CHANNEL_NAME:="mychannel"}
-: ${CC_RUNTIME_LANGUAGE:="golang"}
+: ${CC_SRC_LANGUAGE:="golang"}
 : ${VERSION:="1"}
 : ${DELAY:="3"}
 : ${MAX_RETRY:="5"}
 : ${VERBOSE:="false"}
-CC_RUNTIME_LANGUAGE=`echo "$CC_RUNTIME_LANGUAGE" | tr [:upper:] [:lower:]`
+CC_SRC_LANGUAGE=`echo "$CC_SRC_LANGUAGE" | tr [:upper:] [:lower:]`
 
 FABRIC_CFG_PATH=$PWD/../config/
 
-if [ "$CC_RUNTIME_LANGUAGE" = "go" -o "$CC_RUNTIME_LANGUAGE" = "golang" ] ; then
+if [ "$CC_SRC_LANGUAGE" = "go" -o "$CC_SRC_LANGUAGE" = "golang" ] ; then
 	CC_RUNTIME_LANGUAGE=golang
 	CC_SRC_PATH="../chaincode/fabcar/go/"
 
@@ -25,11 +25,11 @@ if [ "$CC_RUNTIME_LANGUAGE" = "go" -o "$CC_RUNTIME_LANGUAGE" = "golang" ] ; then
 	popd
 	echo Finished vendoring Go dependencies
 
-elif [ "$CC_RUNTIME_LANGUAGE" = "javascript" ]; then
+elif [ "$CC_SRC_LANGUAGE" = "javascript" ]; then
 	CC_RUNTIME_LANGUAGE=node # chaincode runtime language is node.js
 	CC_SRC_PATH="../chaincode/fabcar/javascript/"
 
-elif [ "$CC_RUNTIME_LANGUAGE" = "java" ]; then
+elif [ "$CC_SRC_LANGUAGE" = "java" ]; then
 	CC_RUNTIME_LANGUAGE=java
 	CC_SRC_PATH="../chaincode/fabcar/java/build/install/fabcar"
 
@@ -39,9 +39,20 @@ elif [ "$CC_RUNTIME_LANGUAGE" = "java" ]; then
 	popd
 	echo Finished compiling Java code
 
+elif [ "$CC_SRC_LANGUAGE" = "typescript" ]; then
+	CC_RUNTIME_LANGUAGE=node # chaincode runtime language is node.js
+	CC_SRC_PATH="../chaincode/fabcar/typescript/"
+
+	echo Compiling TypeScript code into JavaScript ...
+	pushd ../chaincode/fabcar/typescript
+	npm install
+	npm run build
+	popd
+	echo Finished compiling TypeScript code into JavaScript
+
 else
-	echo The chaincode language ${CC_RUNTIME_LANGUAGE} is not supported by this script
-	echo Supported chaincode languages are: go, javascript, java
+	echo The chaincode language ${CC_SRC_LANGUAGE} is not supported by this script
+	echo Supported chaincode languages are: go, java, javascript, and typescript
 	exit 1
 fi
 


### PR DESCRIPTION
Signed-off-by: NIKHIL E GUPTA <negupta@us.ibm.com>

Moving fabcar from byfn to the new test network.
- Using the CAs supported natively by the test network
- Using the scripts provided by the test network and remove the chaincode deployment in `startFabric.sh`
- Change connection profile path
- user1 > appUser since user 1 is already registered with the CA
- Adding a `stopFabric.sh` script so users do not have to change directories.

Related Issues:
This update to the sample corresponds to this update to the first app tutorial: https://github.com/hyperledger/fabric/pull/522
The two should be merged together.