### PR TITLE
Change docker compose file version

### DIFF
--- a/test-network/docker/docker-compose-ca.yaml
+++ b/test-network/docker/docker-compose-ca.yaml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-version: '2'
+version: '2.4'
 
 networks:
   test:

--- a/test-network/docker/docker-compose-couch.yaml
+++ b/test-network/docker/docker-compose-couch.yaml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-version: '2'
+version: '2.4'
 
 networks:
   test:

--- a/test-network/docker/docker-compose-test-net.yaml
+++ b/test-network/docker/docker-compose-test-net.yaml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-version: '2'
+version: '2.4'
 
 volumes:
   orderer.example.com:


### PR DESCRIPTION
When i tried to set up a new test network, i got the error
`ERROR: The Compose file './docker/docker-compose-ca.yaml' is invalid because:
networks.test value Additional properties are not allowed ('name' was unexpected)`

I think the reason is that the 'name' is only available after version 2.1 according to the [docker docs](https://docs.docker.com/compose/compose-file/compose-file-v2/#name-1). So I change the version of docker compose file to 2.4, just like the example in the docker docs. Finally, everything worked fine.
