### PR TITLE
abstore contract - Aval, Bval bad validation if values are not a number

### DIFF
--- a/chaincode/abstore/javascript/abstore.js
+++ b/chaincode/abstore/javascript/abstore.js
@@ -25,7 +25,7 @@ var ABstore = class {
     let Aval = args[1];
     let Bval = args[3];
 
-    if (typeof parseInt(Aval) !== 'number' || typeof parseInt(Bval) !== 'number') {
+    if (isNaN(parseInt(Aval)) || isNaN(parseInt(Bval))) {
       return shim.error('Expecting integer value for asset holding');
     }
 


### PR DESCRIPTION
Standard validation for numbers does not work.

`if (typeof parseInt(Aval) !== 'number' || typeof parseInt(Bval) !== 'number') {
      return shim.error('Expecting integer value for asset holding');
    }`

Good:

`if (isNaN(parseInt(Aval)) || isNaN(parseInt(Bval))) {
      return shim.error('Expecting integer value for asset holding');
    }`

Otherwise contract accepts no number values as below:
![image](https://user-images.githubusercontent.com/21140074/113018553-f6f49e80-9180-11eb-92aa-944446c42d9d.png)
