### PR TITLE
[FAB-17818] Update documetation in Fabric samples repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,27 @@
 [//]: # (SPDX-License-Identifier: CC-BY-4.0)
 
-## Hyperledger Fabric Samples
+# Hyperledger Fabric Samples
 
-Please visit the [installation instructions](http://hyperledger-fabric.readthedocs.io/en/latest/install.html)
-to ensure you have the correct prerequisites installed. Please use the
-version of the documentation that matches the version of the software you
-intend to use to ensure alignment.
+You can use Fabric samples to get started working with Hyperledger Fabric, explore important Fabric features, and learn how to build applications that can interact with blockchain networks using the Fabric SDKs. To learn more about Hyperledger Fabric, visit the [Fabric documentation](https://hyperledger-fabric.readthedocs.io/en/master).
 
-## Download Binaries and Docker Images
+## Getting started with the Fabric samples
 
-The installation instructions will utilize `scripts/bootstrap.sh` (available in the fabric repository)
-script to download all of the requisite Hyperledger Fabric binaries and docker
-images, and tag the images with the 'latest' tag. Optionally,
-specify a version for fabric, fabric-ca and thirdparty images. If versions
-are not passed, the latest available versions will be downloaded.
+To use the Fabric samples, you need to download the Fabric Docker images and the Fabric CLI tools. First, make sure that you have installed all of the [Fabric prerequisites](https://hyperledger-fabric.readthedocs.io/en/master/prereqs.html). You can then follow the instructions to [Install the Fabric Samples, Binaries, and Docker Images](https://hyperledger-fabric.readthedocs.io/en/master/install.html) in the Fabric documentation. In addition to downloading the Fabric images and tool binaries, the instructions will make you clone the Fabric samples on your local machine.
 
-The script will also clone fabric-samples repository using the version tag that
-is aligned with the Fabric version.
+## Guide to the Fabric samples
 
-You can also download the script and execute locally:
+You can use the following table to learn more about each sample, and find the corresponding tutorial or documentation.
 
-```bash
-# Fetch bootstrap.sh from fabric repository using
-curl -sS https://raw.githubusercontent.com/hyperledger/fabric/master/scripts/bootstrap.sh -o ./scripts/bootstrap.sh
-# Change file mode to executable
-chmod +x ./scripts/bootstrap.sh
-# Download binaries and docker images
-./scripts/bootstrap.sh [version] [ca version] [thirdparty_version]
-```
+|  **Sample** | **Description** | **Documentation** |
+| -------------|------------------------------|------------------|
+| [Fabric test network](test-network) | Get started by deploying a basic Fabric network on your local machine. | [Using the Fabric test network](https://hyperledger-fabric.readthedocs.io/en/master/test_network.html) |
+| [Fabcar](fabcar) | Learn how to use the Fabric SDK's to invoke smart contracts from your client applications. | [Writing your first application](https://hyperledger-fabric.readthedocs.io/en/master/write_first_app.html) |
+| [Commercial paper](commercial-paper) | Explore a use case in which two organizations use a blockchain network to trade commercial paper. | [Commercial paper tutorial](https://hyperledger-fabric.readthedocs.io/en/master/tutorial/commercial_paper.html) |
+| [Interest rate swaps](interest_rate_swaps) | Explore state based endorsement using a financial services use case. | [Setting Key level endorsement policies](https://hyperledger-fabric.readthedocs.io/en/master/endorsement-policies.html#setting-key-level-endorsement-policies) |
+| [Off chain data](off_chain_data) | Learn how to use the Peer channel-based event services to build an off chain database for reporting and analytics. | [Peer channel-based event services](https://hyperledger-fabric.readthedocs.io/en/master/peer_event_services.html) |
+| [High throughput](high-throughput) | Learn how you can design your smart contracts to process a large volume of transactions. | |
+| [First network](first-network) | **Deprecated. Use the Fabric test network to get started.** | [Build your first network](https://hyperledger-fabric.readthedocs.io/en/master/build_network.html) |
+| [Chaincode](chaincode) | A set of sample smart contracts used by other samples and the tutorials in the Fabric documentation. | [Fabric tutorials](https://hyperledger-fabric.readthedocs.io/en/master/tutorials.html) |
 
 ## License <a name="license"></a>
 

--- a/chaincode/README.md
+++ b/chaincode/README.md
@@ -1,0 +1,21 @@
+[//]: # (SPDX-License-Identifier: CC-BY-4.0)
+
+# Sample smart contracts
+
+This folder contains example smart contracts that are used by the Hyperledger Fabric documentation and by other samples
+
+|  **Smart Contract** | **Description** | **Tutorial** | **Languages** |
+| -----------|------------------------------|----------|---------|
+| [fabcar](fabcar) | Basic smart contract that allows you to add and change data on the ledger using the Fabric contract API. Also contains an example on how to run chaincode as an external service. | [Writing your first application](https://hyperledger-fabric.readthedocs.io/en/master/write_first_app.html) | Go, Java, JavaScript, Typescript |
+| [marbles02](marbles02) | Sample that demonstrates how to deploy an index and use rich queries when you are using CouchDB as your state database. | [Using CouchDB](https://hyperledger-fabric.readthedocs.io/en/master/couchdb_tutorial.html) | Go |
+| [marbles02_private](marbles02_private) | Sample that demonstrates the use of private data collections. | [Private data tutorial](https://hyperledger-fabric.readthedocs.io/en/master/private_data_tutorial.html) | Go |
+| [abac](abac) | Smart contract that restricts access to the chaincode namespace using Attribute Based Access Control. | | Go|
+| [sacc](sacc) | Simple asset chaincode that interacts with the ledger using the low-level APIs provided by the Fabric Chaincode Shim API. | [Chaincode for developers](https://hyperledger-fabric.readthedocs.io/en/master/chaincode4ade.html) | Go |
+| [abstore](abstore) | Basic smart contract that allows you to transfer data (from A to B) using the Fabric contract API. |  | Go, Java, JavaScript |
+
+## License <a name="license"></a>
+
+Hyperledger Project source code files are made available under the Apache
+License, Version 2.0 (Apache-2.0), located in the [LICENSE](LICENSE) file.
+Hyperledger Project documentation files are made available under the Creative
+Commons Attribution 4.0 International License (CC-BY-4.0), available at http://creativecommons.org/licenses/by/4.0/.

--- a/off_chain_data/README.md
+++ b/off_chain_data/README.md
@@ -1,6 +1,6 @@
 # Off Chain data
 
-This sample demonstrates how you can use [Peer channel-based event services](https://hyperledger-fabric.readthedocs.io/en/release-2.0/peer_event_services.html)
+This sample demonstrates how you can use [Peer channel-based event services](https://hyperledger-fabric.readthedocs.io/en/master/peer_event_services.html)
 to replicate the data on your blockchain network to an off chain database.
 Using an off chain database allows you to analyze the data from your network or
 build a dashboard without degrading the performance of your application.


### PR DESCRIPTION
Update READMEs to improve documentation in the samples repo.

Most importantly, for download instructions, we should use the topics in the Fabric docs to capture the most recent changes. I also think users would benefit from tables that would provide more detail on each sample and include a link to the accompanying tutorial. Some of these samples and chaincode, interest rate samples = state based endorsement, abac = attribute based access control, could help users find and take advantage of these samples.

Signed-off-by: NIKHIL E GUPTA <negupta@us.ibm.com>