### PR TITLE
Replace ca waiting period

### DIFF
--- a/test-network/network.sh
+++ b/test-network/network.sh
@@ -236,7 +236,14 @@ function createOrgs() {
 
     . organizations/fabric-ca/registerEnroll.sh
 
-    sleep 10
+  while :
+    do
+      if [ ! -f "organizations/fabric-ca/org1/tls-cert.pem" ]; then
+        sleep 1
+      else
+        break
+      fi
+    done
 
     infoln "Create Org1 Identities"
 


### PR DESCRIPTION
If the registerEnroll script runs before the CA is fully stood up, the script fails. Currently, there is a 10 second waiting period to guarantee that the CAs are up before the enroll commands are issued. This was always a temporary hack, but it is still there.

This removes the 10 second waiting period and instead waits until the CA container creates the required TLS certificate. It's much shorter than 10 seconds, and should speed up the tutorials and the tests (more and more of which use the CA's). If you have a better idea, feel free to let me know.

Signed-off-by: NIKHIL E GUPTA <negupta@us.ibm.com>