### PR TITLE
abstore smart contract - Fixed Aval and Bval validation

### DIFF
--- a/chaincode/abstore/javascript/abstore.js
+++ b/chaincode/abstore/javascript/abstore.js
@@ -25,7 +25,7 @@ var ABstore = class {
     let Aval = args[1];
     let Bval = args[3];
 
-    if (typeof parseInt(Aval) !== 'number' || typeof parseInt(Bval) !== 'number') {
+    if (isNaN(parseInt(Aval)) || isNaN(parseInt(Bval))) {
       return shim.error('Expecting integer value for asset holding');
     }
 


### PR DESCRIPTION
Standard validation for numbers does not work.

if (typeof parseInt(Aval) !== 'number' || typeof parseInt(Bval) !== 'number') { return shim.error('Expecting integer value for asset holding'); }

Good:

if (isNaN(parseInt(Aval)) || isNaN(parseInt(Bval))) { return shim.error('Expecting integer value for asset holding'); }

Otherwise contract accepts no number values as below:
![image](https://user-images.githubusercontent.com/21140074/113177302-a72fd900-924d-11eb-9ddf-4d95b9c3e830.png)


Signed-off-by: Michał Mirończuk <michalmironczuk1@gmail.com>