### PR TITLE
Correct Javascript Chaincode

### DIFF
--- a/asset-transfer-basic/chaincode-javascript/lib/assetTransfer.js
+++ b/asset-transfer-basic/chaincode-javascript/lib/assetTransfer.js
@@ -72,7 +72,7 @@ class AssetTransfer extends Contract {
             Owner: owner,
             AppraisedValue: appraisedValue,
         };
-        ctx.stub.putState(id, Buffer.from(JSON.stringify(asset)));
+        await ctx.stub.putState(id, Buffer.from(JSON.stringify(asset)));
         return JSON.stringify(asset);
     }
 
@@ -146,8 +146,6 @@ class AssetTransfer extends Contract {
         }
         return JSON.stringify(allResults);
     }
-
-
 }
 
 module.exports = AssetTransfer;


### PR DESCRIPTION
- In CreateAsset, await was never called on putState causing issues
especially with tools such as caliper and is not correct practice.
Unfortunately all the other examples use `return` which works but is
actually not the idiomatic way of handling promises, so here await is
chosen rather than return