### PR TITLE
Remove .env Files and Explicitly Name Network

### DIFF
--- a/test-network/addOrg3/.env
+++ b/test-network/addOrg3/.env
@@ -1,2 +1,0 @@
-COMPOSE_PROJECT_NAME=net
-IMAGE_TAG=latest

--- a/test-network/addOrg3/docker/docker-compose-ca-org3.yaml
+++ b/test-network/addOrg3/docker/docker-compose-ca-org3.yaml
@@ -5,10 +5,14 @@
 
 version: '2'
 
+networks:
+  test:
+    name: fabric_test
+
 services:
 
   ca_org3:
-    image: hyperledger/fabric-ca:$IMAGE_TAG
+    image: hyperledger/fabric-ca:latest
     environment:
       - FABRIC_CA_HOME=/etc/hyperledger/fabric-ca-server
       - FABRIC_CA_SERVER_CA_NAME=ca-org3

--- a/test-network/addOrg3/docker/docker-compose-couch-org3.yaml
+++ b/test-network/addOrg3/docker/docker-compose-couch-org3.yaml
@@ -7,6 +7,7 @@ version: '2'
 
 networks:
   test:
+    name: fabric_test
 
 services:
   couchdb4:

--- a/test-network/addOrg3/docker/docker-compose-org3.yaml
+++ b/test-network/addOrg3/docker/docker-compose-org3.yaml
@@ -10,19 +10,17 @@ volumes:
 
 networks:
   test:
+    name: fabric_test
 
 services:
 
   peer0.org3.example.com:
     container_name: peer0.org3.example.com
-    image: hyperledger/fabric-peer:$IMAGE_TAG
+    image: hyperledger/fabric-peer:latest
     environment:
       #Generic peer variables
       - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
-      # the following setting starts chaincode containers on the same
-      # bridge network as the peers
-      # https://docs.docker.com/compose/networking/
-      - CORE_VM_DOCKER_HOSTCONFIG_NETWORKMODE=${COMPOSE_PROJECT_NAME}_test
+      - CORE_VM_DOCKER_HOSTCONFIG_NETWORKMODE=fabric_test
       - FABRIC_LOGGING_SPEC=INFO
       #- FABRIC_LOGGING_SPEC=DEBUG
       - CORE_PEER_TLS_ENABLED=true

--- a/test-network/docker/.env
+++ b/test-network/docker/.env
@@ -1,3 +1,0 @@
-COMPOSE_PROJECT_NAME=net
-IMAGE_TAG=latest
-SYS_CHANNEL=system-channel

--- a/test-network/docker/docker-compose-ca.yaml
+++ b/test-network/docker/docker-compose-ca.yaml
@@ -7,11 +7,12 @@ version: '2'
 
 networks:
   test:
+    name: fabric_test
 
 services:
 
   ca_org1:
-    image: hyperledger/fabric-ca:$IMAGE_TAG
+    image: hyperledger/fabric-ca:latest
     environment:
       - FABRIC_CA_HOME=/etc/hyperledger/fabric-ca-server
       - FABRIC_CA_SERVER_CA_NAME=ca-org1
@@ -27,7 +28,7 @@ services:
       - test
 
   ca_org2:
-    image: hyperledger/fabric-ca:$IMAGE_TAG
+    image: hyperledger/fabric-ca:latest
     environment:
       - FABRIC_CA_HOME=/etc/hyperledger/fabric-ca-server
       - FABRIC_CA_SERVER_CA_NAME=ca-org2
@@ -43,7 +44,7 @@ services:
       - test
 
   ca_orderer:
-    image: hyperledger/fabric-ca:$IMAGE_TAG
+    image: hyperledger/fabric-ca:latest
     environment:
       - FABRIC_CA_HOME=/etc/hyperledger/fabric-ca-server
       - FABRIC_CA_SERVER_CA_NAME=ca-orderer

--- a/test-network/docker/docker-compose-couch.yaml
+++ b/test-network/docker/docker-compose-couch.yaml
@@ -7,6 +7,7 @@ version: '2'
 
 networks:
   test:
+    name: fabric_test
 
 services:
   couchdb0:

--- a/test-network/docker/docker-compose-test-net.yaml
+++ b/test-network/docker/docker-compose-test-net.yaml
@@ -12,12 +12,13 @@ volumes:
 
 networks:
   test:
+    name: fabric_test
 
 services:
 
   orderer.example.com:
     container_name: orderer.example.com
-    image: hyperledger/fabric-orderer:$IMAGE_TAG
+    image: hyperledger/fabric-orderer:latest
     environment:
       - FABRIC_LOGGING_SPEC=INFO
       - ORDERER_GENERAL_LISTENADDRESS=0.0.0.0
@@ -57,14 +58,11 @@ services:
 
   peer0.org1.example.com:
     container_name: peer0.org1.example.com
-    image: hyperledger/fabric-peer:$IMAGE_TAG
+    image: hyperledger/fabric-peer:latest
     environment:
       #Generic peer variables
       - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
-      # the following setting starts chaincode containers on the same
-      # bridge network as the peers
-      # https://docs.docker.com/compose/networking/
-      - CORE_VM_DOCKER_HOSTCONFIG_NETWORKMODE=${COMPOSE_PROJECT_NAME}_test
+      - CORE_VM_DOCKER_HOSTCONFIG_NETWORKMODE=fabric_test
       - FABRIC_LOGGING_SPEC=INFO
       #- FABRIC_LOGGING_SPEC=DEBUG
       - CORE_PEER_TLS_ENABLED=true
@@ -95,14 +93,11 @@ services:
 
   peer0.org2.example.com:
     container_name: peer0.org2.example.com
-    image: hyperledger/fabric-peer:$IMAGE_TAG
+    image: hyperledger/fabric-peer:latest
     environment:
       #Generic peer variables
       - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
-      # the following setting starts chaincode containers on the same
-      # bridge network as the peers
-      # https://docs.docker.com/compose/networking/
-      - CORE_VM_DOCKER_HOSTCONFIG_NETWORKMODE=${COMPOSE_PROJECT_NAME}_test
+      - CORE_VM_DOCKER_HOSTCONFIG_NETWORKMODE=fabric_test
       - FABRIC_LOGGING_SPEC=INFO
       #- FABRIC_LOGGING_SPEC=DEBUG
       - CORE_PEER_TLS_ENABLED=true
@@ -133,7 +128,7 @@ services:
   
   cli:
     container_name: cli
-    image: hyperledger/fabric-tools:$IMAGE_TAG
+    image: hyperledger/fabric-tools:latest
     tty: true
     stdin_open: true
     environment:


### PR DESCRIPTION
There have been lots of changes and quirks with the docker-compose .env file, this change removes the file and explicitly creates and assigns the networks in the compose yaml files.

As a sidenote, this is why the functionality changed, they changed the default location where `.env` was read from, CI recently upgraded to a version of compose that had this change: https://github.com/docker/docker.github.io/commit/7c8c667165f2c275b0294e4ddd4e74761bd930e7#diff-4b87475dd0f3c1791c56c3b5f231860a7e4ee3a2a380ba86a0bc27af64296e56

Signed-off-by: Brett Logan <lindluni@github.com>