### PR TITLE
[FAB-17447] Update to 2.0.0 Libraries

### DIFF
--- a/chaincode/abstore/java/build.gradle
+++ b/chaincode/abstore/java/build.gradle
@@ -25,7 +25,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.0.0-beta.1'
+    implementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.0.+'
 }
 
 shadowJar {

--- a/chaincode/abstore/javascript/package.json
+++ b/chaincode/abstore/javascript/package.json
@@ -12,6 +12,6 @@
 	"engine-strict": true,
 	"license": "Apache-2.0",
 	"dependencies": {
-		"fabric-shim": "beta"
+		"fabric-shim": "^2.0.0"
 	}
 }

--- a/chaincode/fabcar/java/build.gradle
+++ b/chaincode/fabcar/java/build.gradle
@@ -12,9 +12,9 @@ group 'org.hyperledger.fabric.samples'
 version '1.0-SNAPSHOT'
 
 dependencies {
-    compileOnly 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.0.0-beta.1'
+    compileOnly 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.0.+'
     implementation 'com.owlike:genson:1.5'
-    testImplementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.0.0-beta.1'
+    testImplementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.0.+'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.4.2'
     testImplementation 'org.assertj:assertj-core:3.11.1'
     testImplementation 'org.mockito:mockito-core:2.+'

--- a/chaincode/fabcar/javascript/package.json
+++ b/chaincode/fabcar/javascript/package.json
@@ -17,8 +17,8 @@
     "author": "Hyperledger",
     "license": "Apache-2.0",
     "dependencies": {
-        "fabric-contract-api": "beta",
-        "fabric-shim": "beta"
+        "fabric-contract-api": "^2.0.0",
+        "fabric-shim": "^2.0.0"
     },
     "devDependencies": {
         "chai": "^4.1.2",

--- a/chaincode/fabcar/typescript/package.json
+++ b/chaincode/fabcar/typescript/package.json
@@ -21,8 +21,8 @@
     "author": "Hyperledger",
     "license": "Apache-2.0",
     "dependencies": {
-        "fabric-contract-api": "beta",
-        "fabric-shim": "beta"
+        "fabric-contract-api": "^2.0.0",
+        "fabric-shim": "^2.0.0"
     },
     "devDependencies": {
         "@types/chai": "^4.1.7",

--- a/chaincode/marbles02/javascript/package.json
+++ b/chaincode/marbles02/javascript/package.json
@@ -12,6 +12,6 @@
 	"engine-strict": true,
 	"license": "Apache-2.0",
 	"dependencies": {
-		"fabric-shim": "beta"
+		"fabric-shim": "^2.0.0"
 	}
 }

--- a/commercial-paper/organization/digibank/application-java/pom.xml
+++ b/commercial-paper/organization/digibank/application-java/pom.xml
@@ -14,7 +14,7 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
 		<!-- fabric-chaincode-java -->
-		<fabric-chaincode-java.version>2.0.0-beta.1</fabric-chaincode-java.version>
+		<fabric-chaincode-java.version>[2.0.0,2.1)</fabric-chaincode-java.version>
 
 	</properties>
 

--- a/commercial-paper/organization/digibank/contract-java/shadow-build.gradle
+++ b/commercial-paper/organization/digibank/contract-java/shadow-build.gradle
@@ -20,7 +20,7 @@ repositories {
 }
 
 dependencies {
-    implementation group: 'org.hyperledger.fabric-chaincode-java', name: 'fabric-chaincode-shim', version: '2.0.0-beta.1'
+    implementation group: 'org.hyperledger.fabric-chaincode-java', name: 'fabric-chaincode-shim', version: '2.0.+'
     implementation group: 'org.json', name: 'json', version: '20180813'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.4.2'
     testImplementation 'org.assertj:assertj-core:3.11.1'

--- a/commercial-paper/organization/digibank/contract/package.json
+++ b/commercial-paper/organization/digibank/contract/package.json
@@ -18,8 +18,8 @@
     "author": "hyperledger",
     "license": "Apache-2.0",
     "dependencies": {
-        "fabric-contract-api": "beta",
-        "fabric-shim": "beta"
+        "fabric-contract-api": "^2.0.0",
+        "fabric-shim": "^2.0.0"
     },
     "devDependencies": {
         "chai": "^4.1.2",

--- a/commercial-paper/organization/magnetocorp/contract-java/build.gradle
+++ b/commercial-paper/organization/magnetocorp/contract-java/build.gradle
@@ -20,7 +20,7 @@ repositories {
 }
 
 dependencies {
-    implementation group: 'org.hyperledger.fabric-chaincode-java', name: 'fabric-chaincode-shim', version: '2.0.0-beta.1'
+    implementation group: 'org.hyperledger.fabric-chaincode-java', name: 'fabric-chaincode-shim', version: '2.0.+'
     implementation group: 'org.json', name: 'json', version: '20180813'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.4.2'
     testImplementation 'org.assertj:assertj-core:3.11.1'

--- a/commercial-paper/organization/magnetocorp/contract/package.json
+++ b/commercial-paper/organization/magnetocorp/contract/package.json
@@ -18,8 +18,8 @@
     "author": "hyperledger",
     "license": "Apache-2.0",
     "dependencies": {
-        "fabric-contract-api": "beta",
-        "fabric-shim": "beta"
+        "fabric-contract-api": "^2.0.0",
+        "fabric-shim": "^2.0.0"
     },
     "devDependencies": {
         "chai": "^4.1.2",


### PR DESCRIPTION
NodeSDK has not been released at 2.0.0 to date

Signed-off-by: Matthew B White <whitemat@uk.ibm.com>