### PR TITLE
Remove .env Files and Explicitly Name Network (#417)

### DIFF
--- a/test-network/.env
+++ b/test-network/.env
@@ -1,3 +1,0 @@
-COMPOSE_PROJECT_NAME=net
-IMAGE_TAG=latest
-SYS_CHANNEL=system-channel

--- a/test-network/addOrg3/.env
+++ b/test-network/addOrg3/.env
@@ -1,2 +1,0 @@
-COMPOSE_PROJECT_NAME=net
-IMAGE_TAG=latest

--- a/test-network/addOrg3/docker/docker-compose-ca-org3.yaml
+++ b/test-network/addOrg3/docker/docker-compose-ca-org3.yaml
@@ -5,10 +5,14 @@
 
 version: '2'
 
+networks:
+  test:
+    name: fabric_test
+
 services:
 
   ca_org3:
-    image: hyperledger/fabric-ca:$IMAGE_TAG
+    image: hyperledger/fabric-ca:latest
     environment:
       - FABRIC_CA_HOME=/etc/hyperledger/fabric-ca-server
       - FABRIC_CA_SERVER_CA_NAME=ca-org3

--- a/test-network/addOrg3/docker/docker-compose-couch-org3.yaml
+++ b/test-network/addOrg3/docker/docker-compose-couch-org3.yaml
@@ -7,6 +7,7 @@ version: '2'
 
 networks:
   test:
+    name: fabric_test
 
 services:
   couchdb4:

--- a/test-network/addOrg3/docker/docker-compose-org3.yaml
+++ b/test-network/addOrg3/docker/docker-compose-org3.yaml
@@ -10,19 +10,17 @@ volumes:
 
 networks:
   test:
+    name: fabric_test
 
 services:
 
   peer0.org3.example.com:
     container_name: peer0.org3.example.com
-    image: hyperledger/fabric-peer:$IMAGE_TAG
+    image: hyperledger/fabric-peer:latest
     environment:
       #Generic peer variables
       - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
-      # the following setting starts chaincode containers on the same
-      # bridge network as the peers
-      # https://docs.docker.com/compose/networking/
-      - CORE_VM_DOCKER_HOSTCONFIG_NETWORKMODE=${COMPOSE_PROJECT_NAME}_test
+      - CORE_VM_DOCKER_HOSTCONFIG_NETWORKMODE=fabric_test
       - FABRIC_LOGGING_SPEC=INFO
       #- FABRIC_LOGGING_SPEC=DEBUG
       - CORE_PEER_TLS_ENABLED=true

--- a/test-network/docker/docker-compose-ca.yaml
+++ b/test-network/docker/docker-compose-ca.yaml
@@ -12,7 +12,7 @@ networks:
 services:
 
   ca_org1:
-    image: hyperledger/fabric-ca:$IMAGE_TAG
+    image: hyperledger/fabric-ca:latest
     environment:
       - FABRIC_CA_HOME=/etc/hyperledger/fabric-ca-server
       - FABRIC_CA_SERVER_CA_NAME=ca-org1
@@ -30,7 +30,7 @@ services:
       - test
 
   ca_org2:
-    image: hyperledger/fabric-ca:$IMAGE_TAG
+    image: hyperledger/fabric-ca:latest
     environment:
       - FABRIC_CA_HOME=/etc/hyperledger/fabric-ca-server
       - FABRIC_CA_SERVER_CA_NAME=ca-org2
@@ -48,7 +48,7 @@ services:
       - test
 
   ca_orderer:
-    image: hyperledger/fabric-ca:$IMAGE_TAG
+    image: hyperledger/fabric-ca:latest
     environment:
       - FABRIC_CA_HOME=/etc/hyperledger/fabric-ca-server
       - FABRIC_CA_SERVER_CA_NAME=ca-orderer

--- a/test-network/docker/docker-compose-test-net.yaml
+++ b/test-network/docker/docker-compose-test-net.yaml
@@ -18,7 +18,7 @@ services:
 
   orderer.example.com:
     container_name: orderer.example.com
-    image: hyperledger/fabric-orderer:$IMAGE_TAG
+    image: hyperledger/fabric-orderer:latest
     environment:
       - FABRIC_LOGGING_SPEC=INFO
       - ORDERER_GENERAL_LISTENADDRESS=0.0.0.0
@@ -53,13 +53,10 @@ services:
 
   peer0.org1.example.com:
     container_name: peer0.org1.example.com
-    image: hyperledger/fabric-peer:$IMAGE_TAG
+    image: hyperledger/fabric-peer:latest
     environment:
       #Generic peer variables
       - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
-      # the following setting starts chaincode containers on the same
-      # bridge network as the peers
-      # https://docs.docker.com/compose/networking/
       - CORE_VM_DOCKER_HOSTCONFIG_NETWORKMODE=fabric_test
       - FABRIC_LOGGING_SPEC=INFO
       #- FABRIC_LOGGING_SPEC=DEBUG
@@ -93,13 +90,10 @@ services:
 
   peer0.org2.example.com:
     container_name: peer0.org2.example.com
-    image: hyperledger/fabric-peer:$IMAGE_TAG
+    image: hyperledger/fabric-peer:latest
     environment:
       #Generic peer variables
       - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
-      # the following setting starts chaincode containers on the same
-      # bridge network as the peers
-      # https://docs.docker.com/compose/networking/
       - CORE_VM_DOCKER_HOSTCONFIG_NETWORKMODE=fabric_test
       - FABRIC_LOGGING_SPEC=INFO
       #- FABRIC_LOGGING_SPEC=DEBUG
@@ -133,7 +127,7 @@ services:
 
   cli:
     container_name: cli
-    image: hyperledger/fabric-tools:$IMAGE_TAG
+    image: hyperledger/fabric-tools:latest
     tty: true
     stdin_open: true
     environment:


### PR DESCRIPTION
Backport from main to release-2.2.

There have been lots of changes and quirks with the
docker-compose .env file, this change removes the file
and explicitly creates and assigns the networks in the
compose yaml files.

Signed-off-by: Brett Logan <lindluni@github.com>
Signed-off-by: David Enyeart <enyeart@us.ibm.com>