### PR TITLE
Remove adding current directory to path

### DIFF
--- a/test-network/network.sh
+++ b/test-network/network.sh
@@ -12,7 +12,7 @@
 #
 # prepending $PWD/../bin to PATH to ensure we are picking up the correct binaries
 # this may be commented out to resolve installed version of tools if desired
-export PATH=${PWD}/../bin:${PWD}:$PATH
+export PATH=${PWD}/../bin:$PATH
 export FABRIC_CFG_PATH=${PWD}/configtx
 export VERBOSE=false
 


### PR DESCRIPTION
Currently, the test network appends the current directory to the path. `PATH=${PWD}/../bin:${PWD}:$PATH`

As @jyellick points, this is unnecessary. The tested the network on MacOS without it and it works fine.

Is there a reason why it should still be added? Is there another platform or use case where it needs to added?

Signed-off-by: NIKHIL E GUPTA <negupta@us.ibm.com>