### PR TITLE
Add process.exit(0) to sample applications

### DIFF
--- a/asset-transfer-basic/application-javascript/app.js
+++ b/asset-transfer-basic/application-javascript/app.js
@@ -175,6 +175,7 @@ async function main() {
 	} catch (error) {
 		console.error(`******** FAILED to run the application: ${error}`);
 	}
+	process.exit(0);
 }
 
 main();

--- a/asset-transfer-basic/application-typescript/src/app.ts
+++ b/asset-transfer-basic/application-typescript/src/app.ts
@@ -166,6 +166,7 @@ async function main() {
     } catch (error) {
         console.error(`******** FAILED to run the application: ${error}`);
     }
+    process.exit(0);
 }
 
 main();

--- a/asset-transfer-ledger-queries/application-javascript/app.js
+++ b/asset-transfer-ledger-queries/application-javascript/app.js
@@ -238,7 +238,7 @@ async function main() {
 	}
 
 	console.log('*** application ending');
-
+	process.exit(0);
 }
 
 main();

--- a/asset-transfer-private-data/application-javascript/app.js
+++ b/asset-transfer-private-data/application-javascript/app.js
@@ -353,6 +353,7 @@ async function main() {
         }
         process.exit(1);
     }
+    process.exit(0);
 }
 
 main();

--- a/asset-transfer-sbe/application-javascript/app.js
+++ b/asset-transfer-sbe/application-javascript/app.js
@@ -344,6 +344,7 @@ async function main() {
 		}
 		process.exit(1);
 	}
+	process.exit(0);
 }
 
 main();

--- a/asset-transfer-secured-agreement/application-javascript/app.js
+++ b/asset-transfer-secured-agreement/application-javascript/app.js
@@ -563,5 +563,6 @@ async function main() {
 		process.exit(1);
 	}
 	console.log(`${GREEN} **** END ****${RESET}`);
+	process.exit(0);
 }
 main();

--- a/commercial-paper/organization/digibank/application/buy.js
+++ b/commercial-paper/organization/digibank/application/buy.js
@@ -88,6 +88,7 @@ async function main () {
         // Disconnect from the gateway
         console.log('Disconnect from Fabric gateway.');
         gateway.disconnect();
+        process.exit(0);
 
     }
 }

--- a/commercial-paper/organization/digibank/application/queryapp.js
+++ b/commercial-paper/organization/digibank/application/queryapp.js
@@ -138,6 +138,7 @@ async function main() {
         // Disconnect from the gateway
         console.log('Disconnect from Fabric gateway.');
         gateway.disconnect();
+        process.exit(0);
 
     }
 }

--- a/commercial-paper/organization/digibank/application/redeem.js
+++ b/commercial-paper/organization/digibank/application/redeem.js
@@ -89,6 +89,7 @@ async function main() {
     // Disconnect from the gateway
     console.log('Disconnect from Fabric gateway.')
     gateway.disconnect();
+    process.exit(0);
 
   }
 }

--- a/commercial-paper/organization/magnetocorp/application/issue.js
+++ b/commercial-paper/organization/magnetocorp/application/issue.js
@@ -86,6 +86,7 @@ async function main() {
         // Disconnect from the gateway
         console.log('Disconnect from Fabric gateway.');
         gateway.disconnect();
+        process.exit(0);
 
     }
 }

--- a/commercial-paper/organization/magnetocorp/application/transfer.js
+++ b/commercial-paper/organization/magnetocorp/application/transfer.js
@@ -86,6 +86,7 @@ async function main() {
         // Disconnect from the gateway
         console.log('Disconnect from Fabric gateway.');
         gateway.disconnect();
+        process.exit(0);
 
     }
 }

--- a/fabcar/javascript/enrollAdmin.js
+++ b/fabcar/javascript/enrollAdmin.js
@@ -51,6 +51,7 @@ async function main() {
         console.error(`Failed to enroll admin user "admin": ${error}`);
         process.exit(1);
     }
+    process.exit(0);
 }
 
 main();

--- a/fabcar/javascript/invoke.js
+++ b/fabcar/javascript/invoke.js
@@ -52,6 +52,7 @@ async function main() {
         console.error(`Failed to submit transaction: ${error}`);
         process.exit(1);
     }
+    process.exit(0);
 }
 
 main();

--- a/fabcar/javascript/query.js
+++ b/fabcar/javascript/query.js
@@ -48,11 +48,12 @@ async function main() {
 
         // Disconnect from the gateway.
         await gateway.disconnect();
-        
+
     } catch (error) {
         console.error(`Failed to evaluate transaction: ${error}`);
         process.exit(1);
     }
+    process.exit(0);
 }
 
 main();

--- a/fabcar/javascript/registerUser.js
+++ b/fabcar/javascript/registerUser.js
@@ -70,6 +70,7 @@ async function main() {
         console.error(`Failed to register user "appUser": ${error}`);
         process.exit(1);
     }
+    process.exit(0);
 }
 
 main();

--- a/fabcar/typescript/src/enrollAdmin.ts
+++ b/fabcar/typescript/src/enrollAdmin.ts
@@ -47,6 +47,7 @@ async function main() {
         console.error(`Failed to enroll admin user "admin": ${error}`);
         process.exit(1);
     }
+    process.exit(0);
 }
 
 main();

--- a/fabcar/typescript/src/invoke.ts
+++ b/fabcar/typescript/src/invoke.ts
@@ -48,6 +48,7 @@ async function main() {
         console.error(`Failed to submit transaction: ${error}`);
         process.exit(1);
     }
+    process.exit(0);
 }
 
 main();

--- a/fabcar/typescript/src/query.ts
+++ b/fabcar/typescript/src/query.ts
@@ -46,6 +46,7 @@ async function main() {
         console.error(`Failed to evaluate transaction: ${error}`);
         process.exit(1);
     }
+    process.exit(0);
 }
 
 main();

--- a/fabcar/typescript/src/registerUser.ts
+++ b/fabcar/typescript/src/registerUser.ts
@@ -59,6 +59,7 @@ async function main() {
         console.error(`Failed to register user "appUser": ${error}`);
         process.exit(1);
     }
+    process.exit(0);
 }
 
 main();


### PR DESCRIPTION
Add process.exit(0) so that sample javascript and typescript
applications exit with success upon completion instead of hanging.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>