### PR TITLE
Add mode specific help text

### DIFF
--- a/test-network/network.sh
+++ b/test-network/network.sh
@@ -18,57 +18,6 @@ export VERBOSE=false
 
 source scriptUtils.sh
 
-# Print the usage message
-function printHelp() {
-  println "Usage: "
-  println "  network.sh <Mode> [Flags]"
-  println "    Modes:"
-  println "      \033[0;32mup\033[0m - bring up fabric orderer and peer nodes. No channel is created"
-  println "      \033[0;32mup createChannel\033[0m - bring up fabric network with one channel"
-  println "      \033[0;32mcreateChannel\033[0m - create and join a channel after the network is created"
-  println "      \033[0;32mdeployCC\033[0m - deploy the asset transfer basic chaincode on the channel or specify"
-  println "      \033[0;32mdown\033[0m - clear the network with docker-compose down"
-  println "      \033[0;32mrestart\033[0m - restart the network"
-  println
-  println "    Flags:"
-  println "    Used with \033[0;32mnetwork.sh up\033[0m, \033[0;32mnetwork.sh createChannel\033[0m:"
-  println "    -ca <use CAs> -  create Certificate Authorities to generate the crypto material"
-  println "    -c <channel name> - channel name to use (defaults to \"mychannel\")"
-  println "    -s <dbtype> - the database backend to use: goleveldb (default) or couchdb"
-  println "    -r <max retry> - CLI times out after certain number of attempts (defaults to 5)"
-  println "    -d <delay> - delay duration in seconds (defaults to 3)"
-  println "    -i <imagetag> - the tag to be used to launch the network (defaults to \"latest\")"
-  println "    -cai <ca_imagetag> - the image tag to be used for CA (defaults to \"${CA_IMAGETAG}\")"
-  println "    -verbose - verbose mode"
-  println "    Used with \033[0;32mnetwork.sh deployCC\033[0m"
-  println "    -c <channel name> - deploy chaincode to channel"
-  println "    -ccn <name> - the short name of the chaincode to deploy: basic (default),ledger, private, sbe, secured"
-  println "    -ccl <language> - the programming language of the chaincode to deploy: go (default), java, javascript, typescript"
-  println "    -ccv <version>  - chaincode version. 1.0 (default)"
-  println "    -ccs <sequence>  - chaincode definition sequence. Must be an integer, 1 (default), 2, 3, etc"
-  println "    -ccp <path>  - Optional, path to the chaincode. When provided the -ccn will be used as the deployed name and not the short name of the known chaincodes."
-  println "    -ccep <policy>  - Optional, chaincode endorsement policy, using signature policy syntax. The default policy requires an endorsement from Org1 and Org2"
-  println "    -cccg <collection-config>  - Optional, path to a private data collections configuration file"
-  println "    -cci <fcn name>  - Optional, chaincode init required function to invoke. When provided this function will be invoked after deployment of the chaincode and will define the chaincode as initialization required."
-  println
-  println "    -h - print this message"
-  println
-  println " Possible Mode and flag combinations"
-  println "   \033[0;32mup\033[0m -ca -c -r -d -s -i -verbose"
-  println "   \033[0;32mup createChannel\033[0m -ca -c -r -d -s -i -verbose"
-  println "   \033[0;32mcreateChannel\033[0m -c -r -d -verbose"
-  println "   \033[0;32mdeployCC\033[0m -ccn -ccl -ccv -ccs -ccp -cci -r -d -verbose"
-  println
-  println " Taking all defaults:"
-  println "   network.sh up"
-  println
-  println " Examples:"
-  println "   network.sh up createChannel -ca -c mychannel -s couchdb -i 2.0.0"
-  println "   network.sh createChannel -c channelName"
-  println "   network.sh deployCC -ccn basic -ccl javascript"
-  println "   network.sh deployCC -ccn mychaincode -ccp ./user/mychaincode -ccv 1 -ccl javascript"
-}
-
 # Obtain CONTAINER_IDS and remove them
 # TODO Might want to make this optional - could clear other containers
 # This function is called when you bring a network down
@@ -472,7 +421,7 @@ while [[ $# -ge 1 ]] ; do
   key="$1"
   case $key in
   -h )
-    printHelp
+    printHelp $MODE
     exit 0
     ;;
   -c )
@@ -579,9 +528,6 @@ elif [ "${MODE}" == "deployCC" ]; then
   deployCC
 elif [ "${MODE}" == "down" ]; then
   networkDown
-elif [ "${MODE}" == "restart" ]; then
-  networkDown
-  networkUp
 else
   printHelp
   exit 1

--- a/test-network/scriptUtils.sh
+++ b/test-network/scriptUtils.sh
@@ -6,6 +6,119 @@ C_GREEN='\033[0;32m'
 C_BLUE='\033[0;34m'
 C_YELLOW='\033[1;33m'
 
+# Print the usage message
+function printHelp() {
+  USAGE="$1"
+  if [ "$USAGE" == "up" ]; then
+    println "Usage: "
+    println "  network.sh \033[0;32mup\033[0m [Flags]"
+    println
+    println "    Flags:"
+    println "    -ca <use CAs> -  Use Certificate Authorities to generate network crypto material"
+    println "    -c <channel name> - Name of channel to create (defaults to \"mychannel\")"
+    println "    -s <dbtype> - Peer state database to deploy: goleveldb (default) or couchdb"
+    println "    -r <max retry> - CLI times out after certain number of attempts (defaults to 5)"
+    println "    -d <delay> - CLI delays for a certain number of seconds (defaults to 3)"
+    println "    -i <imagetag> - Docker image tag of Fabric to deploy (defaults to \"latest\")"
+    println "    -cai <ca_imagetag> - Docker image tag of Fabric CA to deploy (defaults to \"${CA_IMAGETAG}\")"
+    println "    -verbose - Verbose mode"
+    println
+    println "    -h - Print this message"
+    println
+    println " Possible Mode and flag combinations"
+    println "   \033[0;32mup\033[0m -ca -r -d -s -i -cai -verbose"
+    println "   \033[0;32mup createChannel\033[0m -ca -c -r -d -s -i -cai -verbose"
+    println
+    println " Examples:"
+    println "   network.sh up createChannel -ca -c mychannel -s couchdb -i 2.0.0"
+  elif [ "$USAGE" == "createChannel" ]; then
+    println "Usage: "
+    println "  network.sh \033[0;32mcreateChannel\033[0m [Flags]"
+    println
+    println "    Flags:"
+    println "    -c <channel name> - Name of channel to create (defaults to \"mychannel\")"
+    println "    -r <max retry> - CLI times out after certain number of attempts (defaults to 5)"
+    println "    -d <delay> - CLI delays for a certain number of seconds (defaults to 3)"
+    println "    -verbose - Verbose mode"
+    println
+    println "    -h - Print this message"
+    println
+    println " Possible Mode and flag combinations"
+    println "   \033[0;32mcreateChannel\033[0m -c -r -d -verbose"
+    println
+    println " Examples:"
+    println "   network.sh createChannel -c channelName"
+  elif [ "$USAGE" == "deployCC" ]; then
+    println "Usage: "
+    println "  network.sh \033[0;32mdeployCC\033[0m [Flags]"
+    println
+    println "    Flags:"
+    println "    -c <channel name> - Name of channel to deploy chaincode to"
+    println "    -ccn <name> - Chaincode name. This flag can be used to deploy one of the asset transfer samples to a channel. Sample options: basic (default),ledger, private, sbe, secured"
+    println "    -ccl <language> - Programming language of chaincode to deploy: go (default), java, javascript, typescript"
+    println "    -ccv <version>  - Chaincode version. 1.0 (default), v2, version3.x, etc"
+    println "    -ccs <sequence>  - Chaincode definition sequence. Must be an integer, 1 (default), 2, 3, etc"
+    println "    -ccp <path>  - (Optional) File path to the chaincode. When provided, the -ccn flag will be used only for the chaincode name."
+    println "    -ccep <policy>  - (Optional) Chaincode endorsement policy using signature policy syntax. The default policy requires an endorsement from Org1 and Org2"
+    println "    -cccg <collection-config>  - (Optional) File path to private data collections configuration file"
+    println "    -cci <fcn name>  - (Optional) Name of chaincode initialization function. When a function is provided, the execution of init will be requested and the function will be invoked."
+    println
+    println "    -h - Print this message"
+    println
+    println " Possible Mode and flag combinations"
+    println "   \033[0;32mdeployCC\033[0m -ccn -ccl -ccv -ccs -ccp -cci -r -d -verbose"
+    println
+    println " Examples:"
+    println "   network.sh deployCC -ccn basic -ccl javascript"
+    println "   network.sh deployCC -ccn mychaincode -ccp ./user/mychaincode -ccv 1 -ccl javascript"
+  else
+    println "Usage: "
+    println "  network.sh <Mode> [Flags]"
+    println "    Modes:"
+    println "      \033[0;32mup\033[0m - Bring up Fabric orderer and peer nodes. No channel is created"
+    println "      \033[0;32mup createChannel\033[0m - Bring up fabric network with one channel"
+    println "      \033[0;32mcreateChannel\033[0m - Create and join a channel after the network is created"
+    println "      \033[0;32mdeployCC\033[0m - Deploy a chaincode to a channel (defaults to asset-transfer-basic)"
+    println "      \033[0;32mdown\033[0m - Bring down the network"
+    println
+    println "    Flags:"
+    println "    Used with \033[0;32mnetwork.sh up\033[0m, \033[0;32mnetwork.sh createChannel\033[0m:"
+    println "    -ca <use CAs> -  Use Certificate Authorities to generate network crypto material"
+    println "    -c <channel name> - Name of channel to create (defaults to \"mychannel\")"
+    println "    -s <dbtype> - Peer state database to deploy: goleveldb (default) or couchdb"
+    println "    -r <max retry> - CLI times out after certain number of attempts (defaults to 5)"
+    println "    -d <delay> - CLI delays for a certain number of seconds (defaults to 3)"
+    println "    -i <imagetag> - Docker image tag of Fabric to deploy (defaults to \"latest\")"
+    println "    -cai <ca_imagetag> - Docker image tag of Fabric CA to deploy (defaults to \"${CA_IMAGETAG}\")"
+    println "    -verbose - Verbose mode"
+    println
+    println "    Used with \033[0;32mnetwork.sh deployCC\033[0m"
+    println "    -c <channel name> - Name of channel to deploy chaincode to"
+    println "    -ccn <name> - Chaincode name. This flag can be used to deploy one of the asset transfer samples to a channel. Sample options: basic (default),ledger, private, sbe, secured"
+    println "    -ccl <language> - Programming language of the chaincode to deploy: go (default), java, javascript, typescript"
+    println "    -ccv <version>  - Chaincode version. 1.0 (default), v2, version3.x, etc"
+    println "    -ccs <sequence>  - Chaincode definition sequence. Must be an integer, 1 (default), 2, 3, etc"
+    println "    -ccp <path>  - (Optional) File path to the chaincode. When provided, the -ccn flag will be used only for the chaincode name."
+    println "    -ccep <policy>  - (Optional) Chaincode endorsement policy using signature policy syntax. The default policy requires an endorsement from Org1 and Org2"
+    println "    -cccg <collection-config>  - (Optional) File path to private data collections configuration file"
+    println "    -cci <fcn name>  - (Optional) Name of chaincode initialization function. When a function is provided, the execution of init will be requested and the function will be invoked."
+    println
+    println "    -h - Print this message"
+    println
+    println " Possible Mode and flag combinations"
+    println "   \033[0;32mup\033[0m -ca -r -d -s -i -cai -verbose"
+    println "   \033[0;32mup createChannel\033[0m -ca -c -r -d -s -i -cai -verbose"
+    println "   \033[0;32mcreateChannel\033[0m -c -r -d -verbose"
+    println "   \033[0;32mdeployCC\033[0m -ccn -ccl -ccv -ccs -ccp -cci -r -d -verbose"
+    println
+    println " Examples:"
+    println "   network.sh up createChannel -ca -c mychannel -s couchdb -i 2.0.0"
+    println "   network.sh createChannel -c channelName"
+    println "   network.sh deployCC -ccn basic -ccl javascript"
+    println "   network.sh deployCC -ccn mychaincode -ccp ./user/mychaincode -ccv 1 -ccl javascript"
+  fi
+}
+
 # println echos string
 function println() {
   echo -e "$1"

--- a/test-network/scripts/deployCC.sh
+++ b/test-network/scripts/deployCC.sh
@@ -134,10 +134,6 @@ else
   CC_COLL_CONFIG="--collections-config $CC_COLL_CONFIG"
 fi
 
-#if [ "$CC_INIT_FCN" = "NA" ]; then
-#	INIT_REQUIRED=""
-#fi
-
 # import utils
 . scripts/envVar.sh
 


### PR DESCRIPTION
Moves the help text to the scriptUtils, and create mode specific help text.

For example:
```
Usage: 
  network.sh deployCC [Flags]

    Flags:
    -c <channel name> - Name of channel to deploy chaincode to
    -ccn <name> - Chaincode name. This flag can be used to deploy one of the asset transfer samples to a channel. Sample options: basic (default),ledger, private, sbe, secured
    -ccl <language> - Programming language of chaincode to deploy: go (default), java, javascript, typescript
    -ccv <version>  - Chaincode version. 1.0 (default), v2, version3.x, etc
    -ccs <sequence>  - Chaincode definition sequence. Must be an integer, 1 (default), 2, 3, etc
    -ccp <path>  - (Optional) File path to the chaincode. When provided, the -ccn flag will be used only for the chaincode name.
    -ccep <policy>  - (Optional) Chaincode endorsement policy using signature policy syntax. The default policy requires an endorsement from Org1 and Org2
    -cccg <collection-config>  - (Optional) File path to private data collections configuration file
    -cci <fcn name>  - (Optional) Name of chaincode initialization function. When a function is provided, the execution of init will be requested and the function will be invoked.

    -h - Print this message

 Possible Mode and flag combinations
   deployCC -ccn -ccl -ccv -ccs -ccp -cci -r -d -verbose

 Examples:
   network.sh deployCC -ccn basic -ccl javascript
   network.sh deployCC -ccn mychaincode -ccp ./user/mychaincode -ccv 1 -ccl javascript
```

Let me know what you think.

Signed-off-by: NIKHIL E GUPTA <ngupta@symbridge.com>