### PR TITLE
changed all 'complileOnly' to 'implementation' on all fabric-samples for the fabric dependency

### DIFF
--- a/asset-transfer-events/chaincode-java/build.gradle
+++ b/asset-transfer-events/chaincode-java/build.gradle
@@ -13,7 +13,7 @@ group 'org.hyperledger.fabric.samples'
 version '1.0-SNAPSHOT'
 
 dependencies {
-    compileOnly 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.+'
+    implementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.+'
     testImplementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.+'
 }
 

--- a/asset-transfer-private-data/chaincode-java/build.gradle
+++ b/asset-transfer-private-data/chaincode-java/build.gradle
@@ -14,7 +14,7 @@ version '1.0-SNAPSHOT'
 
 dependencies {
     
-    compileOnly 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.+'
+    implementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.+'
 
     testImplementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.+'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.4.2'

--- a/asset-transfer-sbe/chaincode-java/build.gradle
+++ b/asset-transfer-sbe/chaincode-java/build.gradle
@@ -14,7 +14,7 @@ version '1.0-SNAPSHOT'
 
 dependencies {
     
-    compileOnly 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.+'
+    implementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.+'
     implementation 'com.owlike:genson:1.5'
     testImplementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.+'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.4.2'


### PR DESCRIPTION
spotted that on the dependencies of all chaincode-java we were doing 'compileOnly 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.+'' instead of 'implementation'
This was preventing all java smart contracts to run on VSCode: microfab (used on vscode) does not import fabric while in cli (which uses test-network) it is embeded