### PR TITLE
Fix: logspec output

### DIFF
--- a/test-network/docker/docker-compose-test-net.yaml
+++ b/test-network/docker/docker-compose-test-net.yaml
@@ -32,8 +32,6 @@ services:
       - ORDERER_GENERAL_TLS_PRIVATEKEY=/var/hyperledger/orderer/tls/server.key
       - ORDERER_GENERAL_TLS_CERTIFICATE=/var/hyperledger/orderer/tls/server.crt
       - ORDERER_GENERAL_TLS_ROOTCAS=[/var/hyperledger/orderer/tls/ca.crt]
-      - ORDERER_KAFKA_TOPIC_REPLICATIONFACTOR=1
-      - ORDERER_KAFKA_VERBOSE=true
       - ORDERER_GENERAL_CLUSTER_CLIENTCERTIFICATE=/var/hyperledger/orderer/tls/server.crt
       - ORDERER_GENERAL_CLUSTER_CLIENTPRIVATEKEY=/var/hyperledger/orderer/tls/server.key
       - ORDERER_GENERAL_CLUSTER_ROOTCAS=[/var/hyperledger/orderer/tls/ca.crt]


### PR DESCRIPTION
If ORDERER_KAFKA_VERBOSE is true, the output of /logspec will contain
the following kafka information even if it is raft orderer.
{"spec":"orderer.consensus.kafka.sarama=debug:info"}
This PR deletes environment valiable for kafka in docker-compose.

Signed-off-by: Nao Nishijima <nao.nishijima.xt@hitachi.com>