### PR TITLE
Fix go mod for chaincode-go

### DIFF
--- a/asset-transfer-basic/chaincode-go/go.mod
+++ b/asset-transfer-basic/chaincode-go/go.mod
@@ -1,4 +1,4 @@
-module github.com/hyperledger/fabric-samples/chaincode/fabcar/go
+module github.com/hyperledger/fabric-samples/asset-transfer-basic/chaincode-go
 
 go 1.14
 


### PR DESCRIPTION
Signed-off-by: Chongxin Luo <Chongxin.Luo@ibm.com>

**Description**

* Fixing go.mod module path for `asset-transfer-basic` chaincode-go to point at the correct directory.