### PR TITLE
fix ccp template and generator to include orderer and channel

### DIFF
--- a/test-network/organizations/ccp-generate.sh
+++ b/test-network/organizations/ccp-generate.sh
@@ -5,26 +5,35 @@ function one_line_pem {
 }
 
 function json_ccp {
-    local PP=$(one_line_pem $4)
-    local CP=$(one_line_pem $5)
+    local OP=$(one_line_pem $5)
+    local PP=$(one_line_pem $6)
+    local CP=$(one_line_pem $7)
     sed -e "s/\${ORG}/$1/" \
-        -e "s/\${P0PORT}/$2/" \
-        -e "s/\${CAPORT}/$3/" \
+        -e "s/\${ORDERERPORT}/$2/" \
+        -e "s/\${P0PORT}/$3/" \
+        -e "s/\${CAPORT}/$4/" \
+        -e "s#\${ORDERERPEM}#$OP#" \
         -e "s#\${PEERPEM}#$PP#" \
         -e "s#\${CAPEM}#$CP#" \
         organizations/ccp-template.json
 }
 
 function yaml_ccp {
-    local PP=$(one_line_pem $4)
-    local CP=$(one_line_pem $5)
+    local OP=$(one_line_pem $5)
+    local PP=$(one_line_pem $6)
+    local CP=$(one_line_pem $7)
     sed -e "s/\${ORG}/$1/" \
-        -e "s/\${P0PORT}/$2/" \
-        -e "s/\${CAPORT}/$3/" \
+        -e "s/\${ORDERERPORT}/$2/" \
+        -e "s/\${P0PORT}/$3/" \
+        -e "s/\${CAPORT}/$4/" \
+        -e "s#\${ORDERERPEM}#$OP#" \
         -e "s#\${PEERPEM}#$PP#" \
         -e "s#\${CAPEM}#$CP#" \
         organizations/ccp-template.yaml | sed -e $'s/\\\\n/\\\n          /g'
 }
+
+ORDERERPORT=7050
+ORDERERPEM=organizations/ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem
 
 ORG=1
 P0PORT=7051
@@ -32,8 +41,8 @@ CAPORT=7054
 PEERPEM=organizations/peerOrganizations/org1.example.com/tlsca/tlsca.org1.example.com-cert.pem
 CAPEM=organizations/peerOrganizations/org1.example.com/ca/ca.org1.example.com-cert.pem
 
-echo "$(json_ccp $ORG $P0PORT $CAPORT $PEERPEM $CAPEM)" > organizations/peerOrganizations/org1.example.com/connection-org1.json
-echo "$(yaml_ccp $ORG $P0PORT $CAPORT $PEERPEM $CAPEM)" > organizations/peerOrganizations/org1.example.com/connection-org1.yaml
+echo "$(json_ccp $ORG $ORDERERPORT $P0PORT $CAPORT $ORDERERPEM $PEERPEM $CAPEM)" > organizations/peerOrganizations/org1.example.com/connection-org1.json
+echo "$(yaml_ccp $ORG $ORDERERPORT $P0PORT $CAPORT $ORDERERPEM $PEERPEM $CAPEM)" > organizations/peerOrganizations/org1.example.com/connection-org1.yaml
 
 ORG=2
 P0PORT=9051
@@ -41,5 +50,5 @@ CAPORT=8054
 PEERPEM=organizations/peerOrganizations/org2.example.com/tlsca/tlsca.org2.example.com-cert.pem
 CAPEM=organizations/peerOrganizations/org2.example.com/ca/ca.org2.example.com-cert.pem
 
-echo "$(json_ccp $ORG $P0PORT $CAPORT $PEERPEM $CAPEM)" > organizations/peerOrganizations/org2.example.com/connection-org2.json
-echo "$(yaml_ccp $ORG $P0PORT $CAPORT $PEERPEM $CAPEM)" > organizations/peerOrganizations/org2.example.com/connection-org2.yaml
+echo "$(json_ccp $ORG $ORDERERPORT $P0PORT $CAPORT $ORDERERPEM $PEERPEM $CAPEM)" > organizations/peerOrganizations/org2.example.com/connection-org2.json
+echo "$(yaml_ccp $ORG $ORDERERPORT $P0PORT $CAPORT $ORDERERPEM $PEERPEM $CAPEM)" > organizations/peerOrganizations/org2.example.com/connection-org2.yaml

--- a/test-network/organizations/ccp-template.json
+++ b/test-network/organizations/ccp-template.json
@@ -22,6 +22,20 @@
             ]
         }
     },
+    "channels": {
+        "mychannel": {
+            "orderers": ["orderer.example.com"],
+            "peers": {
+                "peer0.org${ORG}.example.com": {
+                    "endorsingPeer": true,
+                    "chaincodeQuery": true,
+                    "ledgerQuery": true,
+                    "eventSource": true,
+                    "discover": true
+                }
+            }
+        }
+    },
     "peers": {
         "peer0.org${ORG}.example.com": {
             "url": "grpcs://localhost:${P0PORT}",
@@ -31,6 +45,18 @@
             "grpcOptions": {
                 "ssl-target-name-override": "peer0.org${ORG}.example.com",
                 "hostnameOverride": "peer0.org${ORG}.example.com"
+            }
+        }
+    },
+    "orderers": {
+        "orderer.example.com": {
+            "url": "grpcs://localhost:${ORDERERPORT}",
+            "tlsCACerts": {
+                "pem": "${ORDERERPEM}"
+            },
+            "grpcOptions": {
+                "ssl-target-name-override": "orderer.example.com",
+                "hostnameOverride": "orderer.example.com"
             }
         }
     },

--- a/test-network/organizations/ccp-template.yaml
+++ b/test-network/organizations/ccp-template.yaml
@@ -14,6 +14,17 @@ organizations:
     - peer0.org${ORG}.example.com
     certificateAuthorities:
     - ca.org${ORG}.example.com
+channels:
+  mychannel:
+    orderers:
+      - orderer.example.com
+    peers:
+      peer0.org${ORG}.example.com:
+        endorsingPeer: true
+        chaincodeQuery: true
+        ledgerQuery: true
+        eventSource: true
+        discover:  true
 peers:
   peer0.org${ORG}.example.com:
     url: grpcs://localhost:${P0PORT}
@@ -23,6 +34,15 @@ peers:
     grpcOptions:
       ssl-target-name-override: peer0.org${ORG}.example.com
       hostnameOverride: peer0.org${ORG}.example.com
+orderers:
+  orderer.example.com:
+    url: grpcs://localhost:${ORDERERPORT}
+    tlsCACerts:
+      pem: |
+          ${ORDERERPEM}
+    grpcOptions:
+      ssl-target-name-override: orderer.example.com
+      hostnameOverride: orderer.example.com
 certificateAuthorities:
   ca.org${ORG}.example.com:
     url: https://localhost:${CAPORT}


### PR DESCRIPTION
Update ccp template and generator to include orderer and channel.
needed for `asset-transfer-basic/application-go/assetTransfer.go`

Signed-off-by: Naser Mirzaei <nasermirzaei89@gmail.com>