### PR TITLE
Fix repolinter failures

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,5 +8,5 @@ There are two ways to report a security bug. The easiest is to email a descripti
 
 The other way is to file a confidential security bug in our [JIRA bug tracking system](https://jira.hyperledger.org). Be sure to set the “Security Level” to “Security issue”.
 
-The process by which the Hyperledger Security Team handles security bugs is documented further in our [Defect Response page](https://wiki.hyperledger.org/display/HYP/Defect+Response) on our [wiki](https://wiki.hyperledger.org).
+The process by which the Hyperledger Security Team handles security bugs is documented further in our [Defect Response page](https://wiki.hyperledger.org/display/SEC/Defect+Response) on our [wiki](https://wiki.hyperledger.org).
 

--- a/asset-transfer-basic/chaincode-javascript/test/assetTransfer.test.js
+++ b/asset-transfer-basic/chaincode-javascript/test/assetTransfer.test.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright IBM Corp. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+*/
+
 'use strict';
 const sinon = require('sinon');
 const chai = require('chai');

--- a/asset-transfer-events/chaincode-javascript/test/assetTransferEvents.test.js
+++ b/asset-transfer-events/chaincode-javascript/test/assetTransferEvents.test.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright IBM Corp. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+*/
+
 'use strict';
 const sinon = require('sinon');
 const chai = require('chai');

--- a/asset-transfer-ledger-queries/chaincode-javascript/lib/asset_transfer_ledger_chaincode.js
+++ b/asset-transfer-ledger-queries/chaincode-javascript/lib/asset_transfer_ledger_chaincode.js
@@ -1,5 +1,7 @@
 /*
- SPDX-License-Identifier: Apache-2.0
+ * Copyright IBM Corp. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
 */
 
 // ====CHAINCODE EXECUTION SAMPLES (CLI) ==================

--- a/commercial-paper/organization/digibank/contract/lib/queries.js
+++ b/commercial-paper/organization/digibank/contract/lib/queries.js
@@ -1,7 +1,9 @@
-
 /*
-SPDX-License-Identifier: Apache-2.0
+ * Copyright IBM Corp. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
 */
+
 'use strict';
 
 const State = require('../ledger-api/state.js');

--- a/commercial-paper/organization/magnetocorp/application/cpListener.js
+++ b/commercial-paper/organization/magnetocorp/application/cpListener.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright IBM Corp. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+*/
+
 "use strict";
 
 const yaml = require('js-yaml');

--- a/commercial-paper/organization/magnetocorp/contract/lib/queries.js
+++ b/commercial-paper/organization/magnetocorp/contract/lib/queries.js
@@ -1,6 +1,7 @@
-
 /*
-SPDX-License-Identifier: Apache-2.0
+ * Copyright IBM Corp. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
 */
 'use strict';
 

--- a/token-erc-20/chaincode-javascript/index.js
+++ b/token-erc-20/chaincode-javascript/index.js
@@ -1,5 +1,7 @@
 /*
-SPDX-License-Identifier: Apache-2.0
+ * Copyright IBM Corp. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
 */
 
 'use strict';

--- a/token-erc-20/chaincode-javascript/lib/tokenERC20.js
+++ b/token-erc-20/chaincode-javascript/lib/tokenERC20.js
@@ -1,5 +1,7 @@
 /*
-SPDX-License-Identifier: Apache-2.0
+ * Copyright IBM Corp. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
 */
 
 'use strict';

--- a/token-erc-20/chaincode-javascript/test/tokenERC20.test.js
+++ b/token-erc-20/chaincode-javascript/test/tokenERC20.test.js
@@ -1,5 +1,7 @@
 /*
-SPDX-License-Identifier: Apache-2.0
+ * Copyright IBM Corp. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
 */
 
 'use strict';


### PR DESCRIPTION
Fix link in SECURITY file, and add missing copyright and license notices.

To check, run: repolinter --rulesetUrl https://github.com/hyperledger-labs/hyperledger-community-management-tools/raw/main/repo_structure/repolint.json

Signed-off-by: Arnaud J Le Hors <lehors@us.ibm.com>