### PR TITLE
Add CA's to docker test network

### DIFF
--- a/test-network/docker/docker-compose-ca.yaml
+++ b/test-network/docker/docker-compose-ca.yaml
@@ -5,6 +5,9 @@
 
 version: '2'
 
+networks:
+  test:
+
 services:
 
   ca_org1:
@@ -20,6 +23,8 @@ services:
     volumes:
       - ../organizations/fabric-ca/org1:/etc/hyperledger/fabric-ca-server
     container_name: ca_org1
+    networks:
+      - test
 
   ca_org2:
     image: hyperledger/fabric-ca:$IMAGE_TAG
@@ -34,6 +39,8 @@ services:
     volumes:
       - ../organizations/fabric-ca/org2:/etc/hyperledger/fabric-ca-server
     container_name: ca_org2
+    networks:
+      - test
 
   ca_orderer:
     image: hyperledger/fabric-ca:$IMAGE_TAG
@@ -48,3 +55,5 @@ services:
     volumes:
       - ../organizations/fabric-ca/ordererOrg:/etc/hyperledger/fabric-ca-server
     container_name: ca_orderer
+    networks:
+      - test


### PR DESCRIPTION
The CA's are not part of the `test` docker network. So applications written and hosted on the `test` network cannot interact with the CA

Signed-off-by: Brett Logan <brett.t.logan@ibm.com>