### PR TITLE
Remove QueryResult Type

### DIFF
--- a/asset-transfer-basic/chaincode-go/chaincode/smartcontract.go
+++ b/asset-transfer-basic/chaincode-go/chaincode/smartcontract.go
@@ -21,12 +21,6 @@ type Asset struct {
 	AppraisedValue int    `json:"appraisedValue"`
 }
 
-// QueryResult structure used for handling result of query
-type QueryResult struct {
-	Key    string `json:"Key"`
-	Record *Asset
-}
-
 // InitLedger adds a base set of assets to the ledger
 func (s *SmartContract) InitLedger(ctx contractapi.TransactionContextInterface) error {
 	assets := []Asset{
@@ -163,7 +157,7 @@ func (s *SmartContract) TransferAsset(ctx contractapi.TransactionContextInterfac
 }
 
 // GetAllAssets returns all assets found in world state
-func (s *SmartContract) GetAllAssets(ctx contractapi.TransactionContextInterface) ([]QueryResult, error) {
+func (s *SmartContract) GetAllAssets(ctx contractapi.TransactionContextInterface) ([]*Asset, error) {
 	// range query with empty string for startKey and endKey does an
 	// open-ended query of all assets in the chaincode namespace.
 	resultsIterator, err := ctx.GetStub().GetStateByRange("", "")
@@ -172,7 +166,7 @@ func (s *SmartContract) GetAllAssets(ctx contractapi.TransactionContextInterface
 	}
 	defer resultsIterator.Close()
 
-	var results []QueryResult
+	var assets []*Asset
 	for resultsIterator.HasNext() {
 		queryResponse, err := resultsIterator.Next()
 		if err != nil {
@@ -184,10 +178,8 @@ func (s *SmartContract) GetAllAssets(ctx contractapi.TransactionContextInterface
 		if err != nil {
 			return nil, err
 		}
-
-		queryResult := QueryResult{Key: queryResponse.Key, Record: asset}
-		results = append(results, queryResult)
+		assets = append(assets, asset)
 	}
 
-	return results, nil
+	return assets, nil
 }

--- a/asset-transfer-basic/chaincode-go/chaincode/smartcontract_test.go
+++ b/asset-transfer-basic/chaincode-go/chaincode/smartcontract_test.go
@@ -169,7 +169,7 @@ func TestGetAllAssets(t *testing.T) {
 	assetTransfer := &chaincode.SmartContract{}
 	assets, err := assetTransfer.GetAllAssets(transactionContext)
 	require.NoError(t, err)
-	require.Equal(t, []chaincode.QueryResult{{Record: asset}}, assets)
+	require.Equal(t, []*chaincode.Asset{asset}, assets)
 
 	iterator.HasNextReturns(true)
 	iterator.NextReturns(nil, fmt.Errorf("failed retrieving next item"))


### PR DESCRIPTION
There was no need for GetAllAssets to return a custom type, it can simple return an array of all assets.

Signed-off-by: Brett Logan <brett.t.logan@ibm.com>