### PR TITLE
Fixes Fabcar Java chaincode build dependency

### DIFF
--- a/chaincode/fabcar/java/build.gradle
+++ b/chaincode/fabcar/java/build.gradle
@@ -13,7 +13,7 @@ group 'org.hyperledger.fabric.samples'
 version '1.0-SNAPSHOT'
 
 dependencies {
-    implementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:1.4.3'
+    implementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:1.4+'
     implementation 'com.owlike:genson:1.5'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.4.2'
     testImplementation 'org.assertj:assertj-core:3.11.1'


### PR DESCRIPTION
This change updates build.gradle to fabric 1.4.4.

Signed-off-by: Arnaud J Le Hors <lehors@us.ibm.com>