### PR TITLE
Wrong groupId on hyperledger fabric dependencies for java-application

### DIFF
--- a/commercial-paper/organization/magnetocorp/application-java/pom.xml
+++ b/commercial-paper/organization/magnetocorp/application-java/pom.xml
@@ -75,7 +75,7 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>org.hyperledger.fabric-gateway-java</groupId>
+			<groupId>org.hyperledger</groupId>
 			<artifactId>fabric-gateway-java</artifactId>
 			<version>1.4.0-SNAPSHOT</version>
 		</dependency>


### PR DESCRIPTION
The remote artifactory https://hyperledger.jfrog.io/hyperledger/fabric-maven contain the hyperledger dependencies but the group id was wrong.

This PR corrects the groupId to be able to retrieve it locally and process the build.