### PR TITLE
Fix unread .env file

### DIFF
--- a/test-network/network.sh
+++ b/test-network/network.sh
@@ -179,7 +179,7 @@ function createOrgs() {
   if [ "$CRYPTO" == "Certificate Authorities" ]; then
     infoln "Generating certificates using Fabric CA"
 
-    IMAGE_TAG=${CA_IMAGETAG} docker-compose -f $COMPOSE_FILE_CA up -d 2>&1
+    IMAGE_TAG=${CA_IMAGETAG} docker-compose --env-file ${COMPOSE_FILE_ENV} -f $COMPOSE_FILE_CA up -d 2>&1
 
     . organizations/fabric-ca/registerEnroll.sh
 
@@ -250,7 +250,7 @@ function networkUp() {
     COMPOSE_FILES="${COMPOSE_FILES} -f ${COMPOSE_FILE_COUCH}"
   fi
 
-  IMAGE_TAG=$IMAGETAG docker-compose ${COMPOSE_FILES} up -d 2>&1
+  IMAGE_TAG=$IMAGETAG docker-compose --env-file ${COMPOSE_FILE_ENV} ${COMPOSE_FILES} up -d 2>&1
 
   docker ps -a
   if [ $? -ne 0 ]; then
@@ -287,8 +287,8 @@ function deployCC() {
 # Tear down running network
 function networkDown() {
   # stop org3 containers also in addition to org1 and org2, in case we were running sample to add org3
-  docker-compose -f $COMPOSE_FILE_BASE -f $COMPOSE_FILE_COUCH -f $COMPOSE_FILE_CA down --volumes --remove-orphans
-  docker-compose -f $COMPOSE_FILE_COUCH_ORG3 -f $COMPOSE_FILE_ORG3 down --volumes --remove-orphans
+  docker-compose --env-file ${COMPOSE_FILE_ENV} -f $COMPOSE_FILE_BASE -f $COMPOSE_FILE_COUCH -f $COMPOSE_FILE_CA down --volumes --remove-orphans
+  docker-compose --env-file ${COMPOSE_FILE_ENV} -f $COMPOSE_FILE_COUCH_ORG3 -f $COMPOSE_FILE_ORG3 down --volumes --remove-orphans
   # Don't remove the generated artifacts -- note, the ledgers are always removed
   if [ "$MODE" != "restart" ]; then
     # Bring down the network, deleting the volumes
@@ -340,6 +340,8 @@ COMPOSE_FILE_CA=docker/docker-compose-ca.yaml
 COMPOSE_FILE_COUCH_ORG3=addOrg3/docker/docker-compose-couch-org3.yaml
 # use this as the default docker-compose yaml definition for org3
 COMPOSE_FILE_ORG3=addOrg3/docker/docker-compose-org3.yaml
+# environment file
+COMPOSE_FILE_ENV=docker/.env
 #
 # chaincode language defaults to "NA"
 CC_SRC_LANGUAGE="NA"


### PR DESCRIPTION
Deploying chaincode failed due to missing .env file.
The previous commit moves .env file to docker directory from
test-network directory. Therefore, .env file doesn't exist
current working directory.
This PR adds --env-file option to docker-compose command to
read .env file.

Signed-off-by: Nao Nishijima <nao.nishijima.xt@hitachi.com>