### PR TITLE
Avoid double spent in token-utxo chaincode

### DIFF
--- a/token-utxo/chaincode-go/chaincode/token_contract.go
+++ b/token-utxo/chaincode-go/chaincode/token_contract.go
@@ -70,9 +70,13 @@ func (s *SmartContract) Transfer(ctx contractapi.TransactionContextInterface, ut
 	}
 
 	// Validate and summarize utxo inputs
-	var utxoInputs []*UTXO
+	utxoInputs := make(map[string]*UTXO)
 	var totalInputAmount int
 	for _, utxoInputKey := range utxoInputKeys {
+		if utxoInputs[utxoInputKey] != nil {
+			return nil, fmt.Errorf("the same utxo input can not be spend twice")
+		}
+
 		utxoInputCompositeKey, err := ctx.GetStub().CreateCompositeKey("utxo", []string{clientID, utxoInputKey})
 		if err != nil {
 			return nil, fmt.Errorf("failed to create composite key: %v", err)
@@ -97,7 +101,7 @@ func (s *SmartContract) Transfer(ctx contractapi.TransactionContextInterface, ut
 		}
 
 		totalInputAmount += amount
-		utxoInputs = append(utxoInputs, utxoInput)
+		utxoInputs[utxoInputKey] = utxoInput
 	}
 
 	// Validate and summarize utxo outputs


### PR DESCRIPTION
Added check to avoid double spent in token-utxo chaincode

In the transfer function it was possible to pass the same utxo more than once in the array of input utxos without any error. Making it possible to spend the same utxo more than once in the same transaction and like this create more tokens than minted. To fix this I changed the array that was used to store the input utxo states to a map and so utxos were stored in the map by there key, which made it possible to know if a key and so a utxo had already been used.
I tested this by setting up the test-network, deploying the token-utxo chaincode with my fix, minting a utxo and trying to spent this utxo more than once in the same transaction, which was not possible anymore. It can only be spent one time anymore with this fix.