### PR TITLE
Fix: Cannot launch chaincode in nano bash in Linux

### DIFF
--- a/test-network-nano-bash/peer1.sh
+++ b/test-network-nano-bash/peer1.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+if [ "$(uname)" == "Linux" ] ; then
+  CCADDR="127.0.0.1"
+else
+  CCADDR="host.docker.internal"
+fi
+
 # look for binaries in local dev environment /build/bin directory and then in local samples /bin directory
 export PATH="${PWD}"/../../fabric/build/bin:"${PWD}"/../bin:"$PATH"
 export FABRIC_CFG_PATH="${PWD}"/../config
@@ -13,7 +19,7 @@ export CORE_PEER_TLS_ROOTCERT_FILE="${PWD}"/crypto-config/peerOrganizations/org1
 export CORE_PEER_ID=peer0.org1.example.com
 export CORE_PEER_ADDRESS=127.0.0.1:7051
 export CORE_PEER_LISTENADDRESS=127.0.0.1:7051
-export CORE_PEER_CHAINCODEADDRESS=host.docker.internal:7052
+export CORE_PEER_CHAINCODEADDRESS="${CCADDR}":7052
 export CORE_PEER_CHAINCODELISTENADDRESS=127.0.0.1:7052
 # bootstrap peer is the other peer in the same org
 export CORE_PEER_GOSSIP_BOOTSTRAP=127.0.0.1:7053

--- a/test-network-nano-bash/peer2.sh
+++ b/test-network-nano-bash/peer2.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+if [ "$(uname)" == "Linux" ] ; then
+  CCADDR="127.0.0.1"
+else
+  CCADDR="host.docker.internal"
+fi
+
 # look for binaries in local dev environment /build/bin directory and then in local samples /bin directory
 export PATH="${PWD}"/../../fabric/build/bin:"${PWD}"/../bin:"$PATH"
 export FABRIC_CFG_PATH="${PWD}"/../config
@@ -13,7 +19,7 @@ export CORE_PEER_TLS_ROOTCERT_FILE="${PWD}"/crypto-config/peerOrganizations/org1
 export CORE_PEER_ID=peer1.org1.example.com
 export CORE_PEER_ADDRESS=127.0.0.1:7053
 export CORE_PEER_LISTENADDRESS=127.0.0.1:7053
-export CORE_PEER_CHAINCODEADDRESS=host.docker.internal:7054
+export CORE_PEER_CHAINCODEADDRESS="${CCADDR}":7054
 export CORE_PEER_CHAINCODELISTENADDRESS=127.0.0.1:7054
 # bootstrap peer is the other peer in the same org
 export CORE_PEER_GOSSIP_BOOTSTRAP=127.0.0.1:7051

--- a/test-network-nano-bash/peer3.sh
+++ b/test-network-nano-bash/peer3.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+if [ "$(uname)" == "Linux" ] ; then
+  CCADDR="127.0.0.1"
+else
+  CCADDR="host.docker.internal"
+fi
+
 # look for binaries in local dev environment /build/bin directory and then in local samples /bin directory
 export PATH="${PWD}"/../../fabric/build/bin:"${PWD}"/../bin:"$PATH"
 export FABRIC_CFG_PATH="${PWD}"/../config
@@ -13,7 +19,7 @@ export CORE_PEER_TLS_ROOTCERT_FILE="${PWD}"/crypto-config/peerOrganizations/org2
 export CORE_PEER_ID=peer0.org2.example.com
 export CORE_PEER_ADDRESS=127.0.0.1:7055
 export CORE_PEER_LISTENADDRESS=127.0.0.1:7055
-export CORE_PEER_CHAINCODEADDRESS=host.docker.internal:7056
+export CORE_PEER_CHAINCODEADDRESS="${CCADDR}":7056
 export CORE_PEER_CHAINCODELISTENADDRESS=127.0.0.1:7056
 # bootstrap peer is the other peer in the same org
 export CORE_PEER_GOSSIP_BOOTSTRAP=127.0.0.1:7057

--- a/test-network-nano-bash/peer4.sh
+++ b/test-network-nano-bash/peer4.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+if [ "$(uname)" == "Linux" ] ; then
+  CCADDR="127.0.0.1"
+else
+  CCADDR="host.docker.internal"
+fi
+
 # look for binaries in local dev environment /build/bin directory and then in local samples /bin directory
 export PATH="${PWD}"/../../fabric/build/bin:"${PWD}"/../bin:"$PATH"
 export FABRIC_CFG_PATH="${PWD}"/../config
@@ -13,7 +19,7 @@ export CORE_PEER_TLS_ROOTCERT_FILE="${PWD}"/crypto-config/peerOrganizations/org2
 export CORE_PEER_ID=peer0.org2.example.com
 export CORE_PEER_ADDRESS=127.0.0.1:7057
 export CORE_PEER_LISTENADDRESS=127.0.0.1:7057
-export CORE_PEER_CHAINCODEADDRESS=host.docker.internal:7058
+export CORE_PEER_CHAINCODEADDRESS="${CCADDR}":7058
 export CORE_PEER_CHAINCODELISTENADDRESS=127.0.0.1:7058
 # bootstrap peer is the other peer in the same org
 export CORE_PEER_GOSSIP_BOOTSTRAP=127.0.0.1:7055


### PR DESCRIPTION
CHAINCODEADDRESS is set to host.docker.internal which is
only available in MAC and Windows environments.
For that reason, it cannot launch chaincode on Linux.
This PR sets CHAINCODEADDRESS to 127.0.0.1 instead of
host.docker.internal.

Signed-off-by: Nao Nishijima <nao.nishijima.xt@hitachi.com>