### PR TITLE
Improve basic asset transfer external chaincode detect script

### DIFF
--- a/asset-transfer-basic/chaincode-external/sampleBuilder/bin/detect
+++ b/asset-transfer-basic/chaincode-external/sampleBuilder/bin/detect
@@ -4,8 +4,10 @@ set -euo pipefail
 
 METADIR=$2
 # check if the "type" field is set to "external"
-# crude way without jq, fragile but good enough for this sample...
-if [ "$(grep type "$METADIR/metadata.json" |cut -f4 -d\")" = "external" ]; then
+# crude way without jq which is not in the default fabric peer image
+TYPE=$(tr -d '\n' < "$METADIR/metadata.json" | awk -F':' '{ for (i = 1; i < NF; i++){ if ($i~/type/) { print $(i+1); break }}}'| cut -d\" -f2)
+
+if [ "$TYPE" = "external" ]; then
     exit 0
 fi
 


### PR DESCRIPTION
This change makes the way the type property is extracted from the
metadata.json file much more robust, and therefore sets a better
example.

Signed-off-by: Arnaud J Le Hors <lehors@us.ibm.com>