### PR TITLE
Re-enable CI tests for asset-transfer-private-data JS app

### DIFF
--- a/asset-transfer-private-data/application-javascript/app.js
+++ b/asset-transfer-private-data/application-javascript/app.js
@@ -123,7 +123,7 @@ async function main() {
             let asset2Data = { objectType: assetType, assetID: assetID2, color: 'blue', size: 35, appraisedValue: 727 };
 
             console.log('\n**************** As Org1 Client ****************');
-            console.log('Adding Assets to work with: Submit Transaction: CreateAsset ' + assetID1);
+            console.log('Adding Assets to work with:\n--> Submit Transaction: CreateAsset ' + assetID1);
             let statefulTxn = contractOrg1.createTransaction('CreateAsset');
             //if you need to customize endorsement to specific set of Orgs, use setEndorsingOrganizations
             //statefulTxn.setEndorsingOrganizations(mspOrg1);

--- a/asset-transfer-private-data/chaincode-go/private_asset_queries.go
+++ b/asset-transfer-private-data/chaincode-go/private_asset_queries.go
@@ -147,7 +147,6 @@ func (s *SmartContract) QueryAssetByOwner(ctx contractapi.TransactionContextInte
 	return queryResults, nil
 }
 
-
 // QueryAssets uses a query string to perform a query for assets.
 // Query string matching state database syntax is passed in and executed as is.
 // Supports ad hoc queries that can be defined at runtime by the client.

--- a/ci/scripts/run-test-network-private.sh
+++ b/ci/scripts/run-test-network-private.sh
@@ -15,7 +15,7 @@ function createNetwork() {
   print "Creating network"
   ./network.sh up createChannel -ca -s couchdb -i "${FABRIC_VERSION}"
   print "Deploying ${CHAINCODE_NAME} chaincode"
-  ./network.sh deployCC -ccn "${CHAINCODE_NAME}" -ccv 1 -ccs 1 -ccl "${CHAINCODE_LANGUAGE}"
+  ./network.sh deployCC -ccn "${CHAINCODE_NAME}" -ccv 1 -ccs 1 -ccl "${CHAINCODE_LANGUAGE}" -ccep "OR('Org1MSP.peer','Org2MSP.peer')" -cccg ../asset-transfer-private-data/chaincode-go/collections_config.json
 }
 
 function stopNetwork() {
@@ -25,10 +25,10 @@ function stopNetwork() {
 
 # Run Javascript application
 createNetwork
-#print "Initializing Javascript application"
-#pushd ../asset-transfer-private-data/application-javascript
-#npm install
-#print "Executing app.js"
-#node app.js
-#popd
+print "Initializing Javascript application"
+pushd ../asset-transfer-private-data/application-javascript
+npm install
+print "Executing app.js"
+node app.js
+popd
 stopNetwork


### PR DESCRIPTION
Re-enable CI tests for asset-transfer-private-data JavaScript application.

Also re-add the error when private asset details are not found in the collection,
so that the CLI instructions work as desired, and to demonstrate error
handing in the client application.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>