### PR TITLE
test-network chaincode deployment script: init function does not exist on fabcar

### DIFF
--- a/test-network/scripts/deployCC.sh
+++ b/test-network/scripts/deployCC.sh
@@ -216,7 +216,7 @@ chaincodeInvokeInit() {
   # it using the "-o" option
   if [ -z "$CORE_PEER_TLS_ENABLED" -o "$CORE_PEER_TLS_ENABLED" = "false" ]; then
     set -x
-    peer chaincode invoke -o localhost:7050 -C $CHANNEL_NAME -n fabcar $PEER_CONN_PARMS --isInit -c '{"function":"init","Args":[]}' >&log.txt
+    peer chaincode invoke -o localhost:7050 -C $CHANNEL_NAME -n fabcar $PEER_CONN_PARMS --isInit -c '{"function":"initLedger","Args":[]}' >&log.txt
     res=$?
     set +x
   else


### PR DESCRIPTION
_initLedger_ must be called instead of _init_, that does not exist.
That also keeps consistency between the "with TLS" and "withtout" TLS cases.

Signed-off-by: Jonathan Gross <woodyjon@gmail.com>