### PR TITLE
Fix commercial paper org scripts

### DIFF
--- a/commercial-paper/organization/digibank/digibank.sh
+++ b/commercial-paper/organization/digibank/digibank.sh
@@ -15,7 +15,7 @@ function _exit(){
 : ${VERBOSE:="false"}
 
 # Where am I?
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+DIR=${PWD}
 
 # Locate the test network
 cd "${DIR}/../../../test-network"

--- a/commercial-paper/organization/magnetocorp/magnetocorp.sh
+++ b/commercial-paper/organization/magnetocorp/magnetocorp.sh
@@ -15,7 +15,7 @@ function _exit(){
 : ${VERBOSE:="false"}
 
 # Where am I?
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+DIR=${PWD}
 
 # Locate the test-network 
 cd "${DIR}/../../../test-network"


### PR DESCRIPTION
The current scripts given to setup the user environment do not work
on Mac:

$ . ./magnetocorp.sh
-bash: cd: /Users/lehors/Projects/Go/src/github.com/hyperledger/fabric-samples/commercial-paper/organization/magnetocorp
Saving session...
...copying shared history...
...saving history...truncating history files...
...completed./../../../test-network: No such file or directory
-bash: ./scripts/envVar.sh: No such file or directory
[...truncated...]
export FABRIC_CFG_PATH="/Users/lehors/Projects/Go/src/github.com/hyperledger/fabric-samples/commercial-paper/organization/magnetocorp"
export PATH="/Users/lehors/Projects/Go/src/github.com/hyperledger/fabric-samples/commercial-paper/organization/magnetocorp"
export PEER_PARMS=""
Saving session...
Saving session...

The session history related output is actually captured when setting the environment variables:

$ echo $FABRIC_CFG_PATH
/Users/lehors/Projects/Go/src/github.com/hyperledger/fabric-samples/commercial-paper/organization/magnetocorp
Saving session...
...copying shared history...
...saving history...truncating history files...
...completed./../../../config

With this simple change the scripts work:

$ echo $FABRIC_CFG_PATH
/Users/lehors/Projects/Go/src/github.com/hyperledger/fabric-samples/commercial-paper/organization/magnetocorp/../../../config

Signed-off-by: Arnaud J Le Hors <lehors@us.ibm.com>