### PR TITLE
Update fabcar java sample build

### DIFF
--- a/chaincode/fabcar/java/build.gradle
+++ b/chaincode/fabcar/java/build.gradle
@@ -3,8 +3,8 @@
  */
 
 plugins {
+    id 'application'
     id 'checkstyle'
-    id 'java-library-distribution'
     id 'jacoco'
 }
 
@@ -30,6 +30,10 @@ repositories {
     }
 }
 
+application {
+    mainClass = 'org.hyperledger.fabric.contract.ContractRouter'
+}
+
 checkstyle {
     toolVersion '8.21'
     configFile file("config/checkstyle/checkstyle.xml")
@@ -43,14 +47,11 @@ checkstyleTest {
     source ='src/test/java'
 }
 
+jacocoTestReport {
+    dependsOn test
+}
+
 jacocoTestCoverageVerification {
-    afterEvaluate {
-        classDirectories = files(classDirectories.files.collect {
-            fileTree(dir: it, exclude:  [
-                    'org/hyperledger/fabric/samples/fabcar/Start.*'
-            ])
-        })
-    }
     violationRules {
         rule {
             limit {
@@ -70,3 +71,4 @@ test {
 }
 
 check.dependsOn jacocoTestCoverageVerification
+installDist.dependsOn check

--- a/chaincode/fabcar/java/gradle/wrapper/gradle-wrapper.properties
+++ b/chaincode/fabcar/java/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
- Update gradle version
- Switch to application plugin
  (cc is started as an app not a lib, and java-library-distribution
  is still incubating)
- make sure tests and coverage checks are run before installDist

Signed-off-by: James Taylor <jamest@uk.ibm.com>