### PR TITLE
Allow install of a chaincode

### DIFF
--- a/ci/templates/test-network/azure-pipelines.yml
+++ b/ci/templates/test-network/azure-pipelines.yml
@@ -5,7 +5,10 @@
 steps:
   - script: |
       ./network.sh up createChannel -s couchdb -i ${FABRIC_VERSION} # FABRIC_VERSION is set in ci/azure-pipelines.yml
-      ./network.sh deployCC -l javascript
+      ./network.sh deployCC -ccn basic -ccv 1 -ccl javascript -cci initLedger
+      ./network.sh deployCC -ccn basic -ccv 2 -ccl golang -cci initLedger
+      ./network.sh deployCC -ccn basic -ccv 3 -ccl typescript -cci initLedger
+      ./network.sh deployCC -ccn secure -ccv 1 -ccl golang
       ./network.sh down
     workingDirectory: test-network
     displayName: Start Test Network

--- a/fabcar/startFabric.sh
+++ b/fabcar/startFabric.sh
@@ -12,13 +12,19 @@ export MSYS_NO_PATHCONV=1
 starttime=$(date +%s)
 CC_SRC_LANGUAGE=${1:-"go"}
 CC_SRC_LANGUAGE=`echo "$CC_SRC_LANGUAGE" | tr [:upper:] [:lower:]`
-if [ "$CC_SRC_LANGUAGE" != "go" -a "$CC_SRC_LANGUAGE" != "golang" -a "$CC_SRC_LANGUAGE" != "java" \
- -a  "$CC_SRC_LANGUAGE" != "javascript"  -a "$CC_SRC_LANGUAGE" != "typescript" ] ; then
 
+if [ "$CC_SRC_LANGUAGE" = "go" -o "$CC_SRC_LANGUAGE" = "golang" ] ; then
+	CC_SRC_PATH="../chaincode/fabcar/go/"
+elif [ "$CC_SRC_LANGUAGE" = "javascript" ]; then
+	CC_SRC_PATH="../chaincode/fabcar/javascript/"
+elif [ "$CC_SRC_LANGUAGE" = "java" ]; then
+	CC_SRC_PATH="../chaincode/fabcar/java"
+elif [ "$CC_SRC_LANGUAGE" = "typescript" ]; then
+	CC_SRC_PATH="../chaincode/fabcar/typescript/"
+else
 	echo The chaincode language ${CC_SRC_LANGUAGE} is not supported by this script
- 	echo Supported chaincode languages are: go, java, javascript, and typescript
- 	exit 1
-
+	echo Supported chaincode languages are: go, java, javascript, and typescript
+	exit 1
 fi
 
 # clean out any old identites in the wallets
@@ -31,7 +37,7 @@ rm -rf go/wallet/*
 pushd ../test-network
 ./network.sh down
 ./network.sh up createChannel -ca -s couchdb
-./network.sh deployCC -l ${CC_SRC_LANGUAGE}
+./network.sh deployCC -ccn fabcar -ccv 1 -cci initLedger -ccl ${CC_SRC_LANGUAGE} -ccp ${CC_SRC_PATH}
 popd
 
 cat <<EOF

--- a/test-network/.gitignore
+++ b/test-network/.gitignore
@@ -10,5 +10,5 @@ organizations/fabric-ca/org2/*
 organizations/ordererOrganizations/*
 organizations/peerOrganizations/*
 system-genesis-block/*
-fabcar.tar.gz
+*.tar.gz
 log.txt

--- a/test-network/README.md
+++ b/test-network/README.md
@@ -1,5 +1,5 @@
 ## Running the test network
 
-You can use the `./network.sh` script to stand up a simple Fabric test network. The test network has two peer organizations with one peer each and a single node raft ordering service. You can also use the `./network.sh` script to create channels and deploy the fabcar chaincode. For more information, see [Using the Fabric test network](https://hyperledger-fabric.readthedocs.io/en/latest/test_network.html). The test network is being introduced in Fabric v2.0 as the long term replacement for the `first-network` sample.
+You can use the `./network.sh` script to stand up a simple Fabric test network. The test network has two peer organizations with one peer each and a single node raft ordering service. You can also use the `./network.sh` script to create channels and deploy chaincode. For more information, see [Using the Fabric test network](https://hyperledger-fabric.readthedocs.io/en/latest/test_network.html). The test network is being introduced in Fabric v2.0 as the long term replacement for the `first-network` sample.
 
 Before you can deploy the test network, you need to follow the instructions to [Install the Samples, Binaries and Docker Images](https://hyperledger-fabric.readthedocs.io/en/latest/install.html) in the Hyperledger Fabric documentation.

--- a/test-network/scripts/deployCC.sh
+++ b/test-network/scripts/deployCC.sh
@@ -1,50 +1,94 @@
+CHANNEL_NAME=${1:-"mychannel"}
+CC_NAME=${2:-"basic"}
+CC_SRC_PATH=${3:-"NA"}
+CC_SRC_LANGUAGE=${4:-"go"}
+CC_VERSION=${5:-"1.0"}
+CC_SEQUENCE=${6:-"1"}
+CC_INIT_FCN=${7:-"NA"}
+DELAY=${8:-"3"}
+MAX_RETRY=${9:-"5"}
+VERBOSE=${10:-"false"}
 
-CHANNEL_NAME="$1"
-CC_SRC_LANGUAGE="$2"
-VERSION="$3"
-DELAY="$4"
-MAX_RETRY="$5"
-VERBOSE="$6"
-: ${CHANNEL_NAME:="mychannel"}
-: ${CC_SRC_LANGUAGE:="golang"}
-: ${VERSION:="1"}
-: ${DELAY:="3"}
-: ${MAX_RETRY:="5"}
-: ${VERBOSE:="false"}
+echo --- executing with the following
+echo   - CHANNEL_NAME:$'\e[0;32m'$CHANNEL_NAME$'\e[0m'
+echo   - CC_NAME:$'\e[0;32m'$CC_NAME$'\e[0m'
+echo   - CC_SRC_PATH:$'\e[0;32m'$CC_SRC_PATH$'\e[0m'
+echo   - CC_SRC_LANGUAGE:$'\e[0;32m'$CC_SRC_LANGUAGE$'\e[0m'
+echo   - CC_VERSION:$'\e[0;32m'$CC_VERSION$'\e[0m'
+echo   - CC_SEQUENCE:$'\e[0;32m'$CC_SEQUENCE$'\e[0m'
+echo   - CC_INIT_FCN:$'\e[0;32m'$CC_INIT_FCN$'\e[0m'
+echo   - DELAY:$'\e[0;32m'$DELAY$'\e[0m'
+echo   - MAX_RETRY:$'\e[0;32m'$MAX_RETRY$'\e[0m'
+echo   - VERBOSE:$'\e[0;32m'$VERBOSE$'\e[0m'
+
 CC_SRC_LANGUAGE=`echo "$CC_SRC_LANGUAGE" | tr [:upper:] [:lower:]`
 
 FABRIC_CFG_PATH=$PWD/../config/
 
-if [ "$CC_SRC_LANGUAGE" = "go" -o "$CC_SRC_LANGUAGE" = "golang" ] ; then
-	CC_RUNTIME_LANGUAGE=golang
-	CC_SRC_PATH="../chaincode/fabcar/go/"
+# User has not provided a path, therefore the CC_NAME must
+# be the short name of a known chaincode sample
+if [ "$CC_SRC_PATH" = "NA" ]; then
+	echo Determining the path to the chaincode
+	# first see which chaincode we have. This will be based on the
+	# short name of the known chaincode sample
+	if [ "$CC_NAME" = "basic" ]; then
+		echo $'\e[0;32m'asset-transfer-basic$'\e[0m' chaincode
+		CC_SRC_PATH="../asset-transfer-basic"
+	elif [ "$CC_NAME" = "secure" ]; then
+		echo $'\e[0;32m'asset-transfer-secured-agreeement$'\e[0m' chaincode
+		CC_SRC_PATH="../asset-transfer-secured-agreement"
+	elif [ "$CC_NAME" = "ledger" ]; then
+		echo $'\e[0;32m'asset-transfer-secured-agreeement$'\e[0m' chaincode
+		CC_SRC_PATH="../asset-transfer-ledger-queries"
+	elif [ "$CC_NAME" = "private" ]; then
+		echo $'\e[0;32m'asset-transfer-private-data$'\e[0m' chaincode
+		CC_SRC_PATH="../asset-transfer-private-data"
+	else
+		echo The chaincode name ${CC_NAME} is not supported by this script
+		echo Supported chaincode names are: basic, secure, and private
+		exit 1
+	fi
 
-	echo Vendoring Go dependencies ...
-	pushd ../chaincode/fabcar/go
+	# now see what language it is written in
+	if [ "$CC_SRC_LANGUAGE" = "go" ]; then
+		CC_SRC_PATH="$CC_SRC_PATH/chaincode-go/"
+	elif [ "$CC_SRC_LANGUAGE" = "java" ]; then
+		CC_SRC_PATH="$CC_SRC_PATH/chaincode-java/"
+	elif [ "$CC_SRC_LANGUAGE" = "javascript" ]; then
+		CC_SRC_PATH="$CC_SRC_PATH/chaincode-javascript/"
+	elif [ "$CC_SRC_LANGUAGE" = "typescript" ]; then
+		CC_SRC_PATH="$CC_SRC_PATH/chaincode-typescript/"
+	fi
+fi
+
+# do some language specific preparation to the chaincode before packaging
+if [ "$CC_SRC_LANGUAGE" = "go" ]; then
+		CC_RUNTIME_LANGUAGE=golang
+
+	echo Vendoring Go dependencies at $CC_SRC_PATH
+	pushd $CC_SRC_PATH
 	GO111MODULE=on go mod vendor
 	popd
 	echo Finished vendoring Go dependencies
 
-elif [ "$CC_SRC_LANGUAGE" = "javascript" ]; then
-	CC_RUNTIME_LANGUAGE=node # chaincode runtime language is node.js
-	CC_SRC_PATH="../chaincode/fabcar/javascript/"
-
 elif [ "$CC_SRC_LANGUAGE" = "java" ]; then
 	CC_RUNTIME_LANGUAGE=java
-	CC_SRC_PATH="../chaincode/fabcar/java/build/install/fabcar"
 
 	echo Compiling Java code ...
-	pushd ../chaincode/fabcar/java
+	pushd $CC_SRC_PATH
 	./gradlew installDist
 	popd
 	echo Finished compiling Java code
+	CC_SRC_PATH=$CC_SRC_PATH/build/install/$CC_NAME
+
+elif [ "$CC_SRC_LANGUAGE" = "javascript" ]; then
+	CC_RUNTIME_LANGUAGE=node
 
 elif [ "$CC_SRC_LANGUAGE" = "typescript" ]; then
-	CC_RUNTIME_LANGUAGE=node # chaincode runtime language is node.js
-	CC_SRC_PATH="../chaincode/fabcar/typescript/"
+	CC_RUNTIME_LANGUAGE=node
 
 	echo Compiling TypeScript code into JavaScript ...
-	pushd ../chaincode/fabcar/typescript
+	pushd $CC_SRC_PATH
 	npm install
 	npm run build
 	popd
@@ -56,200 +100,210 @@ else
 	exit 1
 fi
 
+INIT_REQUIRED="--init-required"
+# check if the init fcn should be called
+if [ "$CC_INIT_FCN" = "NA" ]; then
+	INIT_REQUIRED=""
+fi
+
 # import utils
 . scripts/envVar.sh
 
 
 packageChaincode() {
-  ORG=$1
-  setGlobals $ORG
-  set -x
-  peer lifecycle chaincode package fabcar.tar.gz --path ${CC_SRC_PATH} --lang ${CC_RUNTIME_LANGUAGE} --label fabcar_${VERSION} >&log.txt
-  res=$?
-  set +x
-  cat log.txt
-  verifyResult $res "Chaincode packaging on peer0.org${ORG} has failed"
-  echo "===================== Chaincode is packaged on peer0.org${ORG} ===================== "
-  echo
+	ORG=$1
+	setGlobals $ORG
+	set -x
+	peer lifecycle chaincode package ${CC_NAME}.tar.gz --path ${CC_SRC_PATH} --lang ${CC_RUNTIME_LANGUAGE} --label ${CC_NAME}_${CC_VERSION} >&log.txt
+	res=$?
+	set +x
+	cat log.txt
+	verifyResult $res "Chaincode packaging on peer0.org${ORG} has failed"
+	echo "===================== Chaincode is packaged on peer0.org${ORG} ===================== "
+	echo
 }
 
 # installChaincode PEER ORG
 installChaincode() {
-  ORG=$1
-  setGlobals $ORG
-  set -x
-  peer lifecycle chaincode install fabcar.tar.gz >&log.txt
-  res=$?
-  set +x
-  cat log.txt
-  verifyResult $res "Chaincode installation on peer0.org${ORG} has failed"
-  echo "===================== Chaincode is installed on peer0.org${ORG} ===================== "
-  echo
+	ORG=$1
+	setGlobals $ORG
+	set -x
+	peer lifecycle chaincode install ${CC_NAME}.tar.gz >&log.txt
+	res=$?
+	set +x
+	cat log.txt
+	verifyResult $res "Chaincode installation on peer0.org${ORG} has failed"
+	echo "===================== Chaincode is installed on peer0.org${ORG} ===================== "
+	echo
 }
 
 # queryInstalled PEER ORG
 queryInstalled() {
-  ORG=$1
-  setGlobals $ORG
-  set -x
-  peer lifecycle chaincode queryinstalled >&log.txt
-  res=$?
-  set +x
-  cat log.txt
-	PACKAGE_ID=$(sed -n "/fabcar_${VERSION}/{s/^Package ID: //; s/, Label:.*$//; p;}" log.txt)
-  verifyResult $res "Query installed on peer0.org${ORG} has failed"
-  echo "===================== Query installed successful on peer0.org${ORG} on channel ===================== "
-  echo
+	ORG=$1
+	setGlobals $ORG
+	set -x
+	peer lifecycle chaincode queryinstalled >&log.txt
+	res=$?
+	set +x
+	cat log.txt
+	PACKAGE_ID=$(sed -n "/${CC_NAME}_${CC_VERSION}/{s/^Package ID: //; s/, Label:.*$//; p;}" log.txt)
+	verifyResult $res "Query installed on peer0.org${ORG} has failed"
+	echo "===================== Query installed successful on peer0.org${ORG} on channel ===================== "
+	echo
 }
 
 # approveForMyOrg VERSION PEER ORG
 approveForMyOrg() {
-  ORG=$1
-  setGlobals $ORG
-  set -x
-  peer lifecycle chaincode approveformyorg -o localhost:7050 --ordererTLSHostnameOverride orderer.example.com --tls --cafile $ORDERER_CA --channelID $CHANNEL_NAME --name fabcar --version ${VERSION} --init-required --package-id ${PACKAGE_ID} --sequence ${VERSION} >&log.txt
-  set +x
-  cat log.txt
-  verifyResult $res "Chaincode definition approved on peer0.org${ORG} on channel '$CHANNEL_NAME' failed"
-  echo "===================== Chaincode definition approved on peer0.org${ORG} on channel '$CHANNEL_NAME' ===================== "
-  echo
+	ORG=$1
+	setGlobals $ORG
+	set -x
+	peer lifecycle chaincode approveformyorg -o localhost:7050 --ordererTLSHostnameOverride orderer.example.com --tls --cafile $ORDERER_CA --channelID $CHANNEL_NAME --name ${CC_NAME} --version ${CC_VERSION} --package-id ${PACKAGE_ID} --sequence ${CC_SEQUENCE} ${INIT_REQUIRED} >&log.txt
+	set +x
+	cat log.txt
+	verifyResult $res "Chaincode definition approved on peer0.org${ORG} on channel '$CHANNEL_NAME' failed"
+	echo "===================== Chaincode definition approved on peer0.org${ORG} on channel '$CHANNEL_NAME' ===================== "
+	echo
 }
 
 # checkCommitReadiness VERSION PEER ORG
 checkCommitReadiness() {
-  ORG=$1
-  shift 1
-  setGlobals $ORG
-  echo "===================== Checking the commit readiness of the chaincode definition on peer0.org${ORG} on channel '$CHANNEL_NAME'... ===================== "
+	ORG=$1
+	shift 1
+	setGlobals $ORG
+	echo "===================== Checking the commit readiness of the chaincode definition on peer0.org${ORG} on channel '$CHANNEL_NAME'... ===================== "
 	local rc=1
 	local COUNTER=1
 	# continue to poll
-  # we either get a successful response, or reach MAX RETRY
-	while [ $rc -ne 0 -a $COUNTER -lt $MAX_RETRY ] ; do
-    sleep $DELAY
-    echo "Attempting to check the commit readiness of the chaincode definition on peer0.org${ORG}, Retry after $DELAY seconds."
-    set -x
-    peer lifecycle chaincode checkcommitreadiness --channelID $CHANNEL_NAME --name fabcar --version ${VERSION} --sequence ${VERSION} --output json --init-required >&log.txt
-    res=$?
-    set +x
-    let rc=0
-    for var in "$@"
-    do
-      grep "$var" log.txt &>/dev/null || let rc=1
-    done
+	# we either get a successful response, or reach MAX RETRY
+	while [ $rc -ne 0 -a $COUNTER -lt $MAX_RETRY ]; do
+		sleep $DELAY
+		echo "Attempting to check the commit readiness of the chaincode definition on peer0.org${ORG}, Retry after $DELAY seconds."
+		set -x
+		peer lifecycle chaincode checkcommitreadiness --channelID $CHANNEL_NAME --name ${CC_NAME} --version ${CC_VERSION} --sequence ${CC_SEQUENCE} ${INIT_REQUIRED} --output json >&log.txt
+		res=$?
+		set +x
+		let rc=0
+		for var in "$@"; do
+			grep "$var" log.txt &>/dev/null || let rc=1
+		done
 		COUNTER=$(expr $COUNTER + 1)
 	done
-  cat log.txt
-  if test $rc -eq 0; then
-    echo "===================== Checking the commit readiness of the chaincode definition successful on peer0.org${ORG} on channel '$CHANNEL_NAME' ===================== "
-  else
-    echo "!!!!!!!!!!!!!!! After $MAX_RETRY attempts, Check commit readiness result on peer0.org${ORG} is INVALID !!!!!!!!!!!!!!!!"
-    echo
-    exit 1
-  fi
+	cat log.txt
+	if test $rc -eq 0; then
+		echo "===================== Checking the commit readiness of the chaincode definition successful on peer0.org${ORG} on channel '$CHANNEL_NAME' ===================== "
+	else
+		echo
+		echo $'\e[1;31m'"!!!!!!!!!!!!!!! After $MAX_RETRY attempts, Check commit readiness result on peer0.org${ORG} is INVALID !!!!!!!!!!!!!!!!"$'\e[0m'
+		echo
+		exit 1
+	fi
 }
 
 # commitChaincodeDefinition VERSION PEER ORG (PEER ORG)...
 commitChaincodeDefinition() {
-  parsePeerConnectionParameters $@
-  res=$?
-  verifyResult $res "Invoke transaction failed on channel '$CHANNEL_NAME' due to uneven number of peer and org parameters "
+	parsePeerConnectionParameters $@
+	res=$?
+	verifyResult $res "Invoke transaction failed on channel '$CHANNEL_NAME' due to uneven number of peer and org parameters "
 
-  # while 'peer chaincode' command can get the orderer endpoint from the
-  # peer (if join was successful), let's supply it directly as we know
-  # it using the "-o" option
-  set -x
-  peer lifecycle chaincode commit -o localhost:7050 --ordererTLSHostnameOverride orderer.example.com --tls --cafile $ORDERER_CA --channelID $CHANNEL_NAME --name fabcar $PEER_CONN_PARMS --version ${VERSION} --sequence ${VERSION} --init-required >&log.txt
-  res=$?
-  set +x
-  cat log.txt
-  verifyResult $res "Chaincode definition commit failed on peer0.org${ORG} on channel '$CHANNEL_NAME' failed"
-  echo "===================== Chaincode definition committed on channel '$CHANNEL_NAME' ===================== "
-  echo
+	# while 'peer chaincode' command can get the orderer endpoint from the
+	# peer (if join was successful), let's supply it directly as we know
+	# it using the "-o" option
+	set -x
+	peer lifecycle chaincode commit -o localhost:7050 --ordererTLSHostnameOverride orderer.example.com --tls --cafile $ORDERER_CA --channelID $CHANNEL_NAME --name ${CC_NAME} $PEER_CONN_PARMS --version ${CC_VERSION} --sequence ${CC_SEQUENCE} ${INIT_REQUIRED} >&log.txt
+	res=$?
+	set +x
+	cat log.txt
+	verifyResult $res "Chaincode definition commit failed on peer0.org${ORG} on channel '$CHANNEL_NAME' failed"
+	echo "===================== Chaincode definition committed on channel '$CHANNEL_NAME' ===================== "
+	echo
 }
 
 # queryCommitted ORG
 queryCommitted() {
-  ORG=$1
-  setGlobals $ORG
-  EXPECTED_RESULT="Version: ${VERSION}, Sequence: ${VERSION}, Endorsement Plugin: escc, Validation Plugin: vscc"
-  echo "===================== Querying chaincode definition on peer0.org${ORG} on channel '$CHANNEL_NAME'... ===================== "
+	ORG=$1
+	setGlobals $ORG
+	EXPECTED_RESULT="Version: ${CC_VERSION}, Sequence: ${CC_SEQUENCE}, Endorsement Plugin: escc, Validation Plugin: vscc"
+	echo "===================== Querying chaincode definition on peer0.org${ORG} on channel '$CHANNEL_NAME'... ===================== "
 	local rc=1
 	local COUNTER=1
 	# continue to poll
-  # we either get a successful response, or reach MAX RETRY
-	while [ $rc -ne 0 -a $COUNTER -lt $MAX_RETRY ] ; do
-    sleep $DELAY
-    echo "Attempting to Query committed status on peer0.org${ORG}, Retry after $DELAY seconds."
-    set -x
-    peer lifecycle chaincode querycommitted --channelID $CHANNEL_NAME --name fabcar >&log.txt
-    res=$?
-    set +x
-		test $res -eq 0 && VALUE=$(cat log.txt | grep -o '^Version: [0-9], Sequence: [0-9], Endorsement Plugin: escc, Validation Plugin: vscc')
-    test "$VALUE" = "$EXPECTED_RESULT" && let rc=0
+	# we either get a successful response, or reach MAX RETRY
+	while [ $rc -ne 0 -a $COUNTER -lt $MAX_RETRY ]; do
+		sleep $DELAY
+		echo "Attempting to Query committed status on peer0.org${ORG}, Retry after $DELAY seconds."
+		set -x
+		peer lifecycle chaincode querycommitted --channelID $CHANNEL_NAME --name ${CC_NAME} >&log.txt
+		res=$?
+		set +x
+		test $res -eq 0 && VALUE=$(cat log.txt | grep -o '^Version: '$CC_VERSION', Sequence: [0-9], Endorsement Plugin: escc, Validation Plugin: vscc')
+		test "$VALUE" = "$EXPECTED_RESULT" && let rc=0
 		COUNTER=$(expr $COUNTER + 1)
 	done
-  echo
-  cat log.txt
-  if test $rc -eq 0; then
-    echo "===================== Query chaincode definition successful on peer0.org${ORG} on channel '$CHANNEL_NAME' ===================== "
+	echo
+	cat log.txt
+	if test $rc -eq 0; then
+		echo "===================== Query chaincode definition successful on peer0.org${ORG} on channel '$CHANNEL_NAME' ===================== "
 		echo
-  else
-    echo "!!!!!!!!!!!!!!! After $MAX_RETRY attempts, Query chaincode definition result on peer0.org${ORG} is INVALID !!!!!!!!!!!!!!!!"
-    echo
-    exit 1
-  fi
+	else
+		echo
+		echo $'\e[1;31m'"!!!!!!!!!!!!!!! After $MAX_RETRY attempts, Query chaincode definition result on peer0.org${ORG} is INVALID !!!!!!!!!!!!!!!!"$'\e[0m'
+		echo
+		exit 1
+	fi
 }
 
 chaincodeInvokeInit() {
-  parsePeerConnectionParameters $@
-  res=$?
-  verifyResult $res "Invoke transaction failed on channel '$CHANNEL_NAME' due to uneven number of peer and org parameters "
+	parsePeerConnectionParameters $@
+	res=$?
+	verifyResult $res "Invoke transaction failed on channel '$CHANNEL_NAME' due to uneven number of peer and org parameters "
 
-  # while 'peer chaincode' command can get the orderer endpoint from the
-  # peer (if join was successful), let's supply it directly as we know
-  # it using the "-o" option
-  set -x
-  peer chaincode invoke -o localhost:7050 --ordererTLSHostnameOverride orderer.example.com --tls --cafile $ORDERER_CA -C $CHANNEL_NAME -n fabcar $PEER_CONN_PARMS --isInit -c '{"function":"initLedger","Args":[]}' >&log.txt
-  res=$?
-  set +x
-  cat log.txt
-  verifyResult $res "Invoke execution on $PEERS failed "
-  echo "===================== Invoke transaction successful on $PEERS on channel '$CHANNEL_NAME' ===================== "
-  echo
+	# while 'peer chaincode' command can get the orderer endpoint from the
+	# peer (if join was successful), let's supply it directly as we know
+	# it using the "-o" option
+	set -x
+	fcn_call='{"function":"'${CC_INIT_FCN}'","Args":[]}'
+	echo invoke fcn call:${fcn_call}
+	peer chaincode invoke -o localhost:7050 --ordererTLSHostnameOverride orderer.example.com --tls --cafile $ORDERER_CA -C $CHANNEL_NAME -n ${CC_NAME} $PEER_CONN_PARMS --isInit -c ${fcn_call} >&log.txt
+	res=$?
+	set +x
+	cat log.txt
+	verifyResult $res "Invoke execution on $PEERS failed "
+	echo "===================== Invoke transaction successful on $PEERS on channel '$CHANNEL_NAME' ===================== "
+	echo
 }
 
 chaincodeQuery() {
-  ORG=$1
-  setGlobals $ORG
-  echo "===================== Querying on peer0.org${ORG} on channel '$CHANNEL_NAME'... ===================== "
+	ORG=$1
+	setGlobals $ORG
+	echo "===================== Querying on peer0.org${ORG} on channel '$CHANNEL_NAME'... ===================== "
 	local rc=1
 	local COUNTER=1
 	# continue to poll
-  # we either get a successful response, or reach MAX RETRY
-	while [ $rc -ne 0 -a $COUNTER -lt $MAX_RETRY ] ; do
-    sleep $DELAY
-    echo "Attempting to Query peer0.org${ORG}, Retry after $DELAY seconds."
-    set -x
-    peer chaincode query -C $CHANNEL_NAME -n fabcar -c '{"Args":["queryAllCars"]}' >&log.txt
-    res=$?
-    set +x
+	# we either get a successful response, or reach MAX RETRY
+	while [ $rc -ne 0 -a $COUNTER -lt $MAX_RETRY ]; do
+		sleep $DELAY
+		echo "Attempting to Query peer0.org${ORG}, Retry after $DELAY seconds."
+		set -x
+		peer chaincode query -C $CHANNEL_NAME -n ${CC_NAME} -c '{"Args":["queryAllCars"]}' >&log.txt
+		res=$?
+		set +x
 		let rc=$res
 		COUNTER=$(expr $COUNTER + 1)
 	done
-  echo
-  cat log.txt
-  if test $rc -eq 0; then
-    echo "===================== Query successful on peer0.org${ORG} on channel '$CHANNEL_NAME' ===================== "
+	echo
+	cat log.txt
+	if test $rc -eq 0; then
+		echo "===================== Query successful on peer0.org${ORG} on channel '$CHANNEL_NAME' ===================== "
 		echo
-  else
-    echo "!!!!!!!!!!!!!!! After $MAX_RETRY attempts, Query result on peer0.org${ORG} is INVALID !!!!!!!!!!!!!!!!"
-    echo
-    exit 1
-  fi
+	else
+		echo
+		echo $'\e[1;31m'"!!!!!!!!!!!!!!! After $MAX_RETRY attempts, Query result on peer0.org${ORG} is INVALID !!!!!!!!!!!!!!!!"$'\e[0m'
+		echo
+		exit 1
+	fi
 }
 
-## at first we package the chaincode
+## package the chaincode
 packageChaincode 1
 
 ## Install chaincode on peer0.org1 and peer0.org2
@@ -284,13 +338,13 @@ commitChaincodeDefinition 1 2
 queryCommitted 1
 queryCommitted 2
 
-## Invoke the chaincode
-chaincodeInvokeInit 1 2
-
-sleep 10
-
-# Query chaincode on peer0.org1
-echo "Querying chaincode on peer0.org1..."
-chaincodeQuery 1
+## Invoke the chaincode - this does require that the chaincode have the 'initLedger'
+## method defined
+if [ "$CC_INIT_FCN" = "NA" ]; then
+	echo "===================== Chaincode initialization is not required ===================== "
+	echo
+else
+	chaincodeInvokeInit 1 2
+fi
 
 exit 0

--- a/test-network/scripts/envVar.sh
+++ b/test-network/scripts/envVar.sh
@@ -78,7 +78,7 @@ parsePeerConnectionParameters() {
 
 verifyResult() {
   if [ $1 -ne 0 ]; then
-    echo "!!!!!!!!!!!!!!! "$2" !!!!!!!!!!!!!!!!"
+    echo $'\e[1;31m'!!!!!!!!!!!!!!! $2 !!!!!!!!!!!!!!!!$'\e[0m'
     echo
     exit 1
   fi

--- a/test-network/scripts/org3-scripts/envVarCLI.sh
+++ b/test-network/scripts/org3-scripts/envVarCLI.sh
@@ -47,7 +47,7 @@ setGlobals() {
 
 verifyResult() {
   if [ $1 -ne 0 ]; then
-    echo "!!!!!!!!!!!!!!! "$2" !!!!!!!!!!!!!!!!"
+    echo $'\e[1;31m'!!!!!!!!!!!!!!! $2 !!!!!!!!!!!!!!!!$'\e[0m'
     echo
     exit 1
   fi


### PR DESCRIPTION
options on the network script to deploy chaincode
-ccn The name to be used as the deployed name and used as
     the short name of known chaincodes when the -ccp is not included.
   known short names
     'basic' - asset-transfer-basic
     'secure' - asset-transfer-secured-agreement
     'ledger' - asset-transfer-ledger-queries
     'private' - asset-transfer-private-data
-ccl the language of the chaincode
-ccv the version
-ccp [optional] the path to the chaincode, when provided
     the -ccn will be the deployed name
-cci [optional] the chaincode function to call during deployment
     that will perform an initialization of the channel state
     required for this chaincode

Signed-off-by: Bret Harrison <beharrison@nc.rr.com>