### PR TITLE
FAB-17419 Fix off_chain_data sample error

### DIFF
--- a/off_chain_data/blockProcessing.js
+++ b/off_chain_data/blockProcessing.js
@@ -50,14 +50,14 @@ exports.processBlockEvent = async function (channelname, block, use_couchdb, nan
             // filter through valid tx, refer below for list of error codes
             // https://github.com/hyperledger/fabric-sdk-node/blob/release-1.4/fabric-client/lib/protos/peer/transaction.proto
             if (txSuccess[dataItem] !== 0) {
-              continue();
+              continue;
             }
 
             const timestamp = dataArray[dataItem].payload.header.channel_header.timestamp;
 
             // continue to next tx if no actions are set
             if (dataArray[dataItem].payload.data.actions == undefined) {
-                continue();
+                continue;
             }
 
             // actions are stored as an array. In Fabric 1.4.3 only one


### PR DESCRIPTION
This PR replaces PR #101 which was submitted by @manish1635 and was badly mangled.

Before fix:

```
$ node blockEventListener.js
fabric-samples/off_chain_data/blockProcessing.js:53
              continue();
                      ^

SyntaxError: Unexpected token '('
    at Module._compile (internal/modules/cjs/loader.js:895:18)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:995:10)
    at Module.load (internal/modules/cjs/loader.js:815:32)
    at Function.Module._load (internal/modules/cjs/loader.js:727:14)
    at Module.require (internal/modules/cjs/loader.js:852:19)
    at require (internal/modules/cjs/helpers.js:74:18)
    at Object.<anonymous> (fabric-samples/off_chain_data/blockEventListener.js:48:25)
    at Module._compile (internal/modules/cjs/loader.js:959:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:995:10)
    at Module.load (internal/modules/cjs/loader.js:815:32)
```

After fix:

```
$ node blockEventListener.js
Wallet path: fabric-samples/off_chain_data/wallet
2020-03-31T06:14:26.643Z - error: [Channel.js]: Channel:mychannel received discovery error:failed constructing descriptor for chaincodes:<name:"_lifecycle" >
Listening for block events, nextblock: 0
Added block 0 to ProcessingMap
Added block 1 to ProcessingMap
Added block 2 to ProcessingMap
------------------------------------------------
Block Number: 0
------------------------------------------------
Block Number: 1
------------------------------------------------
Block Number: 2
```

Signed-off-by: Arnaud J Le Hors <lehors@us.ibm.com>