### PR TITLE
Update deployCC.sh

### DIFF
--- a/test-network/scripts/deployCC.sh
+++ b/test-network/scripts/deployCC.sh
@@ -98,7 +98,6 @@ queryInstalled() {
   cat log.txt
 	PACKAGE_ID=$(sed -n "/fabcar_${VERSION}/{s/^Package ID: //; s/, Label:.*$//; p;}" log.txt)
   verifyResult $res "Query installed on peer0.org${ORG} has failed"
-  echo PackageID is ${PACKAGE_ID}
   echo "===================== Query installed successful on peer0.org${ORG} on channel ===================== "
   echo
 }


### PR DESCRIPTION
Signed-off-by: Rob Murgai <murgai@us.ibm.com>

In queryInstalled() 
Removing line:   echo PackageID is ${PACKAGE_ID}

the ```peer lifecycle chaincode queryinstalled``` cmd already prints the Package ID when successfull.  Right now with the echo, we are printing it twice:

Installed chaincodes on peer:
Package ID: fabcar_1:c15338b0d9782e18a8115d552dfe63bdab3bb98e15e6af43b3492a4160179a04, Label: fabcar_1
PackageID is fabcar_1:c15338b0d9782e18a8115d552dfe63bdab3bb98e15e6af43b3492a4160179a04
===================== Query installed successful on peer0.org1 on channel =====================