### PR TITLE
port no fixed on org2 fabric-ca-server-config file *8054

### DIFF
--- a/test-network/organizations/fabric-ca/org2/fabric-ca-server-config.yaml
+++ b/test-network/organizations/fabric-ca/org2/fabric-ca-server-config.yaml
@@ -39,8 +39,8 @@
 # Version of config file
 version: 1.2.0
 
-# Server's listening port (default: 7054)
-port: 7054
+# Server's listening port (default: 8054)
+port: 8054
 
 # Enables debug logging (default: false)
 debug: false


### PR DESCRIPTION
On fabric test network ,, the org2 fabric-ca-server-config.yaml
file have port 7054.
But it actually runs on 8054 .