### PR TITLE
Fix ledger queries chaincode-go InitLedger

### DIFF
--- a/asset-transfer-ledger-queries/chaincode-go/asset_transfer_ledger_chaincode.go
+++ b/asset-transfer-ledger-queries/chaincode-go/asset_transfer_ledger_chaincode.go
@@ -436,14 +436,9 @@ func (t *SimpleChaincode) InitLedger(ctx contractapi.TransactionContextInterface
 	}
 
 	for _, asset := range assets {
-		assetBytes, err := json.Marshal(asset)
+		err := t.CreateAsset(ctx, asset.ID, asset.Color, asset.Size, asset.Owner, asset.AppraisedValue)
 		if err != nil {
 			return err
-		}
-
-		err = ctx.GetStub().PutState(asset.ID, assetBytes)
-		if err != nil {
-			return fmt.Errorf("failed to put to world state. %v", err)
 		}
 	}
 


### PR DESCRIPTION
The InitLedger was not writing the composite key for the color index.
Therefore TransferAssetByColor was not working.

Now InitLedger will call CreateAsset which creates both the asset
and the color index entry.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>