### PR TITLE
Add Service Labels and Cleanup Using Standard Tools  and Remove Unused Vars

### DIFF
--- a/test-network/addOrg3/addOrg3.sh
+++ b/test-network/addOrg3/addOrg3.sh
@@ -168,16 +168,10 @@ function networkDown () {
     ./network.sh down
 }
 
-
-# Obtain the OS and Architecture string that will be used to select the correct
-# native binaries for your platform
-OS_ARCH=$(echo "$(uname -s|tr '[:upper:]' '[:lower:]'|sed 's/mingw64_nt.*/windows/')-$(uname -m | sed 's/x86_64/amd64/g')" | awk '{print tolower($0)}')
-# timeout duration - the duration the CLI should wait for a response from
-# another container before giving up
-
 # Using crpto vs CA. default is cryptogen
 CRYPTO="cryptogen"
-
+# timeout duration - the duration the CLI should wait for a response from
+# another container before giving up
 CLI_TIMEOUT=10
 #default for delay
 CLI_DELAY=3

--- a/test-network/addOrg3/docker/docker-compose-ca-org3.yaml
+++ b/test-network/addOrg3/docker/docker-compose-ca-org3.yaml
@@ -10,9 +10,10 @@ networks:
     name: fabric_test
 
 services:
-
   ca_org3:
     image: hyperledger/fabric-ca:latest
+    labels:
+      service: hyperledger-fabric
     environment:
       - FABRIC_CA_HOME=/etc/hyperledger/fabric-ca-server
       - FABRIC_CA_SERVER_CA_NAME=ca-org3

--- a/test-network/addOrg3/docker/docker-compose-couch-org3.yaml
+++ b/test-network/addOrg3/docker/docker-compose-couch-org3.yaml
@@ -13,6 +13,8 @@ services:
   couchdb4:
     container_name: couchdb4
     image: couchdb:3.1.1
+    labels:
+      service: hyperledger-fabric
     # Populate the COUCHDB_USER and COUCHDB_PASSWORD to set an admin user and password
     # for CouchDB.  This will prevent CouchDB from operating in an "Admin Party" mode.
     environment:

--- a/test-network/addOrg3/docker/docker-compose-org3.yaml
+++ b/test-network/addOrg3/docker/docker-compose-org3.yaml
@@ -17,6 +17,8 @@ services:
   peer0.org3.example.com:
     container_name: peer0.org3.example.com
     image: hyperledger/fabric-peer:latest
+    labels:
+      service: hyperledger-fabric
     environment:
       #Generic peer variables
       - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock

--- a/test-network/docker/docker-compose-ca.yaml
+++ b/test-network/docker/docker-compose-ca.yaml
@@ -13,6 +13,8 @@ services:
 
   ca_org1:
     image: hyperledger/fabric-ca:latest
+    labels:
+      service: hyperledger-fabric
     environment:
       - FABRIC_CA_HOME=/etc/hyperledger/fabric-ca-server
       - FABRIC_CA_SERVER_CA_NAME=ca-org1
@@ -29,6 +31,8 @@ services:
 
   ca_org2:
     image: hyperledger/fabric-ca:latest
+    labels:
+      service: hyperledger-fabric
     environment:
       - FABRIC_CA_HOME=/etc/hyperledger/fabric-ca-server
       - FABRIC_CA_SERVER_CA_NAME=ca-org2
@@ -45,6 +49,8 @@ services:
 
   ca_orderer:
     image: hyperledger/fabric-ca:latest
+    labels:
+      service: hyperledger-fabric
     environment:
       - FABRIC_CA_HOME=/etc/hyperledger/fabric-ca-server
       - FABRIC_CA_SERVER_CA_NAME=ca-orderer

--- a/test-network/docker/docker-compose-couch.yaml
+++ b/test-network/docker/docker-compose-couch.yaml
@@ -13,6 +13,8 @@ services:
   couchdb0:
     container_name: couchdb0
     image: couchdb:3.1.1
+    labels:
+      service: hyperledger-fabric
     # Populate the COUCHDB_USER and COUCHDB_PASSWORD to set an admin user and password
     # for CouchDB.  This will prevent CouchDB from operating in an "Admin Party" mode.
     environment:
@@ -40,6 +42,8 @@ services:
   couchdb1:
     container_name: couchdb1
     image: couchdb:3.1.1
+    labels:
+      service: hyperledger-fabric
     # Populate the COUCHDB_USER and COUCHDB_PASSWORD to set an admin user and password
     # for CouchDB.  This will prevent CouchDB from operating in an "Admin Party" mode.
     environment:

--- a/test-network/docker/docker-compose-test-net.yaml
+++ b/test-network/docker/docker-compose-test-net.yaml
@@ -19,6 +19,8 @@ services:
   orderer.example.com:
     container_name: orderer.example.com
     image: hyperledger/fabric-orderer:latest
+    labels:
+      service: hyperledger-fabric
     environment:
       - FABRIC_LOGGING_SPEC=INFO
       - ORDERER_GENERAL_LISTENADDRESS=0.0.0.0
@@ -59,6 +61,8 @@ services:
   peer0.org1.example.com:
     container_name: peer0.org1.example.com
     image: hyperledger/fabric-peer:latest
+    labels:
+      service: hyperledger-fabric
     environment:
       #Generic peer variables
       - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
@@ -94,6 +98,8 @@ services:
   peer0.org2.example.com:
     container_name: peer0.org2.example.com
     image: hyperledger/fabric-peer:latest
+    labels:
+      service: hyperledger-fabric
     environment:
       #Generic peer variables
       - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
@@ -129,6 +135,8 @@ services:
   cli:
     container_name: cli
     image: hyperledger/fabric-tools:latest
+    labels:
+      service: hyperledger-fabric
     tty: true
     stdin_open: true
     environment:

--- a/test-network/network.sh
+++ b/test-network/network.sh
@@ -19,27 +19,19 @@ export VERBOSE=false
 . scripts/utils.sh
 
 # Obtain CONTAINER_IDS and remove them
-# TODO Might want to make this optional - could clear other containers
 # This function is called when you bring a network down
 function clearContainers() {
-  CONTAINER_IDS=$(docker ps -a | awk '($2 ~ /dev-peer.*/) {print $1}')
-  if [ -z "$CONTAINER_IDS" -o "$CONTAINER_IDS" == " " ]; then
-    infoln "No containers available for deletion"
-  else
-    docker rm -f $CONTAINER_IDS
-  fi
+  infoln "Removing remaining containers"
+  docker rm -f $(docker ps -aq --filter label=service=hyperledger-fabric) 2>/dev/null || true
+  docker rm -f $(docker ps -aq --filter name='dev-peer*') 2>/dev/null || true
 }
 
 # Delete any images that were generated as a part of this setup
 # specifically the following images are often left behind:
 # This function is called when you bring the network down
 function removeUnwantedImages() {
-  DOCKER_IMAGE_IDS=$(docker images | awk '($1 ~ /dev-peer.*/) {print $3}')
-  if [ -z "$DOCKER_IMAGE_IDS" -o "$DOCKER_IMAGE_IDS" == " " ]; then
-    infoln "No images available for deletion"
-  else
-    docker rmi -f $DOCKER_IMAGE_IDS
-  fi
+  infoln "Removing generated chaincode docker images"
+  docker image rm -f $(docker images -aq --filter reference='dev-peer*') 2>/dev/null || true
 }
 
 # Versions of fabric known not to work with the test network

--- a/test-network/network.sh
+++ b/test-network/network.sh
@@ -308,9 +308,6 @@ function networkDown() {
   fi
 }
 
-# Obtain the OS and Architecture string that will be used to select the correct
-# native binaries for your platform, e.g., darwin-amd64 or linux-amd64
-OS_ARCH=$(echo "$(uname -s | tr '[:upper:]' '[:lower:]' | sed 's/mingw64_nt.*/windows/')-$(uname -m | sed 's/x86_64/amd64/g')" | awk '{print tolower($0)}')
 # Using crpto vs CA. default is cryptogen
 CRYPTO="cryptogen"
 # timeout duration - the duration the CLI should wait for a response from


### PR DESCRIPTION
 Add a service label to all containers launched by compose. This allows us to filter on the label for removing running containers.
    
Use filtering for querying running containers and images to make sure we only target the containers and images we want to remove.

Removes the `OS_ARCH` var as it was unused.