### PR TITLE
Cleanup of register/enroll script

### DIFF
--- a/test-network/addOrg3/fabric-ca/registerEnroll.sh
+++ b/test-network/addOrg3/fabric-ca/registerEnroll.sh
@@ -5,15 +5,11 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-. ../../scripts/utils.sh
-
 function createOrg3 {
 	infoln "Enrolling the CA admin"
 	mkdir -p ../organizations/peerOrganizations/org3.example.com/
 
 	export FABRIC_CA_CLIENT_HOME=${PWD}/../organizations/peerOrganizations/org3.example.com/
-#  rm -rf $FABRIC_CA_CLIENT_HOME/fabric-ca-client-config.yaml
-#  rm -rf $FABRIC_CA_CLIENT_HOME/msp
 
   set -x
   fabric-ca-client enroll -u https://admin:adminpw@localhost:11054 --caname ca-org3 --tls.certfiles ${PWD}/fabric-ca/org3/tls-cert.pem
@@ -49,9 +45,6 @@ function createOrg3 {
   fabric-ca-client register --caname ca-org3 --id.name org3admin --id.secret org3adminpw --id.type admin --tls.certfiles ${PWD}/fabric-ca/org3/tls-cert.pem
   { set +x; } 2>/dev/null
 
-	mkdir -p ../organizations/peerOrganizations/org3.example.com/peers
-  mkdir -p ../organizations/peerOrganizations/org3.example.com/peers/peer0.org3.example.com
-
   infoln "Generating the peer0 msp"
   set -x
 	fabric-ca-client enroll -u https://peer0:peer0pw@localhost:11054 --caname ca-org3 -M ${PWD}/../organizations/peerOrganizations/org3.example.com/peers/peer0.org3.example.com/msp --csr.hosts peer0.org3.example.com --tls.certfiles ${PWD}/fabric-ca/org3/tls-cert.pem
@@ -78,17 +71,12 @@ function createOrg3 {
   mkdir ${PWD}/../organizations/peerOrganizations/org3.example.com/ca
   cp ${PWD}/../organizations/peerOrganizations/org3.example.com/peers/peer0.org3.example.com/msp/cacerts/* ${PWD}/../organizations/peerOrganizations/org3.example.com/ca/ca.org3.example.com-cert.pem
 
-  mkdir -p ../organizations/peerOrganizations/org3.example.com/users
-  mkdir -p ../organizations/peerOrganizations/org3.example.com/users/User1@org3.example.com
-
   infoln "Generating the user msp"
   set -x
 	fabric-ca-client enroll -u https://user1:user1pw@localhost:11054 --caname ca-org3 -M ${PWD}/../organizations/peerOrganizations/org3.example.com/users/User1@org3.example.com/msp --tls.certfiles ${PWD}/fabric-ca/org3/tls-cert.pem
   { set +x; } 2>/dev/null
 
   cp ${PWD}/../organizations/peerOrganizations/org3.example.com/msp/config.yaml ${PWD}/../organizations/peerOrganizations/org3.example.com/users/User1@org3.example.com/msp/config.yaml
-
-  mkdir -p ../organizations/peerOrganizations/org3.example.com/users/Admin@org3.example.com
 
   infoln "Generating the org admin msp"
   set -x

--- a/test-network/organizations/fabric-ca/registerEnroll.sh
+++ b/test-network/organizations/fabric-ca/registerEnroll.sh
@@ -1,14 +1,10 @@
 #!/bin/bash
 
-source scripts/utils.sh
-
 function createOrg1() {
   infoln "Enrolling the CA admin"
   mkdir -p organizations/peerOrganizations/org1.example.com/
 
   export FABRIC_CA_CLIENT_HOME=${PWD}/organizations/peerOrganizations/org1.example.com/
-  #  rm -rf $FABRIC_CA_CLIENT_HOME/fabric-ca-client-config.yaml
-  #  rm -rf $FABRIC_CA_CLIENT_HOME/msp
 
   set -x
   fabric-ca-client enroll -u https://admin:adminpw@localhost:7054 --caname ca-org1 --tls.certfiles ${PWD}/organizations/fabric-ca/org1/tls-cert.pem
@@ -44,9 +40,6 @@ function createOrg1() {
   fabric-ca-client register --caname ca-org1 --id.name org1admin --id.secret org1adminpw --id.type admin --tls.certfiles ${PWD}/organizations/fabric-ca/org1/tls-cert.pem
   { set +x; } 2>/dev/null
 
-  mkdir -p organizations/peerOrganizations/org1.example.com/peers
-  mkdir -p organizations/peerOrganizations/org1.example.com/peers/peer0.org1.example.com
-
   infoln "Generating the peer0 msp"
   set -x
   fabric-ca-client enroll -u https://peer0:peer0pw@localhost:7054 --caname ca-org1 -M ${PWD}/organizations/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/msp --csr.hosts peer0.org1.example.com --tls.certfiles ${PWD}/organizations/fabric-ca/org1/tls-cert.pem
@@ -72,17 +65,12 @@ function createOrg1() {
   mkdir -p ${PWD}/organizations/peerOrganizations/org1.example.com/ca
   cp ${PWD}/organizations/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/msp/cacerts/* ${PWD}/organizations/peerOrganizations/org1.example.com/ca/ca.org1.example.com-cert.pem
 
-  mkdir -p organizations/peerOrganizations/org1.example.com/users
-  mkdir -p organizations/peerOrganizations/org1.example.com/users/User1@org1.example.com
-
   infoln "Generating the user msp"
   set -x
   fabric-ca-client enroll -u https://user1:user1pw@localhost:7054 --caname ca-org1 -M ${PWD}/organizations/peerOrganizations/org1.example.com/users/User1@org1.example.com/msp --tls.certfiles ${PWD}/organizations/fabric-ca/org1/tls-cert.pem
   { set +x; } 2>/dev/null
 
   cp ${PWD}/organizations/peerOrganizations/org1.example.com/msp/config.yaml ${PWD}/organizations/peerOrganizations/org1.example.com/users/User1@org1.example.com/msp/config.yaml
-
-  mkdir -p organizations/peerOrganizations/org1.example.com/users/Admin@org1.example.com
 
   infoln "Generating the org admin msp"
   set -x
@@ -97,8 +85,6 @@ function createOrg2() {
   mkdir -p organizations/peerOrganizations/org2.example.com/
 
   export FABRIC_CA_CLIENT_HOME=${PWD}/organizations/peerOrganizations/org2.example.com/
-  #  rm -rf $FABRIC_CA_CLIENT_HOME/fabric-ca-client-config.yaml
-  #  rm -rf $FABRIC_CA_CLIENT_HOME/msp
 
   set -x
   fabric-ca-client enroll -u https://admin:adminpw@localhost:8054 --caname ca-org2 --tls.certfiles ${PWD}/organizations/fabric-ca/org2/tls-cert.pem
@@ -134,9 +120,6 @@ function createOrg2() {
   fabric-ca-client register --caname ca-org2 --id.name org2admin --id.secret org2adminpw --id.type admin --tls.certfiles ${PWD}/organizations/fabric-ca/org2/tls-cert.pem
   { set +x; } 2>/dev/null
 
-  mkdir -p organizations/peerOrganizations/org2.example.com/peers
-  mkdir -p organizations/peerOrganizations/org2.example.com/peers/peer0.org2.example.com
-
   infoln "Generating the peer0 msp"
   set -x
   fabric-ca-client enroll -u https://peer0:peer0pw@localhost:8054 --caname ca-org2 -M ${PWD}/organizations/peerOrganizations/org2.example.com/peers/peer0.org2.example.com/msp --csr.hosts peer0.org2.example.com --tls.certfiles ${PWD}/organizations/fabric-ca/org2/tls-cert.pem
@@ -162,17 +145,12 @@ function createOrg2() {
   mkdir -p ${PWD}/organizations/peerOrganizations/org2.example.com/ca
   cp ${PWD}/organizations/peerOrganizations/org2.example.com/peers/peer0.org2.example.com/msp/cacerts/* ${PWD}/organizations/peerOrganizations/org2.example.com/ca/ca.org2.example.com-cert.pem
 
-  mkdir -p organizations/peerOrganizations/org2.example.com/users
-  mkdir -p organizations/peerOrganizations/org2.example.com/users/User1@org2.example.com
-
   infoln "Generating the user msp"
   set -x
   fabric-ca-client enroll -u https://user1:user1pw@localhost:8054 --caname ca-org2 -M ${PWD}/organizations/peerOrganizations/org2.example.com/users/User1@org2.example.com/msp --tls.certfiles ${PWD}/organizations/fabric-ca/org2/tls-cert.pem
   { set +x; } 2>/dev/null
 
   cp ${PWD}/organizations/peerOrganizations/org2.example.com/msp/config.yaml ${PWD}/organizations/peerOrganizations/org2.example.com/users/User1@org2.example.com/msp/config.yaml
-
-  mkdir -p organizations/peerOrganizations/org2.example.com/users/Admin@org2.example.com
 
   infoln "Generating the org admin msp"
   set -x
@@ -187,8 +165,6 @@ function createOrderer() {
   mkdir -p organizations/ordererOrganizations/example.com
 
   export FABRIC_CA_CLIENT_HOME=${PWD}/organizations/ordererOrganizations/example.com
-  #  rm -rf $FABRIC_CA_CLIENT_HOME/fabric-ca-client-config.yaml
-  #  rm -rf $FABRIC_CA_CLIENT_HOME/msp
 
   set -x
   fabric-ca-client enroll -u https://admin:adminpw@localhost:9054 --caname ca-orderer --tls.certfiles ${PWD}/organizations/fabric-ca/ordererOrg/tls-cert.pem
@@ -219,11 +195,6 @@ function createOrderer() {
   fabric-ca-client register --caname ca-orderer --id.name ordererAdmin --id.secret ordererAdminpw --id.type admin --tls.certfiles ${PWD}/organizations/fabric-ca/ordererOrg/tls-cert.pem
   { set +x; } 2>/dev/null
 
-  mkdir -p organizations/ordererOrganizations/example.com/orderers
-  mkdir -p organizations/ordererOrganizations/example.com/orderers/example.com
-
-  mkdir -p organizations/ordererOrganizations/example.com/orderers/orderer.example.com
-
   infoln "Generating the orderer msp"
   set -x
   fabric-ca-client enroll -u https://orderer:ordererpw@localhost:9054 --caname ca-orderer -M ${PWD}/organizations/ordererOrganizations/example.com/orderers/orderer.example.com/msp --csr.hosts orderer.example.com --csr.hosts localhost --tls.certfiles ${PWD}/organizations/fabric-ca/ordererOrg/tls-cert.pem
@@ -245,9 +216,6 @@ function createOrderer() {
 
   mkdir -p ${PWD}/organizations/ordererOrganizations/example.com/msp/tlscacerts
   cp ${PWD}/organizations/ordererOrganizations/example.com/orderers/orderer.example.com/tls/tlscacerts/* ${PWD}/organizations/ordererOrganizations/example.com/msp/tlscacerts/tlsca.example.com-cert.pem
-
-  mkdir -p organizations/ordererOrganizations/example.com/users
-  mkdir -p organizations/ordererOrganizations/example.com/users/Admin@example.com
 
   infoln "Generating the admin msp"
   set -x


### PR DESCRIPTION
There has been a lot of cosmetic updates of the test network script. As part of that, I thought it was time to do some cleanup of the register enroll scripts. This PR

- removes commented out lines.
- removes the unnecessary import of the script utils, which are imported by the main scripts.
- removing unnecessary mkdir commands. The enroll commands generate most of the directories that are required.

Signed-off-by: Nikhil Gupta <ngupta@symbridge.com>