### PR TITLE
Add go smart contract language to deploy commands

### DIFF
--- a/auction/README.md
+++ b/auction/README.md
@@ -29,7 +29,7 @@ Note that we use the `-ca` flag to deploy the network using certificate authorit
 
 Run the following command to deploy the auction smart contract. We will override the default endorsement policy to allow any channel member to create an auction without requiring an endorsement from another organization.
 ```
-./network.sh deployCC -ccn auction -ccp ../auction/chaincode-go/ -ccep "OR('Org1MSP.peer','Org2MSP.peer')"
+./network.sh deployCC -ccn auction -ccp ../auction/chaincode-go/ -ccep "OR('Org1MSP.peer','Org2MSP.peer')" -ccl go
 ```
 
 ## Install the application dependencies

--- a/high-throughput/startFabric.sh
+++ b/high-throughput/startFabric.sh
@@ -19,7 +19,7 @@ pushd ../test-network
 
 echo "Bring up test network"
 ./network.sh up createChannel -ca
-./network.sh deployCC -ccn bigdatacc -ccp ../high-throughput/chaincode-go/ -ccep "OR('Org1MSP.peer','Org2MSP.peer')" -cci Init
+./network.sh deployCC -ccn bigdatacc -ccp ../high-throughput/chaincode-go/ -ccep "OR('Org1MSP.peer','Org2MSP.peer')" -ccl go -cci Init
 popd
 cat <<EOF
 

--- a/token-erc-20/README.md
+++ b/token-erc-20/README.md
@@ -33,7 +33,7 @@ You can use the test network script to deploy the ERC-20 token contract to the c
 
 **For a Go Contract:**
 ```
-./network.sh deployCC -ccn token_erc20 -ccp ../token-erc-20/chaincode-go/
+./network.sh deployCC -ccn token_erc20 -ccp ../token-erc-20/chaincode-go/ -ccl go
 ```
 
 **For a JavaScript Contract:**

--- a/token-utxo/README.md
+++ b/token-utxo/README.md
@@ -32,7 +32,7 @@ The -ca flag is used to deploy the network using certificate authorities. This a
 
 You can use the test network script to deploy the UTXO token contract to the channel that was just created. Deploy the smart contract to `mychannel` using the following command:
 ```
-./network.sh deployCC -ccn token_utxo -ccp ../token-utxo/chaincode-go/
+./network.sh deployCC -ccn token_utxo -ccp ../token-utxo/chaincode-go/ -ccl go
 ```
 
 The above command deploys the go chaincode with short name `token_utxo`. The smart contract will utilize the default endorsement policy of majority of channel members.


### PR DESCRIPTION
With https://github.com/hyperledger/fabric-samples/pull/390 requiring the -ccl path, we need to add it to some samples that used the go default

Signed-off-by: Nikhil Gupta <nikhilgupta@macbook-air.lan>