### PR TITLE
hide set +x from output

### DIFF
--- a/high-throughput/scripts/check-commit-readiness.sh
+++ b/high-throughput/scripts/check-commit-readiness.sh
@@ -43,7 +43,7 @@ checkCommitReadiness() {
     set -x
     peer lifecycle chaincode checkcommitreadiness --channelID mychannel --name bigdatacc --signature-policy "OR('Org1MSP.peer', 'Org2MSP.peer')" --version 0 --init-required --sequence 1 >&log.txt
     res=$?
-    set +x
+    { set +x; } 2>/dev/null
     test $res -eq 0 || continue
     let rc=0
     for var in "$@"

--- a/interest_rate_swaps/network/scripts/check-commit-readiness.sh
+++ b/interest_rate_swaps/network/scripts/check-commit-readiness.sh
@@ -17,7 +17,7 @@ checkCommitReadiness() {
     set -x
     peer lifecycle chaincode checkcommitreadiness -o irs-orderer:7050 --channelID irs --signature-policy "AND(OR('partya.peer','partyb.peer','partyc.peer'), 'auditor.peer')" --name irscc --version 1 --init-required --sequence 1 >&log.txt
     res=$?
-    set +x
+    { set +x; } 2>/dev/null
     test $res -eq 0 || continue
     let rc=0
     for var in "$@"

--- a/test-network/addOrg3/addOrg3.sh
+++ b/test-network/addOrg3/addOrg3.sh
@@ -73,7 +73,7 @@ function generateOrg3() {
     set -x
     cryptogen generate --config=org3-crypto.yaml --output="../organizations"
     res=$?
-    set +x
+    { set +x; } 2>/dev/null
     if [ $res -ne 0 ]; then
       echo "Failed to generate certificates..."
       exit 1
@@ -131,7 +131,7 @@ function generateOrg3Definition() {
    set -x
    configtxgen -printOrg Org3MSP > ../organizations/peerOrganizations/org3.example.com/org3.json
    res=$?
-   set +x
+   { set +x; } 2>/dev/null
    if [ $res -ne 0 ]; then
      echo "Failed to generate Org3 config material..."
      exit 1

--- a/test-network/addOrg3/fabric-ca/registerEnroll.sh
+++ b/test-network/addOrg3/fabric-ca/registerEnroll.sh
@@ -13,7 +13,7 @@ function createOrg3 {
 
   set -x
   fabric-ca-client enroll -u https://admin:adminpw@localhost:11054 --caname ca-org3 --tls.certfiles ${PWD}/fabric-ca/org3/tls-cert.pem
-  set +x
+  { set +x; } 2>/dev/null
 
   echo 'NodeOUs:
   Enable: true
@@ -35,21 +35,21 @@ function createOrg3 {
   echo
   set -x
 	fabric-ca-client register --caname ca-org3 --id.name peer0 --id.secret peer0pw --id.type peer --tls.certfiles ${PWD}/fabric-ca/org3/tls-cert.pem
-  set +x
+  { set +x; } 2>/dev/null
 
   echo
   echo "Register user"
   echo
   set -x
   fabric-ca-client register --caname ca-org3 --id.name user1 --id.secret user1pw --id.type client --tls.certfiles ${PWD}/fabric-ca/org3/tls-cert.pem
-  set +x
+  { set +x; } 2>/dev/null
 
   echo
   echo "Register the org admin"
   echo
   set -x
   fabric-ca-client register --caname ca-org3 --id.name org3admin --id.secret org3adminpw --id.type admin --tls.certfiles ${PWD}/fabric-ca/org3/tls-cert.pem
-  set +x
+  { set +x; } 2>/dev/null
 
 	mkdir -p ../organizations/peerOrganizations/org3.example.com/peers
   mkdir -p ../organizations/peerOrganizations/org3.example.com/peers/peer0.org3.example.com
@@ -59,7 +59,7 @@ function createOrg3 {
   echo
   set -x
 	fabric-ca-client enroll -u https://peer0:peer0pw@localhost:11054 --caname ca-org3 -M ${PWD}/../organizations/peerOrganizations/org3.example.com/peers/peer0.org3.example.com/msp --csr.hosts peer0.org3.example.com --tls.certfiles ${PWD}/fabric-ca/org3/tls-cert.pem
-  set +x
+  { set +x; } 2>/dev/null
 
   cp ${PWD}/../organizations/peerOrganizations/org3.example.com/msp/config.yaml ${PWD}/../organizations/peerOrganizations/org3.example.com/peers/peer0.org3.example.com/msp/config.yaml
 
@@ -68,7 +68,7 @@ function createOrg3 {
   echo
   set -x
   fabric-ca-client enroll -u https://peer0:peer0pw@localhost:11054 --caname ca-org3 -M ${PWD}/../organizations/peerOrganizations/org3.example.com/peers/peer0.org3.example.com/tls --enrollment.profile tls --csr.hosts peer0.org3.example.com --csr.hosts localhost --tls.certfiles ${PWD}/fabric-ca/org3/tls-cert.pem
-  set +x
+  { set +x; } 2>/dev/null
 
 
   cp ${PWD}/../organizations/peerOrganizations/org3.example.com/peers/peer0.org3.example.com/tls/tlscacerts/* ${PWD}/../organizations/peerOrganizations/org3.example.com/peers/peer0.org3.example.com/tls/ca.crt
@@ -92,7 +92,7 @@ function createOrg3 {
   echo
   set -x
 	fabric-ca-client enroll -u https://user1:user1pw@localhost:11054 --caname ca-org3 -M ${PWD}/../organizations/peerOrganizations/org3.example.com/users/User1@org3.example.com/msp --tls.certfiles ${PWD}/fabric-ca/org3/tls-cert.pem
-  set +x
+  { set +x; } 2>/dev/null
 
   cp ${PWD}/../organizations/peerOrganizations/org3.example.com/msp/config.yaml ${PWD}/../organizations/peerOrganizations/org3.example.com/users/User1@org3.example.com/msp/config.yaml
 
@@ -103,7 +103,7 @@ function createOrg3 {
   echo
   set -x
 	fabric-ca-client enroll -u https://org3admin:org3adminpw@localhost:11054 --caname ca-org3 -M ${PWD}/../organizations/peerOrganizations/org3.example.com/users/Admin@org3.example.com/msp --tls.certfiles ${PWD}/fabric-ca/org3/tls-cert.pem
-  set +x
+  { set +x; } 2>/dev/null
 
   cp ${PWD}/../organizations/peerOrganizations/org3.example.com/msp/config.yaml ${PWD}/../organizations/peerOrganizations/org3.example.com/users/Admin@org3.example.com/msp/config.yaml
 

--- a/test-network/network.sh
+++ b/test-network/network.sh
@@ -214,7 +214,7 @@ function createOrgs() {
     set -x
     cryptogen generate --config=./organizations/cryptogen/crypto-config-org1.yaml --output="organizations"
     res=$?
-    set +x
+    { set +x; } 2>/dev/null
     if [ $res -ne 0 ]; then
       echo $'\e[1;32m'"Failed to generate certificates..."$'\e[0m'
       exit 1
@@ -227,7 +227,7 @@ function createOrgs() {
     set -x
     cryptogen generate --config=./organizations/cryptogen/crypto-config-org2.yaml --output="organizations"
     res=$?
-    set +x
+    { set +x; } 2>/dev/null
     if [ $res -ne 0 ]; then
       echo $'\e[1;32m'"Failed to generate certificates..."$'\e[0m'
       exit 1
@@ -240,7 +240,7 @@ function createOrgs() {
     set -x
     cryptogen generate --config=./organizations/cryptogen/crypto-config-orderer.yaml --output="organizations"
     res=$?
-    set +x
+    { set +x; } 2>/dev/null
     if [ $res -ne 0 ]; then
       echo $'\e[1;32m'"Failed to generate certificates..."$'\e[0m'
       exit 1
@@ -329,7 +329,7 @@ function createConsortium() {
   set -x
   configtxgen -profile TwoOrgsOrdererGenesis -channelID system-channel -outputBlock ./system-genesis-block/genesis.block
   res=$?
-  set +x
+  { set +x; } 2>/dev/null
   if [ $res -ne 0 ]; then
     echo $'\e[1;32m'"Failed to generate orderer genesis block..."$'\e[0m'
     exit 1

--- a/test-network/organizations/fabric-ca/registerEnroll.sh
+++ b/test-network/organizations/fabric-ca/registerEnroll.sh
@@ -13,7 +13,7 @@ function createOrg1 {
 
   set -x
   fabric-ca-client enroll -u https://admin:adminpw@localhost:7054 --caname ca-org1 --tls.certfiles ${PWD}/organizations/fabric-ca/org1/tls-cert.pem
-  set +x
+  { set +x; } 2>/dev/null
 
   echo 'NodeOUs:
   Enable: true
@@ -35,21 +35,21 @@ function createOrg1 {
   echo
   set -x
 	fabric-ca-client register --caname ca-org1 --id.name peer0 --id.secret peer0pw --id.type peer --tls.certfiles ${PWD}/organizations/fabric-ca/org1/tls-cert.pem
-  set +x
+  { set +x; } 2>/dev/null
 
   echo
   echo "Register user"
   echo
   set -x
   fabric-ca-client register --caname ca-org1 --id.name user1 --id.secret user1pw --id.type client --tls.certfiles ${PWD}/organizations/fabric-ca/org1/tls-cert.pem
-  set +x
+  { set +x; } 2>/dev/null
 
   echo
   echo "Register the org admin"
   echo
   set -x
   fabric-ca-client register --caname ca-org1 --id.name org1admin --id.secret org1adminpw --id.type admin --tls.certfiles ${PWD}/organizations/fabric-ca/org1/tls-cert.pem
-  set +x
+  { set +x; } 2>/dev/null
 
 	mkdir -p organizations/peerOrganizations/org1.example.com/peers
   mkdir -p organizations/peerOrganizations/org1.example.com/peers/peer0.org1.example.com
@@ -59,7 +59,7 @@ function createOrg1 {
   echo
   set -x
 	fabric-ca-client enroll -u https://peer0:peer0pw@localhost:7054 --caname ca-org1 -M ${PWD}/organizations/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/msp --csr.hosts peer0.org1.example.com --tls.certfiles ${PWD}/organizations/fabric-ca/org1/tls-cert.pem
-  set +x
+  { set +x; } 2>/dev/null
 
   cp ${PWD}/organizations/peerOrganizations/org1.example.com/msp/config.yaml ${PWD}/organizations/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/msp/config.yaml
 
@@ -68,7 +68,7 @@ function createOrg1 {
   echo
   set -x
   fabric-ca-client enroll -u https://peer0:peer0pw@localhost:7054 --caname ca-org1 -M ${PWD}/organizations/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls --enrollment.profile tls --csr.hosts peer0.org1.example.com --csr.hosts localhost --tls.certfiles ${PWD}/organizations/fabric-ca/org1/tls-cert.pem
-  set +x
+  { set +x; } 2>/dev/null
 
 
   cp ${PWD}/organizations/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls/tlscacerts/* ${PWD}/organizations/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls/ca.crt
@@ -92,7 +92,7 @@ function createOrg1 {
   echo
   set -x
 	fabric-ca-client enroll -u https://user1:user1pw@localhost:7054 --caname ca-org1 -M ${PWD}/organizations/peerOrganizations/org1.example.com/users/User1@org1.example.com/msp --tls.certfiles ${PWD}/organizations/fabric-ca/org1/tls-cert.pem
-  set +x
+  { set +x; } 2>/dev/null
 
   cp ${PWD}/organizations/peerOrganizations/org1.example.com/msp/config.yaml ${PWD}/organizations/peerOrganizations/org1.example.com/users/User1@org1.example.com/msp/config.yaml
 
@@ -103,7 +103,7 @@ function createOrg1 {
   echo
   set -x
 	fabric-ca-client enroll -u https://org1admin:org1adminpw@localhost:7054 --caname ca-org1 -M ${PWD}/organizations/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp --tls.certfiles ${PWD}/organizations/fabric-ca/org1/tls-cert.pem
-  set +x
+  { set +x; } 2>/dev/null
 
   cp ${PWD}/organizations/peerOrganizations/org1.example.com/msp/config.yaml ${PWD}/organizations/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/config.yaml
 
@@ -123,7 +123,7 @@ function createOrg2 {
 
   set -x
   fabric-ca-client enroll -u https://admin:adminpw@localhost:8054 --caname ca-org2 --tls.certfiles ${PWD}/organizations/fabric-ca/org2/tls-cert.pem
-  set +x
+  { set +x; } 2>/dev/null
 
   echo 'NodeOUs:
   Enable: true
@@ -145,21 +145,21 @@ function createOrg2 {
   echo
   set -x
 	fabric-ca-client register --caname ca-org2 --id.name peer0 --id.secret peer0pw --id.type peer --tls.certfiles ${PWD}/organizations/fabric-ca/org2/tls-cert.pem
-  set +x
+  { set +x; } 2>/dev/null
 
   echo
   echo "Register user"
   echo
   set -x
   fabric-ca-client register --caname ca-org2 --id.name user1 --id.secret user1pw --id.type client --tls.certfiles ${PWD}/organizations/fabric-ca/org2/tls-cert.pem
-  set +x
+  { set +x; } 2>/dev/null
 
   echo
   echo "Register the org admin"
   echo
   set -x
   fabric-ca-client register --caname ca-org2 --id.name org2admin --id.secret org2adminpw --id.type admin --tls.certfiles ${PWD}/organizations/fabric-ca/org2/tls-cert.pem
-  set +x
+  { set +x; } 2>/dev/null
 
 	mkdir -p organizations/peerOrganizations/org2.example.com/peers
   mkdir -p organizations/peerOrganizations/org2.example.com/peers/peer0.org2.example.com
@@ -169,7 +169,7 @@ function createOrg2 {
   echo
   set -x
 	fabric-ca-client enroll -u https://peer0:peer0pw@localhost:8054 --caname ca-org2 -M ${PWD}/organizations/peerOrganizations/org2.example.com/peers/peer0.org2.example.com/msp --csr.hosts peer0.org2.example.com --tls.certfiles ${PWD}/organizations/fabric-ca/org2/tls-cert.pem
-  set +x
+  { set +x; } 2>/dev/null
 
   cp ${PWD}/organizations/peerOrganizations/org2.example.com/msp/config.yaml ${PWD}/organizations/peerOrganizations/org2.example.com/peers/peer0.org2.example.com/msp/config.yaml
 
@@ -178,7 +178,7 @@ function createOrg2 {
   echo
   set -x
   fabric-ca-client enroll -u https://peer0:peer0pw@localhost:8054 --caname ca-org2 -M ${PWD}/organizations/peerOrganizations/org2.example.com/peers/peer0.org2.example.com/tls --enrollment.profile tls --csr.hosts peer0.org2.example.com --csr.hosts localhost --tls.certfiles ${PWD}/organizations/fabric-ca/org2/tls-cert.pem
-  set +x
+  { set +x; } 2>/dev/null
 
 
   cp ${PWD}/organizations/peerOrganizations/org2.example.com/peers/peer0.org2.example.com/tls/tlscacerts/* ${PWD}/organizations/peerOrganizations/org2.example.com/peers/peer0.org2.example.com/tls/ca.crt
@@ -202,7 +202,7 @@ function createOrg2 {
   echo
   set -x
 	fabric-ca-client enroll -u https://user1:user1pw@localhost:8054 --caname ca-org2 -M ${PWD}/organizations/peerOrganizations/org2.example.com/users/User1@org2.example.com/msp --tls.certfiles ${PWD}/organizations/fabric-ca/org2/tls-cert.pem
-  set +x
+  { set +x; } 2>/dev/null
 
   cp ${PWD}/organizations/peerOrganizations/org2.example.com/msp/config.yaml ${PWD}/organizations/peerOrganizations/org2.example.com/users/User1@org2.example.com/msp/config.yaml
 
@@ -213,7 +213,7 @@ function createOrg2 {
   echo
   set -x
 	fabric-ca-client enroll -u https://org2admin:org2adminpw@localhost:8054 --caname ca-org2 -M ${PWD}/organizations/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp --tls.certfiles ${PWD}/organizations/fabric-ca/org2/tls-cert.pem
-  set +x
+  { set +x; } 2>/dev/null
 
   cp ${PWD}/organizations/peerOrganizations/org2.example.com/msp/config.yaml ${PWD}/organizations/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp/config.yaml
 
@@ -232,7 +232,7 @@ function createOrderer {
 
   set -x
   fabric-ca-client enroll -u https://admin:adminpw@localhost:9054 --caname ca-orderer --tls.certfiles ${PWD}/organizations/fabric-ca/ordererOrg/tls-cert.pem
-  set +x
+  { set +x; } 2>/dev/null
 
   echo 'NodeOUs:
   Enable: true
@@ -255,14 +255,14 @@ function createOrderer {
   echo
   set -x
 	fabric-ca-client register --caname ca-orderer --id.name orderer --id.secret ordererpw --id.type orderer --tls.certfiles ${PWD}/organizations/fabric-ca/ordererOrg/tls-cert.pem
-    set +x
+  { set +x; } 2>/dev/null
 
   echo
   echo "Register the orderer admin"
   echo
   set -x
   fabric-ca-client register --caname ca-orderer --id.name ordererAdmin --id.secret ordererAdminpw --id.type admin --tls.certfiles ${PWD}/organizations/fabric-ca/ordererOrg/tls-cert.pem
-  set +x
+  { set +x; } 2>/dev/null
 
 	mkdir -p organizations/ordererOrganizations/example.com/orderers
   mkdir -p organizations/ordererOrganizations/example.com/orderers/example.com
@@ -274,7 +274,7 @@ function createOrderer {
   echo
   set -x
 	fabric-ca-client enroll -u https://orderer:ordererpw@localhost:9054 --caname ca-orderer -M ${PWD}/organizations/ordererOrganizations/example.com/orderers/orderer.example.com/msp --csr.hosts orderer.example.com --csr.hosts localhost --tls.certfiles ${PWD}/organizations/fabric-ca/ordererOrg/tls-cert.pem
-  set +x
+  { set +x; } 2>/dev/null
 
   cp ${PWD}/organizations/ordererOrganizations/example.com/msp/config.yaml ${PWD}/organizations/ordererOrganizations/example.com/orderers/orderer.example.com/msp/config.yaml
 
@@ -283,7 +283,7 @@ function createOrderer {
   echo
   set -x
   fabric-ca-client enroll -u https://orderer:ordererpw@localhost:9054 --caname ca-orderer -M ${PWD}/organizations/ordererOrganizations/example.com/orderers/orderer.example.com/tls --enrollment.profile tls --csr.hosts orderer.example.com --csr.hosts localhost --tls.certfiles ${PWD}/organizations/fabric-ca/ordererOrg/tls-cert.pem
-  set +x
+  { set +x; } 2>/dev/null
 
   cp ${PWD}/organizations/ordererOrganizations/example.com/orderers/orderer.example.com/tls/tlscacerts/* ${PWD}/organizations/ordererOrganizations/example.com/orderers/orderer.example.com/tls/ca.crt
   cp ${PWD}/organizations/ordererOrganizations/example.com/orderers/orderer.example.com/tls/signcerts/* ${PWD}/organizations/ordererOrganizations/example.com/orderers/orderer.example.com/tls/server.crt
@@ -303,7 +303,7 @@ function createOrderer {
   echo
   set -x
 	fabric-ca-client enroll -u https://ordererAdmin:ordererAdminpw@localhost:9054 --caname ca-orderer -M ${PWD}/organizations/ordererOrganizations/example.com/users/Admin@example.com/msp --tls.certfiles ${PWD}/organizations/fabric-ca/ordererOrg/tls-cert.pem
-  set +x
+  { set +x; } 2>/dev/null
 
   cp ${PWD}/organizations/ordererOrganizations/example.com/msp/config.yaml ${PWD}/organizations/ordererOrganizations/example.com/users/Admin@example.com/msp/config.yaml
 

--- a/test-network/scripts/createChannel.sh
+++ b/test-network/scripts/createChannel.sh
@@ -22,7 +22,7 @@ createChannelTx() {
 	set -x
 	configtxgen -profile TwoOrgsChannel -outputCreateChannelTx ./channel-artifacts/${CHANNEL_NAME}.tx -channelID $CHANNEL_NAME
 	res=$?
-	set +x
+	{ set +x; } 2>/dev/null
 	if [ $res -ne 0 ]; then
 		echo "Failed to generate channel configuration transaction..."
 		exit 1
@@ -39,7 +39,7 @@ createAncorPeerTx() {
 	set -x
 	configtxgen -profile TwoOrgsChannel -outputAnchorPeersUpdate ./channel-artifacts/${orgmsp}anchors.tx -channelID $CHANNEL_NAME -asOrg ${orgmsp}
 	res=$?
-	set +x
+	{ set +x; } 2>/dev/null
 	if [ $res -ne 0 ]; then
 		echo "Failed to generate anchor peer update transaction for ${orgmsp}..."
 		exit 1
@@ -58,7 +58,7 @@ createChannel() {
 		set -x
 		peer channel create -o localhost:7050 -c $CHANNEL_NAME --ordererTLSHostnameOverride orderer.example.com -f ./channel-artifacts/${CHANNEL_NAME}.tx --outputBlock ./channel-artifacts/${CHANNEL_NAME}.block --tls --cafile $ORDERER_CA >&log.txt
 		res=$?
-		set +x
+		{ set +x; } 2>/dev/null
 		let rc=$res
 		COUNTER=$(expr $COUNTER + 1)
 	done
@@ -81,7 +81,7 @@ joinChannel() {
     set -x
     peer channel join -b ./channel-artifacts/$CHANNEL_NAME.block >&log.txt
     res=$?
-    set +x
+    { set +x; } 2>/dev/null
 		let rc=$res
 		COUNTER=$(expr $COUNTER + 1)
 	done
@@ -101,7 +101,7 @@ updateAnchorPeers() {
     set -x
 		peer channel update -o localhost:7050 --ordererTLSHostnameOverride orderer.example.com -c $CHANNEL_NAME -f ./channel-artifacts/${CORE_PEER_LOCALMSPID}anchors.tx --tls --cafile $ORDERER_CA >&log.txt
     res=$?
-    set +x
+    { set +x; } 2>/dev/null
 		let rc=$res
 		COUNTER=$(expr $COUNTER + 1)
 	done

--- a/test-network/scripts/deployCC.sh
+++ b/test-network/scripts/deployCC.sh
@@ -153,7 +153,7 @@ packageChaincode() {
 	set -x
 	peer lifecycle chaincode package ${CC_NAME}.tar.gz --path ${CC_SRC_PATH} --lang ${CC_RUNTIME_LANGUAGE} --label ${CC_NAME}_${CC_VERSION} >&log.txt
 	res=$?
-	set +x
+	{ set +x; } 2>/dev/null
 	cat log.txt
 	verifyResult $res "Chaincode packaging on peer0.org${ORG} has failed"
 	echo "===================== Chaincode is packaged on peer0.org${ORG} ===================== "
@@ -167,7 +167,7 @@ installChaincode() {
 	set -x
 	peer lifecycle chaincode install ${CC_NAME}.tar.gz >&log.txt
 	res=$?
-	set +x
+	{ set +x; } 2>/dev/null
 	cat log.txt
 	verifyResult $res "Chaincode installation on peer0.org${ORG} has failed"
 	echo "===================== Chaincode is installed on peer0.org${ORG} ===================== "
@@ -181,7 +181,7 @@ queryInstalled() {
 	set -x
 	peer lifecycle chaincode queryinstalled >&log.txt
 	res=$?
-	set +x
+	{ set +x; } 2>/dev/null
 	cat log.txt
 	PACKAGE_ID=$(sed -n "/${CC_NAME}_${CC_VERSION}/{s/^Package ID: //; s/, Label:.*$//; p;}" log.txt)
 	verifyResult $res "Query installed on peer0.org${ORG} has failed"
@@ -196,7 +196,7 @@ approveForMyOrg() {
 	set -x
 	peer lifecycle chaincode approveformyorg -o localhost:7050 --ordererTLSHostnameOverride orderer.example.com --tls --cafile $ORDERER_CA --channelID $CHANNEL_NAME --name ${CC_NAME} --version ${CC_VERSION} --package-id ${PACKAGE_ID} --sequence ${CC_SEQUENCE} ${INIT_REQUIRED} ${CC_END_POLICY} ${CC_COLL_CONFIG} >&log.txt
 	res=$?
-	set +x
+	{ set +x; } 2>/dev/null
 	cat log.txt
 	verifyResult $res "Chaincode definition approved on peer0.org${ORG} on channel '$CHANNEL_NAME' failed"
 	echo "===================== Chaincode definition approved on peer0.org${ORG} on channel '$CHANNEL_NAME' ===================== "
@@ -219,7 +219,7 @@ checkCommitReadiness() {
 		set -x
 		peer lifecycle chaincode checkcommitreadiness --channelID $CHANNEL_NAME --name ${CC_NAME} --version ${CC_VERSION} --sequence ${CC_SEQUENCE} ${INIT_REQUIRED} ${CC_END_POLICY} ${CC_COLL_CONFIG} --output json >&log.txt
 		res=$?
-		set +x
+		{ set +x; } 2>/dev/null
 		let rc=0
 		for var in "$@"; do
 			grep "$var" log.txt &>/dev/null || let rc=1
@@ -249,7 +249,7 @@ commitChaincodeDefinition() {
 	set -x
 	peer lifecycle chaincode commit -o localhost:7050 --ordererTLSHostnameOverride orderer.example.com --tls --cafile $ORDERER_CA --channelID $CHANNEL_NAME --name ${CC_NAME} $PEER_CONN_PARMS --version ${CC_VERSION} --sequence ${CC_SEQUENCE} ${INIT_REQUIRED} ${CC_END_POLICY} ${CC_COLL_CONFIG} >&log.txt
 	res=$?
-	set +x
+	{ set +x; } 2>/dev/null
 	cat log.txt
 	verifyResult $res "Chaincode definition commit failed on peer0.org${ORG} on channel '$CHANNEL_NAME' failed"
 	echo "===================== Chaincode definition committed on channel '$CHANNEL_NAME' ===================== "
@@ -272,7 +272,7 @@ queryCommitted() {
 		set -x
 		peer lifecycle chaincode querycommitted --channelID $CHANNEL_NAME --name ${CC_NAME} >&log.txt
 		res=$?
-		set +x
+		{ set +x; } 2>/dev/null
 		test $res -eq 0 && VALUE=$(cat log.txt | grep -o '^Version: '$CC_VERSION', Sequence: [0-9]*, Endorsement Plugin: escc, Validation Plugin: vscc')
 		test "$VALUE" = "$EXPECTED_RESULT" && let rc=0
 		COUNTER=$(expr $COUNTER + 1)
@@ -303,7 +303,7 @@ chaincodeInvokeInit() {
 	echo invoke fcn call:${fcn_call}
 	peer chaincode invoke -o localhost:7050 --ordererTLSHostnameOverride orderer.example.com --tls --cafile $ORDERER_CA -C $CHANNEL_NAME -n ${CC_NAME} $PEER_CONN_PARMS --isInit -c ${fcn_call} >&log.txt
 	res=$?
-	set +x
+	{ set +x; } 2>/dev/null
 	cat log.txt
 	verifyResult $res "Invoke execution on $PEERS failed "
 	echo "===================== Invoke transaction successful on $PEERS on channel '$CHANNEL_NAME' ===================== "
@@ -324,7 +324,7 @@ chaincodeQuery() {
 		set -x
 		peer chaincode query -C $CHANNEL_NAME -n ${CC_NAME} -c '{"Args":["queryAllCars"]}' >&log.txt
 		res=$?
-		set +x
+		{ set +x; } 2>/dev/null
 		let rc=$res
 		COUNTER=$(expr $COUNTER + 1)
 	done

--- a/test-network/scripts/org3-scripts/step1org3.sh
+++ b/test-network/scripts/org3-scripts/step1org3.sh
@@ -40,12 +40,12 @@ fetchChannelConfig() {
   echo "Fetching the most recent configuration block for the channel"
   set -x
   peer channel fetch config config_block.pb -o orderer.example.com:7050 --ordererTLSHostnameOverride orderer.example.com -c $CHANNEL --tls --cafile $ORDERER_CA
-  set +x
+  { set +x; } 2>/dev/null
 
   echo "Decoding config block to JSON and isolating config to ${OUTPUT}"
   set -x
   configtxlator proto_decode --input config_block.pb --type common.Block | jq .data.data[0].payload.data.config >"${OUTPUT}"
-  set +x
+  { set +x; } 2>/dev/null
 }
 
 # createConfigUpdate <channel_id> <original_config.json> <modified_config.json> <output.pb>
@@ -64,7 +64,7 @@ createConfigUpdate() {
   configtxlator proto_decode --input config_update.pb --type common.ConfigUpdate >config_update.json
   echo '{"payload":{"header":{"channel_header":{"channel_id":"'$CHANNEL'", "type":2}},"data":{"config_update":'$(cat config_update.json)'}}}' | jq . >config_update_in_envelope.json
   configtxlator proto_encode --input config_update_in_envelope.json --type common.Envelope >"${OUTPUT}"
-  set +x
+  { set +x; } 2>/dev/null
 }
 
 # signConfigtxAsPeerOrg <org> <configtx.pb>
@@ -75,7 +75,7 @@ signConfigtxAsPeerOrg() {
   setGlobals $PEERORG
   set -x
   peer channel signconfigtx -f "${TX}"
-  set +x
+  { set +x; } 2>/dev/null
 }
 
 echo
@@ -88,7 +88,7 @@ fetchChannelConfig 1 ${CHANNEL_NAME} config.json
 # Modify the configuration to append the new org
 set -x
 jq -s '.[0] * {"channel_group":{"groups":{"Application":{"groups": {"Org3MSP":.[1]}}}}}' config.json ./organizations/peerOrganizations/org3.example.com/org3.json > modified_config.json
-set +x
+{ set +x; } 2>/dev/null
 
 # Compute a config update, based on the differences between config.json and modified_config.json, write it as a transaction to org3_update_in_envelope.pb
 createConfigUpdate ${CHANNEL_NAME} config.json modified_config.json org3_update_in_envelope.pb
@@ -107,7 +107,7 @@ echo
 setGlobals 2
 set -x
 peer channel update -f org3_update_in_envelope.pb -c ${CHANNEL_NAME} -o orderer.example.com:7050 --ordererTLSHostnameOverride orderer.example.com --tls --cafile ${ORDERER_CA}
-set +x
+{ set +x; } 2>/dev/null
 
 echo
 echo "========= Config transaction to add org3 to network submitted! =========== "

--- a/test-network/scripts/org3-scripts/step2org3.sh
+++ b/test-network/scripts/org3-scripts/step2org3.sh
@@ -36,7 +36,7 @@ joinChannelWithRetry() {
   set -x
   peer channel join -b $CHANNEL_NAME.block >&log.txt
   res=$?
-  set +x
+  { set +x; } 2>/dev/null
   cat log.txt
   if [ $res -ne 0 -a $COUNTER -lt $MAX_RETRY ]; then
     COUNTER=$(expr $COUNTER + 1)
@@ -54,7 +54,7 @@ echo "Fetching channel config block from orderer..."
 set -x
 peer channel fetch 0 $CHANNEL_NAME.block -o orderer.example.com:7050 --ordererTLSHostnameOverride orderer.example.com -c $CHANNEL_NAME --tls --cafile $ORDERER_CA >&log.txt
 res=$?
-set +x
+{ set +x; } 2>/dev/null
 cat log.txt
 verifyResult $res "Fetching config block from orderer has Failed"
 


### PR DESCRIPTION
This commit will hide `set +x` from scripts output.
We should use `{ set +x; } 2>/dev/null` instead of `set +x` for cleaner output!

Signed-off-by: Naser Mirzaei <nasermirzaei89@gmail.com>