### PR TITLE
Fix empty event in token-erc-20 example

### DIFF
--- a/token-erc-20/chaincode-go/chaincode/token_contract.go
+++ b/token-erc-20/chaincode-go/chaincode/token_contract.go
@@ -23,9 +23,9 @@ type SmartContract struct {
 
 // event provides an organized struct for emitting events
 type event struct {
-	from  string
-	to    string
-	value int
+	From  string `json:"from"`
+	To    string `json:"to"`
+	Value int    `json:"value"`
 }
 
 // Mint creates new tokens and adds them to minter's account balance


### PR DESCRIPTION
Lowercase fields of a struct in Go are not exported. Therefore, the JSON marshalled from the `event` struct creates an empty object. I capitalized the first letters of the fields and added JSON tags so that the key name of the fields remain the same.

Signed-off-by: Baran Kılıç <baran.kilic@boun.edu.tr>