### PR TITLE
[FAB-17504] add Organizations.<Org>.OrdererEndpoints and remove Orderer.Addresses

### DIFF
--- a/first-network/configtx.yaml
+++ b/first-network/configtx.yaml
@@ -41,6 +41,9 @@ Organizations:
                 Type: Signature
                 Rule: "OR('OrdererMSP.admin')"
 
+        OrdererEndpoints:
+            - orderer.example.com:7050
+
     - &Org1
         # DefaultOrg defines the organization which is used in the sampleconfig
         # of the fabric.git development environment
@@ -214,9 +217,6 @@ Orderer: &OrdererDefaults
 
     # Orderer Type: The orderer implementation to start
     OrdererType: etcdraft
-
-    Addresses:
-        - orderer.example.com:7050
 
     # Batch Timeout: The amount of time to wait before creating a batch
     BatchTimeout: 2s

--- a/interest_rate_swaps/network/configtx.yaml
+++ b/interest_rate_swaps/network/configtx.yaml
@@ -41,6 +41,9 @@ Organizations:
                 Type: Signature
                 Rule: "OR('orderer.admin')"
 
+        OrdererEndpoints:
+            - irs-orderer:7050
+
     - &partya
         # DefaultOrg defines the organization which is used in the sampleconfig
         # of the fabric.git development environment
@@ -323,9 +326,6 @@ Orderer: &OrdererDefaults
     # Orderer Type: The orderer implementation to start
     # Available types are "solo" and "kafka"
     OrdererType: solo
-
-    Addresses:
-        - irs-orderer:7050
 
     # Batch Timeout: The amount of time to wait before creating a batch
     BatchTimeout: 2s

--- a/test-network/configtx/configtx.yaml
+++ b/test-network/configtx/configtx.yaml
@@ -41,6 +41,9 @@ Organizations:
                 Type: Signature
                 Rule: "OR('OrdererMSP.admin')"
 
+        OrdererEndpoints:
+            - orderer.example.com:7050
+
     - &Org1
         # DefaultOrg defines the organization which is used in the sampleconfig
         # of the fabric.git development environment
@@ -222,8 +225,6 @@ Orderer: &OrdererDefaults
           Port: 7050
           ClientTLSCert: ../organizations/ordererOrganizations/example.com/orderers/orderer.example.com/tls/server.crt
           ServerTLSCert: ../organizations/ordererOrganizations/example.com/orderers/orderer.example.com/tls/server.crt
-    Addresses:
-        - orderer.example.com:7050
 
     # Batch Timeout: The amount of time to wait before creating a batch
     BatchTimeout: 2s


### PR DESCRIPTION
Description

The use of Orderer.Addresses in configtx.yaml is deprecated, and Organizations.<Org>.OrdererEndpoints should be used instead. Therefore, update all the fabric-samples configtx.yaml files.

Related issues

https://jira.hyperledger.org/browse/FAB-17504

Signed-off-by: xu wu <wuxu1103@163.com>