### PR TITLE
Remove TLS = false if statement in test network

### DIFF
--- a/test-network/scripts/deployCC.sh
+++ b/test-network/scripts/deployCC.sh
@@ -107,16 +107,9 @@ queryInstalled() {
 approveForMyOrg() {
   ORG=$1
   setGlobals $ORG
-
-  if [ -z "$CORE_PEER_TLS_ENABLED" -o "$CORE_PEER_TLS_ENABLED" = "false" ] ; then
-    set -x
-    peer lifecycle chaincode approveformyorg -o localhost:7050 --channelID $CHANNEL_NAME --name fabcar --version ${VERSION} --init-required --package-id ${PACKAGE_ID} --sequence ${VERSION} --waitForEvent >&log.txt
-    set +x
-  else
-    set -x
-    peer lifecycle chaincode approveformyorg -o localhost:7050 --ordererTLSHostnameOverride orderer.example.com --tls $CORE_PEER_TLS_ENABLED --cafile $ORDERER_CA --channelID $CHANNEL_NAME --name fabcar --version ${VERSION} --init-required --package-id ${PACKAGE_ID} --sequence ${VERSION} >&log.txt
-    set +x
-  fi
+  set -x
+  peer lifecycle chaincode approveformyorg -o localhost:7050 --ordererTLSHostnameOverride orderer.example.com --tls $CORE_PEER_TLS_ENABLED --cafile $ORDERER_CA --channelID $CHANNEL_NAME --name fabcar --version ${VERSION} --init-required --package-id ${PACKAGE_ID} --sequence ${VERSION} >&log.txt
+  set +x
   cat log.txt
   verifyResult $res "Chaincode definition approved on peer0.org${ORG} on channel '$CHANNEL_NAME' failed"
   echo "===================== Chaincode definition approved on peer0.org${ORG} on channel '$CHANNEL_NAME' ===================== "
@@ -140,7 +133,6 @@ checkCommitReadiness() {
     peer lifecycle chaincode checkcommitreadiness --channelID $CHANNEL_NAME --name fabcar --version ${VERSION} --sequence ${VERSION} --output json --init-required >&log.txt
     res=$?
     set +x
-		#test $res -eq 0 || continue
     let rc=0
     for var in "$@"
     do
@@ -167,17 +159,10 @@ commitChaincodeDefinition() {
   # while 'peer chaincode' command can get the orderer endpoint from the
   # peer (if join was successful), let's supply it directly as we know
   # it using the "-o" option
-  if [ -z "$CORE_PEER_TLS_ENABLED" -o "$CORE_PEER_TLS_ENABLED" = "false" ] ; then
-    set -x
-    peer lifecycle chaincode commit -o localhost:7050 --channelID $CHANNEL_NAME --name fabcar $PEER_CONN_PARMS --version ${VERSION} --sequence ${VERSION} --init-required >&log.txt
-    res=$?
-    set +x
-  else
-    set -x
-    peer lifecycle chaincode commit -o localhost:7050 --ordererTLSHostnameOverride orderer.example.com --tls $CORE_PEER_TLS_ENABLED --cafile $ORDERER_CA --channelID $CHANNEL_NAME --name fabcar $PEER_CONN_PARMS --version ${VERSION} --sequence ${VERSION} --init-required >&log.txt
-    res=$?
-    set +x
-  fi
+  set -x
+  peer lifecycle chaincode commit -o localhost:7050 --ordererTLSHostnameOverride orderer.example.com --tls $CORE_PEER_TLS_ENABLED --cafile $ORDERER_CA --channelID $CHANNEL_NAME --name fabcar $PEER_CONN_PARMS --version ${VERSION} --sequence ${VERSION} --init-required >&log.txt
+  res=$?
+  set +x
   cat log.txt
   verifyResult $res "Chaincode definition commit failed on peer0.org${ORG} on channel '$CHANNEL_NAME' failed"
   echo "===================== Chaincode definition committed on channel '$CHANNEL_NAME' ===================== "
@@ -225,17 +210,10 @@ chaincodeInvokeInit() {
   # while 'peer chaincode' command can get the orderer endpoint from the
   # peer (if join was successful), let's supply it directly as we know
   # it using the "-o" option
-  if [ -z "$CORE_PEER_TLS_ENABLED" -o "$CORE_PEER_TLS_ENABLED" = "false" ]; then
-    set -x
-    peer chaincode invoke -o localhost:7050 -C $CHANNEL_NAME -n fabcar $PEER_CONN_PARMS --isInit -c '{"function":"initLedger","Args":[]}' >&log.txt
-    res=$?
-    set +x
-  else
-    set -x
-    peer chaincode invoke -o localhost:7050 --ordererTLSHostnameOverride orderer.example.com --tls $CORE_PEER_TLS_ENABLED --cafile $ORDERER_CA -C $CHANNEL_NAME -n fabcar $PEER_CONN_PARMS --isInit -c '{"function":"initLedger","Args":[]}' >&log.txt
-    res=$?
-    set +x
-  fi
+  set -x
+  peer chaincode invoke -o localhost:7050 --ordererTLSHostnameOverride orderer.example.com --tls $CORE_PEER_TLS_ENABLED --cafile $ORDERER_CA -C $CHANNEL_NAME -n fabcar $PEER_CONN_PARMS --isInit -c '{"function":"initLedger","Args":[]}' >&log.txt
+  res=$?
+  set +x
   cat log.txt
   verifyResult $res "Invoke execution on $PEERS failed "
   echo "===================== Invoke transaction successful on $PEERS on channel '$CHANNEL_NAME' ===================== "

--- a/test-network/scripts/envVar.sh
+++ b/test-network/scripts/envVar.sh
@@ -25,7 +25,7 @@ setGlobals() {
   if [ -z "$OVERRIDE_ORG" ]; then
     USING_ORG=$1
   else
-    USING_ORG="${OVERRIDE_ORG}"  
+    USING_ORG="${OVERRIDE_ORG}"
   fi
   echo "Using organization ${USING_ORG}"
   if [ $USING_ORG -eq 1 ]; then
@@ -54,24 +54,22 @@ setGlobals() {
 }
 
 # parsePeerConnectionParameters $@
-# Helper function that takes the parameters from a chaincode operation
-# (e.g. invoke, query, instantiate) and checks for an even number of
-# peers and associated org, then sets $PEER_CONN_PARMS and $PEERS
+# Helper function that sets the peer connection parameters for a chaincode
+# operation
 parsePeerConnectionParameters() {
-  # check for uneven number of peer and org parameters
 
   PEER_CONN_PARMS=""
   PEERS=""
   while [ "$#" -gt 0 ]; do
     setGlobals $1
     PEER="peer0.org$1"
+    ## Set peer adresses
     PEERS="$PEERS $PEER"
     PEER_CONN_PARMS="$PEER_CONN_PARMS --peerAddresses $CORE_PEER_ADDRESS"
-    if [ -z "$CORE_PEER_TLS_ENABLED" -o "$CORE_PEER_TLS_ENABLED" = "true" ]; then
-      TLSINFO=$(eval echo "--tlsRootCertFiles \$PEER0_ORG$1_CA")
-      PEER_CONN_PARMS="$PEER_CONN_PARMS $TLSINFO"
-    fi
-    # shift by two to get the next pair of peer/org parameters
+    ## Set path to TLS certificate
+    TLSINFO=$(eval echo "--tlsRootCertFiles \$PEER0_ORG$1_CA")
+    PEER_CONN_PARMS="$PEER_CONN_PARMS $TLSINFO"
+    # shift by one to get to the next organization
     shift
   done
   # remove leading space for output

--- a/test-network/scripts/org3-scripts/envVarCLI.sh
+++ b/test-network/scripts/org3-scripts/envVarCLI.sh
@@ -45,31 +45,6 @@ setGlobals() {
   fi
 }
 
-# parsePeerConnectionParameters $@
-# Helper function that takes the parameters from a chaincode operation
-# (e.g. invoke, query, instantiate) and checks for an even number of
-# peers and associated org, then sets $PEER_CONN_PARMS and $PEERS
-parsePeerConnectionParameters() {
-  # check for uneven number of peer and org parameters
-
-  PEER_CONN_PARMS=""
-  PEERS=""
-  while [ "$#" -gt 0 ]; do
-    setGlobals $1
-    PEER="peer0.org$1"
-    PEERS="$PEERS $PEER"
-    PEER_CONN_PARMS="$PEER_CONN_PARMS --peerAddresses $CORE_PEER_ADDRESS"
-    if [ -z "$CORE_PEER_TLS_ENABLED" -o "$CORE_PEER_TLS_ENABLED" = "true" ]; then
-      TLSINFO=$(eval echo "--tlsRootCertFiles \$PEER0_ORG$1_CA")
-      PEER_CONN_PARMS="$PEER_CONN_PARMS $TLSINFO"
-    fi
-    # shift by two to get the next pair of peer/org parameters
-    shift
-  done
-  # remove leading space for output
-  PEERS="$(echo -e "$PEERS" | sed -e 's/^[[:space:]]*//')"
-}
-
 verifyResult() {
   if [ $1 -ne 0 ]; then
     echo "!!!!!!!!!!!!!!! "$2" !!!!!!!!!!!!!!!!"

--- a/test-network/scripts/org3-scripts/step1org3.sh
+++ b/test-network/scripts/org3-scripts/step1org3.sh
@@ -38,15 +38,9 @@ fetchChannelConfig() {
   setGlobals $ORG
 
   echo "Fetching the most recent configuration block for the channel"
-  if [ -z "$CORE_PEER_TLS_ENABLED" -o "$CORE_PEER_TLS_ENABLED" = "false" ]; then
-    set -x
-    peer channel fetch config config_block.pb -o orderer.example.com:7050 -c $CHANNEL --cafile $ORDERER_CA
-    set +x
-  else
-    set -x
-    peer channel fetch config config_block.pb -o orderer.example.com:7050 --ordererTLSHostnameOverride orderer.example.com -c $CHANNEL --tls --cafile $ORDERER_CA
-    set +x
-  fi
+  set -x
+  peer channel fetch config config_block.pb -o orderer.example.com:7050 --ordererTLSHostnameOverride orderer.example.com -c $CHANNEL --tls --cafile $ORDERER_CA
+  set +x
 
   echo "Decoding config block to JSON and isolating config to ${OUTPUT}"
   set -x


### PR DESCRIPTION
Signed-off-by: NIKHIL E GUPTA <negupta@us.ibm.com>

The create Channel and deploy chaincode scripts contained an if statement on whether TLS was enabled for many commands
```
  if [ -z "$CORE_PEER_TLS_ENABLED" -o "$CORE_PEER_TLS_ENABLED" = "false" ] ; then
```
I assume this is left over from older versions of 1.x, and from Kafka or solo consensus. Since TLS is required for RAFT and other features, I removed the TLS not enabled option.