### PR TITLE
Remove redundant invoke command from test network

### DIFF
--- a/test-network/scripts/deployCC.sh
+++ b/test-network/scripts/deployCC.sh
@@ -231,31 +231,6 @@ chaincodeInvokeInit() {
   echo
 }
 
-chaincodeInvoke() {
-  parsePeerConnectionParameters $@
-  res=$?
-  verifyResult $res "Invoke transaction failed on channel '$CHANNEL_NAME' due to uneven number of peer and org parameters "
-
-  # while 'peer chaincode' command can get the orderer endpoint from the
-  # peer (if join was successful), let's supply it directly as we know
-  # it using the "-o" option
-  if [ -z "$CORE_PEER_TLS_ENABLED" -o "$CORE_PEER_TLS_ENABLED" = "false" ]; then
-    set -x
-    peer chaincode invoke -o localhost:7050 -C $CHANNEL_NAME -n fabcar $PEER_CONN_PARMS  -c '{"function":"initLedger","Args":[]}' >&log.txt
-    res=$?
-    set +x
-  else
-    set -x
-    peer chaincode invoke -o localhost:7050 --ordererTLSHostnameOverride orderer.example.com --tls $CORE_PEER_TLS_ENABLED --cafile $ORDERER_CA -C $CHANNEL_NAME -n fabcar $PEER_CONN_PARMS -c '{"function":"initLedger","Args":[]}' >&log.txt
-    res=$?
-    set +x
-	fi
-  cat log.txt
-  verifyResult $res "Invoke execution on $PEERS failed "
-  echo "===================== Invoke transaction successful on $PEERS on channel '$CHANNEL_NAME' ===================== "
-  echo
-}
-
 chaincodeQuery() {
   ORG=$1
   setGlobals $ORG
@@ -325,9 +300,6 @@ queryCommitted 2
 chaincodeInvokeInit 1 2
 
 sleep 10
-
-## Invoke the chaincode
-chaincodeInvoke 1 2
 
 # Query chaincode on peer0.org1
 echo "Querying chaincode on peer0.org1..."


### PR DESCRIPTION
With the new Fabric contract class, you can initialize the chaincode by invoking any function, and the init will be invoked under the covers. As a result, the Init and then Invoke flow of the deployCC script is out of date, and the second invoke can be removed.

Thanks @woodyjon and @mbwhite for bringing this to my attention.

Signed-off-by: NIKHIL E GUPTA <negupta@us.ibm.com>