### PR TITLE
Fixed sdk connection bugs "SendTransaction failed: orderers is nil", make it fit the "entityMatchers" way.

### DIFF
--- a/test-network/configtx/configtx.yaml
+++ b/test-network/configtx/configtx.yaml
@@ -217,6 +217,14 @@ Orderer: &OrdererDefaults
 
     # Orderer Type: The orderer implementation to start
     OrdererType: etcdraft
+    
+    # Addresses used to be the list of orderer addresses that clients and peers
+    # could connect to.  However, this does not allow clients to associate orderer
+    # addresses and orderer organizations which can be useful for things such
+    # as TLS validation.  The preferred way to specify orderer addresses is now
+    # to include the OrdererEndpoints item in your org definition
+    Addresses:
+        - orderer.example.com:7050
 
     EtcdRaft:
         Consenters:


### PR DESCRIPTION
Signed-off-by: 暾暾 <631078133@qq.com>