### PR TITLE
Nominate Nikhil Gupta as Fabric-samples maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -12,6 +12,7 @@ fabric-samples uses a non-author code review policy, requiring a single approval
 | Gari Singh                | mastersingh24    | mastersingh24  | gari.r.singh@gmail.com              |
 | Jason Yellick             | jyellick         | jyellick       | jyellick@us.ibm.com                 |
 | Matthew B White           | mbwhite          | mbwhite        | whitemat@uk.ibm.com                 |
+| Nikhil Gupta              | nikhil550        | negupta        | nikhilg550@gmail.com                |
 | Simon Stone               | sstone1          | sstone1        | sstone1@uk.ibm.com                  |
 
 Also: Please see the [Release Manager section](https://github.com/hyperledger/fabric/blob/master/MAINTAINERS.md)


### PR DESCRIPTION
Nik has been the main source of progress in the fabric-samples
repository for several months, making significant improvements with
the introduction of test-network and updates of all the different
samples around it, among other things.

Signed-off-by: Arnaud J Le Hors <lehors@us.ibm.com>