### PR TITLE
Explicitly Mount the Docker Unix Socket

### DIFF
--- a/commercial-paper/organization/digibank/configuration/cli/docker-compose.yml
+++ b/commercial-paper/organization/digibank/configuration/cli/docker-compose.yml
@@ -30,7 +30,7 @@ services:
     working_dir: /opt/gopath/src/github.com/hyperledger/fabric/peer
     command: /bin/bash
     volumes:
-        - /var/run/:/host/var/run/
+        - /var/run/docker.sock:/host/var/run/docker.sock
         - ./../../../../organization/digibank:/opt/gopath/src/github.com/
         - ./../../../../../test-network/organizations:/opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/
     networks:

--- a/commercial-paper/organization/magnetocorp/configuration/cli/docker-compose.yml
+++ b/commercial-paper/organization/magnetocorp/configuration/cli/docker-compose.yml
@@ -30,7 +30,7 @@ services:
     working_dir: /opt/gopath/src/github.com/hyperledger/fabric/peer
     command: /bin/bash
     volumes:
-        - /var/run/:/host/var/run/
+        - /var/run/docker.sock:/host/var/run/docker.sock
         - ./../../../../organization/magnetocorp:/opt/gopath/src/github.com/
         - ./../../../../../test-network/organizations:/opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/
     networks:

--- a/interest_rate_swaps/network/docker-compose.yaml
+++ b/interest_rate_swaps/network/docker-compose.yaml
@@ -25,7 +25,7 @@ services:
     working_dir: /opt/gopath/src/github.com/hyperledger/fabric/peer
     command: peer node start
     volumes:
-    - /var/run/:/host/var/run/
+    - /var/run/docker.sock:/host/var/run/docker.sock
 
   orderer:
     container_name: irs-orderer
@@ -147,7 +147,7 @@ services:
     working_dir: /opt/gopath/src/github.com/hyperledger/fabric/peer
     command: /bin/bash
     volumes:
-        - /var/run/:/host/var/run/
+        - /var/run/docker.sock/:/host/var/run/docker.sock
         - ../chaincode/:/opt/gopath/src/irscc
         - ./crypto-config:/opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/
         - ./scripts:/opt/gopath/src/github.com/hyperledger/fabric/peer/scripts/

--- a/test-network/addOrg3/docker/docker-compose-org3.yaml
+++ b/test-network/addOrg3/docker/docker-compose-org3.yaml
@@ -40,7 +40,7 @@ services:
       - CORE_PEER_GOSSIP_EXTERNALENDPOINT=peer0.org3.example.com:11051
       - CORE_PEER_LOCALMSPID=Org3MSP
     volumes:
-        - /var/run/:/host/var/run/
+        - /var/run/docker.sock:/host/var/run/docker.sock
         - ../../organizations/peerOrganizations/org3.example.com/peers/peer0.org3.example.com/msp:/etc/hyperledger/fabric/msp
         - ../../organizations/peerOrganizations/org3.example.com/peers/peer0.org3.example.com/tls:/etc/hyperledger/fabric/tls
         - peer0.org3.example.com:/var/hyperledger/production
@@ -72,7 +72,7 @@ services:
     working_dir: /opt/gopath/src/github.com/hyperledger/fabric/peer
     command: /bin/bash
     volumes:
-        - /var/run/:/host/var/run/
+        - /var/run/docker.sock:/host/var/run/docker.sock
         - ../../../chaincode/:/opt/gopath/src/github.com/chaincode
         - ../../organizations:/opt/gopath/src/github.com/hyperledger/fabric/peer/organizations
         - ../../scripts:/opt/gopath/src/github.com/hyperledger/fabric/peer/scripts/

--- a/test-network/docker/docker-compose-test-net.yaml
+++ b/test-network/docker/docker-compose-test-net.yaml
@@ -75,7 +75,7 @@ services:
       - CORE_PEER_GOSSIP_EXTERNALENDPOINT=peer0.org1.example.com:7051
       - CORE_PEER_LOCALMSPID=Org1MSP
     volumes:
-        - /var/run/:/host/var/run/
+        - /var/run/docker.sock:/host/var/run/docker.sock
         - ../organizations/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/msp:/etc/hyperledger/fabric/msp
         - ../organizations/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls:/etc/hyperledger/fabric/tls
         - peer0.org1.example.com:/var/hyperledger/production
@@ -113,7 +113,7 @@ services:
       - CORE_PEER_GOSSIP_BOOTSTRAP=peer0.org2.example.com:9051
       - CORE_PEER_LOCALMSPID=Org2MSP
     volumes:
-        - /var/run/:/host/var/run/
+        - /var/run/docker.sock:/host/var/run/docker.sock
         - ../organizations/peerOrganizations/org2.example.com/peers/peer0.org2.example.com/msp:/etc/hyperledger/fabric/msp
         - ../organizations/peerOrganizations/org2.example.com/peers/peer0.org2.example.com/tls:/etc/hyperledger/fabric/tls
         - peer0.org2.example.com:/var/hyperledger/production


### PR DESCRIPTION
Instead of mounting the entire `/var/run` directory explicitly mount the unix socket. Mounting the entire directory causes issues with future versions of Docker on some platforms.

Signed-off-by: Brett Logan <brett.t.logan@ibm.com>