### PR TITLE
Update samples to use v2.0 or later dependencies

### DIFF
--- a/chaincode/abstore/java/build.gradle
+++ b/chaincode/abstore/java/build.gradle
@@ -25,7 +25,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.0.+'
+    implementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.+'
 }
 
 shadowJar {

--- a/chaincode/fabcar/java/build.gradle
+++ b/chaincode/fabcar/java/build.gradle
@@ -12,9 +12,9 @@ group 'org.hyperledger.fabric.samples'
 version '1.0-SNAPSHOT'
 
 dependencies {
-    compileOnly 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.0.+'
+    compileOnly 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.+'
     implementation 'com.owlike:genson:1.5'
-    testImplementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.0.+'
+    testImplementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.+'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.4.2'
     testImplementation 'org.assertj:assertj-core:3.11.1'
     testImplementation 'org.mockito:mockito-core:2.+'

--- a/commercial-paper/organization/digibank/application-java/pom.xml
+++ b/commercial-paper/organization/digibank/application-java/pom.xml
@@ -14,7 +14,7 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
 		<!-- fabric-chaincode-java -->
-		<fabric-chaincode-java.version>[2.0.0,2.1)</fabric-chaincode-java.version>
+		<fabric-chaincode-java.version>[2.0,3.0)</fabric-chaincode-java.version>
 
 	</properties>
 

--- a/commercial-paper/organization/digibank/application/package.json
+++ b/commercial-paper/organization/digibank/application/package.json
@@ -10,8 +10,8 @@
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
-    "fabric-network": "beta",
-    "fabric-ca-client": "beta",
+    "fabric-network": "^2.1.0",
+    "fabric-ca-client": "^2.1.0",
     "js-yaml": "^3.12.0"
   },
   "devDependencies": {

--- a/commercial-paper/organization/digibank/contract-java/build.gradle
+++ b/commercial-paper/organization/digibank/contract-java/build.gradle
@@ -19,7 +19,7 @@ repositories {
 }
 
 dependencies {
-    compileOnly group: 'org.hyperledger.fabric-chaincode-java', name: 'fabric-chaincode-shim', version: '1.4.2'
+    compileOnly group: 'org.hyperledger.fabric-chaincode-java', name: 'fabric-chaincode-shim', version: '2.+'
     compile group: 'org.json', name: 'json', version: '20180813'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.4.2'
     testImplementation 'org.assertj:assertj-core:3.11.1'

--- a/commercial-paper/organization/digibank/contract-java/shadow-build.gradle
+++ b/commercial-paper/organization/digibank/contract-java/shadow-build.gradle
@@ -20,7 +20,7 @@ repositories {
 }
 
 dependencies {
-    implementation group: 'org.hyperledger.fabric-chaincode-java', name: 'fabric-chaincode-shim', version: '2.0.+'
+    implementation group: 'org.hyperledger.fabric-chaincode-java', name: 'fabric-chaincode-shim', version: '2.+'
     implementation group: 'org.json', name: 'json', version: '20180813'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.4.2'
     testImplementation 'org.assertj:assertj-core:3.11.1'

--- a/commercial-paper/organization/magnetocorp/application-java/pom.xml
+++ b/commercial-paper/organization/magnetocorp/application-java/pom.xml
@@ -14,7 +14,7 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
 		<!-- fabric-chaincode-java -->
-		<fabric-chaincode-java.version>1.4.2</fabric-chaincode-java.version>
+		<fabric-chaincode-java.version>[2.0,3.0)</fabric-chaincode-java.version>
 
 	</properties>
 

--- a/commercial-paper/organization/magnetocorp/application/package.json
+++ b/commercial-paper/organization/magnetocorp/application/package.json
@@ -10,8 +10,8 @@
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
-    "fabric-network": "beta",
-    "fabric-ca-client": "beta",
+    "fabric-network": "^2.1.0",
+    "fabric-ca-client": "^2.1.0",
     "js-yaml": "^3.12.0"
   },
   "devDependencies": {

--- a/commercial-paper/organization/magnetocorp/contract-java/build.gradle
+++ b/commercial-paper/organization/magnetocorp/contract-java/build.gradle
@@ -20,7 +20,7 @@ repositories {
 }
 
 dependencies {
-    implementation group: 'org.hyperledger.fabric-chaincode-java', name: 'fabric-chaincode-shim', version: '2.0.+'
+    implementation group: 'org.hyperledger.fabric-chaincode-java', name: 'fabric-chaincode-shim', version: '2.+'
     implementation group: 'org.json', name: 'json', version: '20180813'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.4.2'
     testImplementation 'org.assertj:assertj-core:3.11.1'

--- a/fabcar/typescript/package.json
+++ b/fabcar/typescript/package.json
@@ -18,8 +18,8 @@
     "author": "Hyperledger",
     "license": "Apache-2.0",
     "dependencies": {
-        "fabric-ca-client": "beta",
-        "fabric-network": "beta"
+        "fabric-ca-client": "^2.1.0",
+        "fabric-network": "^2.1.0"
     },
     "devDependencies": {
         "@types/chai": "^4.1.7",

--- a/off_chain_data/package.json
+++ b/off_chain_data/package.json
@@ -15,8 +15,8 @@
     "author": "Hyperledger",
     "license": "Apache-2.0",
     "dependencies": {
-        "fabric-ca-client": "beta",
-        "fabric-network": "beta"
+        "fabric-ca-client": "^2.1.0",
+        "fabric-network": "^2.1.0"
     },
     "devDependencies": {
         "chai": "^4.2.0",


### PR DESCRIPTION
Update application and chaincode dependencies to use v2.0 or
later versions in package.json, build.gradle, pom.xml files.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>