### PR TITLE
Support docker.sock in rootless mode

### DIFF
--- a/test-network/addOrg3/addOrg3.sh
+++ b/test-network/addOrg3/addOrg3.sh
@@ -119,9 +119,9 @@ function generateOrg3Definition() {
 function Org3Up () {
   # start org3 nodes
   if [ "${DATABASE}" == "couchdb" ]; then
-    docker-compose -f $COMPOSE_FILE_ORG3 -f $COMPOSE_FILE_COUCH_ORG3 up -d 2>&1
+    DOCKER_SOCK=${DOCKER_SOCK} docker-compose -f $COMPOSE_FILE_ORG3 -f $COMPOSE_FILE_COUCH_ORG3 up -d 2>&1
   else
-    docker-compose -f $COMPOSE_FILE_ORG3 up -d 2>&1
+    DOCKER_SOCK=${DOCKER_SOCK} docker-compose -f $COMPOSE_FILE_ORG3 up -d 2>&1
   fi
   if [ $? -ne 0 ]; then
     fatalln "ERROR !!!! Unable to start Org3 network"
@@ -182,6 +182,10 @@ COMPOSE_FILE_ORG3=docker/docker-compose-org3.yaml
 COMPOSE_FILE_CA_ORG3=docker/docker-compose-ca-org3.yaml
 # database
 DATABASE="leveldb"
+
+# Get docker sock path from environment variable
+SOCK="${DOCKER_HOST:-/var/run/docker.sock}"
+DOCKER_SOCK="${SOCK##unix://}"
 
 # Parse commandline args
 

--- a/test-network/addOrg3/docker/docker-compose-org3.yaml
+++ b/test-network/addOrg3/docker/docker-compose-org3.yaml
@@ -40,7 +40,7 @@ services:
       - CORE_PEER_GOSSIP_EXTERNALENDPOINT=peer0.org3.example.com:11051
       - CORE_PEER_LOCALMSPID=Org3MSP
     volumes:
-        - /var/run/docker.sock:/host/var/run/docker.sock
+        - ${DOCKER_SOCK}:/host/var/run/docker.sock
         - ../../organizations/peerOrganizations/org3.example.com/peers/peer0.org3.example.com/msp:/etc/hyperledger/fabric/msp
         - ../../organizations/peerOrganizations/org3.example.com/peers/peer0.org3.example.com/tls:/etc/hyperledger/fabric/tls
         - peer0.org3.example.com:/var/hyperledger/production

--- a/test-network/docker/docker-compose-test-net.yaml
+++ b/test-network/docker/docker-compose-test-net.yaml
@@ -84,7 +84,7 @@ services:
       - CORE_PEER_GOSSIP_EXTERNALENDPOINT=peer0.org1.example.com:7051
       - CORE_PEER_LOCALMSPID=Org1MSP
     volumes:
-        - /var/run/docker.sock:/host/var/run/docker.sock
+        - ${DOCKER_SOCK}:/host/var/run/docker.sock
         - ../organizations/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/msp:/etc/hyperledger/fabric/msp
         - ../organizations/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls:/etc/hyperledger/fabric/tls
         - peer0.org1.example.com:/var/hyperledger/production
@@ -121,7 +121,7 @@ services:
       - CORE_PEER_GOSSIP_BOOTSTRAP=peer0.org2.example.com:9051
       - CORE_PEER_LOCALMSPID=Org2MSP
     volumes:
-        - /var/run/docker.sock:/host/var/run/docker.sock
+        - ${DOCKER_SOCK}:/host/var/run/docker.sock
         - ../organizations/peerOrganizations/org2.example.com/peers/peer0.org2.example.com/msp:/etc/hyperledger/fabric/msp
         - ../organizations/peerOrganizations/org2.example.com/peers/peer0.org2.example.com/tls:/etc/hyperledger/fabric/tls
         - peer0.org2.example.com:/var/hyperledger/production

--- a/test-network/network.sh
+++ b/test-network/network.sh
@@ -241,7 +241,7 @@ function networkUp() {
     COMPOSE_FILES="${COMPOSE_FILES} -f ${COMPOSE_FILE_COUCH}"
   fi
 
-  docker-compose ${COMPOSE_FILES} up -d 2>&1
+  DOCKER_SOCK="${DOCKER_SOCK}" docker-compose ${COMPOSE_FILES} up -d 2>&1
 
   docker ps -a
   if [ $? -ne 0 ]; then
@@ -278,7 +278,7 @@ function deployCC() {
 # Tear down running network
 function networkDown() {
   # stop org3 containers also in addition to org1 and org2, in case we were running sample to add org3
-  docker-compose -f $COMPOSE_FILE_BASE -f $COMPOSE_FILE_COUCH -f $COMPOSE_FILE_CA down --volumes --remove-orphans
+  DOCKER_SOCK=$DOCKER_SOCK docker-compose -f $COMPOSE_FILE_BASE -f $COMPOSE_FILE_COUCH -f $COMPOSE_FILE_CA down --volumes --remove-orphans
   docker-compose -f $COMPOSE_FILE_COUCH_ORG3 -f $COMPOSE_FILE_ORG3 down --volumes --remove-orphans
   # Don't remove the generated artifacts -- note, the ledgers are always removed
   if [ "$MODE" != "restart" ]; then
@@ -337,6 +337,10 @@ CC_VERSION="1.0"
 CC_SEQUENCE=1
 # default database
 DATABASE="leveldb"
+
+# Get docker sock path from environment variable
+SOCK="${DOCKER_HOST:-/var/run/docker.sock}"
+DOCKER_SOCK="${SOCK##unix://}"
 
 # Parse commandline args
 


### PR DESCRIPTION
Docker version 20.10 support rootless mode. That features
changes a mount path of docker.sock.
This PR loads a mount path from DOCKER_HOST environment,
and if not set, a mount path will be /var/run/docker.sock

FAB-18481

Signed-off-by: Nao Nishijima <nao.nishijima.xt@hitachi.com>