### PR TITLE
Improve unmarshalling in asset-transfer-basic Go cc

### DIFF
--- a/asset-transfer-basic/chaincode-go/chaincode/smartcontract.go
+++ b/asset-transfer-basic/chaincode-go/chaincode/smartcontract.go
@@ -82,13 +82,13 @@ func (s *SmartContract) ReadAsset(ctx contractapi.TransactionContextInterface, i
 		return nil, fmt.Errorf("the asset %s does not exist", id)
 	}
 
-	var asset *Asset
+	var asset Asset
 	err = json.Unmarshal(assetJSON, &asset)
 	if err != nil {
 		return nil, err
 	}
 
-	return asset, nil
+	return &asset, nil
 }
 
 // UpdateAsset updates an existing asset in the world state with provided parameters.
@@ -173,12 +173,12 @@ func (s *SmartContract) GetAllAssets(ctx contractapi.TransactionContextInterface
 			return nil, err
 		}
 
-		var asset *Asset
+		var asset Asset
 		err = json.Unmarshal(queryResponse.Value, &asset)
 		if err != nil {
 			return nil, err
 		}
-		assets = append(assets, asset)
+		assets = append(assets, &asset)
 	}
 
 	return assets, nil


### PR DESCRIPTION
Although the current code works thanks to Go being quite
forgiving when it comes to pointers, it doesn't exhibit
the best coding style. This patch addresses this.

Signed-off-by: Arnaud J Le Hors <lehors@us.ibm.com>