### PR TITLE
[FAB-18020] Add config.yaml to msp folder for User1 in test-network

### DIFF
--- a/test-network/addOrg3/fabric-ca/registerEnroll.sh
+++ b/test-network/addOrg3/fabric-ca/registerEnroll.sh
@@ -94,6 +94,8 @@ function createOrg3 {
 	fabric-ca-client enroll -u https://user1:user1pw@localhost:11054 --caname ca-org3 -M ${PWD}/../organizations/peerOrganizations/org3.example.com/users/User1@org3.example.com/msp --tls.certfiles ${PWD}/fabric-ca/org3/tls-cert.pem
   set +x
 
+  cp ${PWD}/../organizations/peerOrganizations/org3.example.com/msp/config.yaml ${PWD}/../organizations/peerOrganizations/org3.example.com/users/User1@org3.example.com/msp/config.yaml
+
   mkdir -p ../organizations/peerOrganizations/org3.example.com/users/Admin@org3.example.com
 
   echo

--- a/test-network/organizations/fabric-ca/registerEnroll.sh
+++ b/test-network/organizations/fabric-ca/registerEnroll.sh
@@ -94,6 +94,8 @@ function createOrg1 {
 	fabric-ca-client enroll -u https://user1:user1pw@localhost:7054 --caname ca-org1 -M ${PWD}/organizations/peerOrganizations/org1.example.com/users/User1@org1.example.com/msp --tls.certfiles ${PWD}/organizations/fabric-ca/org1/tls-cert.pem
   set +x
 
+  cp ${PWD}/organizations/peerOrganizations/org1.example.com/msp/config.yaml ${PWD}/organizations/peerOrganizations/org1.example.com/users/User1@org1.example.com/msp/config.yaml
+
   mkdir -p organizations/peerOrganizations/org1.example.com/users/Admin@org1.example.com
 
   echo
@@ -201,6 +203,8 @@ function createOrg2 {
   set -x
 	fabric-ca-client enroll -u https://user1:user1pw@localhost:8054 --caname ca-org2 -M ${PWD}/organizations/peerOrganizations/org2.example.com/users/User1@org2.example.com/msp --tls.certfiles ${PWD}/organizations/fabric-ca/org2/tls-cert.pem
   set +x
+
+  cp ${PWD}/organizations/peerOrganizations/org2.example.com/msp/config.yaml ${PWD}/organizations/peerOrganizations/org2.example.com/users/User1@org2.example.com/msp/config.yaml
 
   mkdir -p organizations/peerOrganizations/org2.example.com/users/Admin@org2.example.com
 


### PR DESCRIPTION
This patch adds missing config.yaml to msp folder for user1 in test-network to make user1 work properly when using FabricCA.

#### Type of change

- Bug fix

#### Description

This patch adds missing config.yaml to msp folder for user1 in test-network to make user1 work properly when using FabricCA.

#### Related issues

- https://jira.hyperledger.org/browse/FAB-18020