### PR TITLE
Remove left over rm -rf command from BYFN

### DIFF
--- a/test-network/network.sh
+++ b/test-network/network.sh
@@ -389,8 +389,6 @@ function networkDown() {
   # Don't remove the generated artifacts -- note, the ledgers are always removed
   if [ "$MODE" != "restart" ]; then
     # Bring down the network, deleting the volumes
-    #Delete any ledger backups
-    docker run -v $PWD:/tmp/first-network --rm hyperledger/fabric-tools:$IMAGETAG rm -Rf /tmp/first-network/ledgers-backup
     #Cleanup the chaincode containers
     clearContainers
     #Cleanup images


### PR DESCRIPTION
Signed-off-by: NIKHIL E GUPTA <negupta@us.ibm.com>

This line in the `networkDown()` cleanup is left over from the network upgrade portion of BYFN. It can be removed from the test network.