### PR TITLE
change docker-compose version from 2 to 2.4  on folder addOrg3/docker

### DIFF
--- a/test-network/addOrg3/docker/docker-compose-ca-org3.yaml
+++ b/test-network/addOrg3/docker/docker-compose-ca-org3.yaml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-version: '2'
+version: '2.4'
 
 networks:
   test:

--- a/test-network/addOrg3/docker/docker-compose-couch-org3.yaml
+++ b/test-network/addOrg3/docker/docker-compose-couch-org3.yaml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-version: '2'
+version: '2.4'
 
 networks:
   test:

--- a/test-network/addOrg3/docker/docker-compose-org3.yaml
+++ b/test-network/addOrg3/docker/docker-compose-org3.yaml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-version: '2'
+version: '2.4'
 
 volumes:
   peer0.org3.example.com:


### PR DESCRIPTION
Following the instructions to set an organization 3, the docker-compose file (test-network/addOrg3/docker/docker-compose-org3.yaml) was invalid because it didn't accept additional properties in the network declaration (test_network) with docker-compose version 2. I was able to solve the problem by setting the version to 2.4.