### PR TITLE
Fix help messages

### DIFF
--- a/test-network/network.sh
+++ b/test-network/network.sh
@@ -23,15 +23,15 @@ function printHelp() {
   println "Usage: "
   println "  network.sh <Mode> [Flags]"
   println "    Modes:"
-  println "      "$'\e[0;32m'up$'\e[0m' - bring up fabric orderer and peer nodes. No channel is created
-  println "      "$'\e[0;32m'up createChannel$'\e[0m' - bring up fabric network with one channel
-  println "      "$'\e[0;32m'createChannel$'\e[0m' - create and join a channel after the network is created
-  println "      "$'\e[0;32m'deployCC$'\e[0m' - deploy the asset transfer basic chaincode on the channel or specify
-  println "      "$'\e[0;32m'down$'\e[0m' - clear the network with docker-compose down
-  println "      "$'\e[0;32m'restart$'\e[0m' - restart the network
+  println "      \e[0;32mup\e[0m - bring up fabric orderer and peer nodes. No channel is created"
+  println "      \e[0;32mup createChannel\e[0m - bring up fabric network with one channel"
+  println "      \e[0;32mcreateChannel\e[0m - create and join a channel after the network is created"
+  println "      \e[0;32mdeployCC\e[0m - deploy the asset transfer basic chaincode on the channel or specify"
+  println "      \e[0;32mdown\e[0m - clear the network with docker-compose down"
+  println "      \e[0;32mrestart\e[0m - restart the network"
   println
   println "    Flags:"
-  println "    Used with "$'\e[0;32m'network.sh up$'\e[0m', $'\e[0;32m'network.sh createChannel$'\e[0m':
+  println "    Used with \e[0;32mnetwork.sh up\e[0m, \e[0;32mnetwork.sh createChannel\e[0m:"
   println "    -ca <use CAs> -  create Certificate Authorities to generate the crypto material"
   println "    -c <channel name> - channel name to use (defaults to \"mychannel\")"
   println "    -s <dbtype> - the database backend to use: goleveldb (default) or couchdb"
@@ -40,7 +40,7 @@ function printHelp() {
   println "    -i <imagetag> - the tag to be used to launch the network (defaults to \"latest\")"
   println "    -cai <ca_imagetag> - the image tag to be used for CA (defaults to \"${CA_IMAGETAG}\")"
   println "    -verbose - verbose mode"
-  println "    Used with "$'\e[0;32m'network.sh deployCC$'\e[0m'
+  println "    Used with \e[0;32mnetwork.sh deployCC\e[0m"
   println "    -c <channel name> - deploy chaincode to channel"
   println "    -ccn <name> - the short name of the chaincode to deploy: basic (default),ledger, private, sbe, secured"
   println "    -ccl <language> - the programming language of the chaincode to deploy: go (default), java, javascript, typescript"
@@ -54,10 +54,10 @@ function printHelp() {
   println "    -h - print this message"
   println
   println " Possible Mode and flag combinations"
-  println "   "$'\e[0;32m'up$'\e[0m' -ca -c -r -d -s -i -verbose
-  println "   "$'\e[0;32m'up createChannel$'\e[0m' -ca -c -r -d -s -i -verbose
-  println "   "$'\e[0;32m'createChannel$'\e[0m' -c -r -d -verbose
-  println "   "$'\e[0;32m'deployCC$'\e[0m' -ccn -ccl -ccv -ccs -ccp -cci -r -d -verbose
+  println "   \e[0;32mup\e[0m -ca -c -r -d -s -i -verbose"
+  println "   \e[0;32mup createChannel\e[0m -ca -c -r -d -s -i -verbose"
+  println "   \e[0;32mcreateChannel\e[0m -c -r -d -verbose"
+  println "   \e[0;32mdeployCC\e[0m -ccn -ccl -ccv -ccs -ccp -cci -r -d -verbose"
   println
   println " Taking all defaults:"
   println "   network.sh up"


### PR DESCRIPTION
In the past, there have been committed to change the output method of help messages from "echo" to "println”.
Dou to that change, network.sh not shown help messages correctly.
When changing the method of output help message "echo" to "println", the message format should be fixed.

Signed-off-by: ikegawa-koshi <koshi.ikegawa.mf@hitachi.com>