### PR TITLE
Enable test-network/network.sh to easily run docker-compose commands

### DIFF
--- a/test-network/network.sh
+++ b/test-network/network.sh
@@ -289,6 +289,16 @@ function networkUp() {
   fi
 }
 
+function dockerComposeCommand() {
+
+  if [ "$CRYPTO" == "Certificate Authorities" ]; then
+      IMAGE_TAG=${CA_IMAGETAG} docker-compose -f $COMPOSE_FILE_CA -f $COMPOSE_FILE_CA_ORG3 "${ARGS[@]}"
+  else
+      IMAGE_TAG=${IMAGETAG}    docker-compose -f ${COMPOSE_FILE_BASE} -f ${COMPOSE_FILE_COUCH} -f $COMPOSE_FILE_COUCH_ORG3 -f $COMPOSE_FILE_ORG3 "${ARGS[@]}"
+  fi
+}
+
+
 ## call the script to join create the channel and join the peers of org1 and org2
 function createChannel() {
 
@@ -381,6 +391,8 @@ COMPOSE_FILE_CA=docker/docker-compose-ca.yaml
 COMPOSE_FILE_COUCH_ORG3=addOrg3/docker/docker-compose-couch-org3.yaml
 # use this as the default docker-compose yaml definition for org3
 COMPOSE_FILE_ORG3=addOrg3/docker/docker-compose-org3.yaml
+# use this as the certificate authorities docker-compose yaml definition for org3
+COMPOSE_FILE_CA_ORG3=addOrg3/docker/docker-compose-ca-org3.yaml
 #
 # use go as the default language for chaincode
 CC_SRC_LANGUAGE="go"
@@ -487,6 +499,11 @@ while [[ $# -ge 1 ]] ; do
     VERBOSE=true
     shift
     ;;
+  -- )
+    shift
+    ARGS=( "$@" )
+    break 2
+    ;;
   * )
     errorln "Unknown flag: $key"
     printHelp
@@ -509,6 +526,8 @@ if [ "$MODE" == "up" ]; then
 elif [ "$MODE" == "createChannel" ]; then
   infoln "Creating channel '${CHANNEL_NAME}'."
   infoln "If network is not up, starting nodes with CLI timeout of '${MAX_RETRY}' tries and CLI delay of '${CLI_DELAY}' seconds and using database '${DATABASE} ${CRYPTO_MODE}"
+elif [ "$MODE" == "dc-command" ]; then
+  infoln "docker-compose command execution"
 elif [ "$MODE" == "down" ]; then
   infoln "Stopping network"
 elif [ "$MODE" == "restart" ]; then
@@ -526,6 +545,8 @@ elif [ "${MODE}" == "createChannel" ]; then
   createChannel
 elif [ "${MODE}" == "deployCC" ]; then
   deployCC
+elif [ "${MODE}" == "dc-command" ]; then
+  dockerComposeCommand
 elif [ "${MODE}" == "down" ]; then
   networkDown
 else

--- a/test-network/scriptUtils.sh
+++ b/test-network/scriptUtils.sh
@@ -71,6 +71,17 @@ function printHelp() {
     println " Examples:"
     println "   network.sh deployCC -ccn basic -ccl javascript"
     println "   network.sh deployCC -ccn mychaincode -ccp ./user/mychaincode -ccv 1 -ccl javascript"
+  elif [ "$USAGE" == "dc-command" ]; then
+    println "Usage: "
+    println "  network.sh \033[0;32mdc-command\033[0m [Flags]"
+    println "    -- <args> - pass following arguments to docker-compose"
+    println "    -ca - run command for CA docker-compose network (instead of network for orderer and peers)"
+    println
+    println "    -h - Print this message"
+    println
+    println " Examples:"
+    println "   network.sh dc-command -- logs -f orderer.example.com"
+    println "   network.sh dc-command -ca -- ps"
   else
     println "Usage: "
     println "  network.sh <Mode> [Flags]"
@@ -80,6 +91,7 @@ function printHelp() {
     println "      \033[0;32mcreateChannel\033[0m - Create and join a channel after the network is created"
     println "      \033[0;32mdeployCC\033[0m - Deploy a chaincode to a channel (defaults to asset-transfer-basic)"
     println "      \033[0;32mdown\033[0m - Bring down the network"
+    println "      \033[0;32mdc-command\033[0m - Run docker-compose commands, e.g., for logging"
     println
     println "    Flags:"
     println "    Used with \033[0;32mnetwork.sh up\033[0m, \033[0;32mnetwork.sh createChannel\033[0m:"
@@ -102,6 +114,10 @@ function printHelp() {
     println "    -ccep <policy>  - (Optional) Chaincode endorsement policy using signature policy syntax. The default policy requires an endorsement from Org1 and Org2"
     println "    -cccg <collection-config>  - (Optional) File path to private data collections configuration file"
     println "    -cci <fcn name>  - (Optional) Name of chaincode initialization function. When a function is provided, the execution of init will be requested and the function will be invoked."
+    println
+    println "    Used with \033[0;32mnetwork.sh dc-command\033[0m"
+    println "    -- <args> - pass following arguments to docker-compose"
+    println "    -ca - run command for CA docker-compose network (instead of network for orderer and peers)"
     println
     println "    -h - Print this message"
     println


### PR DESCRIPTION
Small patch which makes it much easier to trouble-shoot issues in the containers by easily be able to run docker(-compose) commands, e.g., `ps` or `logs` on the started containers or even logging into them. 