### PR TITLE
Add endorsement policy to chaincode deployment script

### DIFF
--- a/test-network/network.sh
+++ b/test-network/network.sh
@@ -29,20 +29,26 @@ function printHelp() {
   echo "      "$'\e[0;32m'restart$'\e[0m' - restart the network
   echo
   echo "    Flags:"
+  echo "    Used with "$'\e[0;32m'network.sh up$'\e[0m', $'\e[0;32m'network.sh createChannel$'\e[0m':
   echo "    -ca <use CAs> -  create Certificate Authorities to generate the crypto material"
   echo "    -c <channel name> - channel name to use (defaults to \"mychannel\")"
   echo "    -s <dbtype> - the database backend to use: goleveldb (default) or couchdb"
   echo "    -r <max retry> - CLI times out after certain number of attempts (defaults to 5)"
   echo "    -d <delay> - delay duration in seconds (defaults to 3)"
+  echo "    -i <imagetag> - the tag to be used to launch the network (defaults to \"latest\")"
+  echo "    -cai <ca_imagetag> - the image tag to be used for CA (defaults to \"${CA_IMAGETAG}\")"
+  echo "    -verbose - verbose mode"
+  echo "    Used with "$'\e[0;32m'network.sh deployCC$'\e[0m'
+  echo "    -c <channel name> - deploy chaincode to channel"
   echo "    -ccn <name> - the short name of the chaincode to deploy: basic (default),ledger, private, secured"
   echo "    -ccl <language> - the programming language of the chaincode to deploy: go (default), java, javascript, typescript"
   echo "    -ccv <version>  - chaincode version. 1.0 (default)"
   echo "    -ccs <sequence>  - chaincode definition sequence. Must be an integer, 1 (default), 2, 3, etc"
-  echo "    -ccp <path>  - Optional, chaincode path. Path to the chaincode. When provided the -ccn will be used as the deployed name and not the short name of the known chaincodes."
+  echo "    -ccp <path>  - Optional, path to the chaincode. When provided the -ccn will be used as the deployed name and not the short name of the known chaincodes."
+  echo "    -ccep <policy>  - Optional, chaincode endorsement policy, using signature policy syntax. The default policy requires an endorsement from Org1 and Org2"
+  echo "    -cccg <collection-config>  - Optional, path to a private data collections configuration file"
   echo "    -cci <fcn name>  - Optional, chaincode init required function to invoke. When provided this function will be invoked after deployment of the chaincode and will define the chaincode as initialization required."
-  echo "    -i <imagetag> - the tag to be used to launch the network (defaults to \"latest\")"
-  echo "    -cai <ca_imagetag> - the image tag to be used for CA (defaults to \"${CA_IMAGETAG}\")"
-  echo "    -verbose - verbose mode"
+  echo
   echo "    -h - print this message"
   echo
   echo " Possible Mode and flag combinations"
@@ -383,10 +389,11 @@ function createChannel() {
 
 }
 
+
 ## Call the script to isntall and instantiate a chaincode on the channel
 function deployCC() {
 
-  scripts/deployCC.sh $CHANNEL_NAME $CC_NAME $CC_SRC_PATH $CC_SRC_LANGUAGE $CC_VERSION $CC_SEQUENCE $CC_INIT_FCN $CLI_DELAY $MAX_RETRY $VERBOSE
+  scripts/deployCC.sh $CHANNEL_NAME $CC_NAME $CC_SRC_PATH $CC_SRC_LANGUAGE $CC_VERSION $CC_SEQUENCE $CC_INIT_FCN $CC_END_POLICY $CC_COLL_CONFIG $CLI_DELAY $MAX_RETRY $VERBOSE
 
   if [ $? -ne 0 ]; then
     echo "ERROR !!! Deploying chaincode failed"
@@ -440,6 +447,10 @@ CHANNEL_NAME="mychannel"
 CC_NAME="basic"
 # chaincode path defaults to "NA"
 CC_SRC_PATH="NA"
+# endorsement policy defaults to "NA". This would allow chaincodes to use the majority default policy.
+CC_END_POLICY="NA"
+# collection configuration defaults to "NA"
+CC_COLL_CONFIG="NA"
 # chaincode init function defaults to "NA"
 CC_INIT_FCN="NA"
 # use this as the default docker-compose yaml definition
@@ -532,6 +543,14 @@ while [[ $# -ge 1 ]] ; do
     ;;
   -ccp )
     CC_SRC_PATH="$2"
+    shift
+    ;;
+  -ccep )
+    CC_END_POLICY="$2"
+    shift
+    ;;
+  -cccg )
+    CC_COLL_CONFIG="$2"
     shift
     ;;
   -cci )


### PR DESCRIPTION
Add endorsement policy and collection configuration parameters to the deployCC script.

Also add let users know if they provide a bad chaincode path, or if the language and sample are not yet available

Signed-off-by: NIKHIL E GUPTA <negupta@us.ibm.com>