### PR TITLE
Updated dependencies for Json and fabric-chaincode-shim:2.+ in java samples

### DIFF
--- a/asset-transfer-basic/chaincode-java/build.gradle
+++ b/asset-transfer-basic/chaincode-java/build.gradle
@@ -14,7 +14,8 @@ version '1.0-SNAPSHOT'
 
 dependencies {
     
-    compileOnly 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.+'
+    implementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.+'
+    implementation 'org.json:json:+'
     implementation 'com.owlike:genson:1.5'
     testImplementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.+'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.4.2'

--- a/asset-transfer-events/chaincode-java/build.gradle
+++ b/asset-transfer-events/chaincode-java/build.gradle
@@ -13,7 +13,8 @@ group 'org.hyperledger.fabric.samples'
 version '1.0-SNAPSHOT'
 
 dependencies {
-    compileOnly 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.+'
+    implementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.+'
+    implementation 'org.json:json:+'
     testImplementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.+'
 }
 

--- a/asset-transfer-private-data/chaincode-java/build.gradle
+++ b/asset-transfer-private-data/chaincode-java/build.gradle
@@ -14,7 +14,8 @@ version '1.0-SNAPSHOT'
 
 dependencies {
     
-    compileOnly 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.+'
+    implementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.+'
+    implementation 'org.json:json:+'
 
     testImplementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.+'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.4.2'

--- a/asset-transfer-sbe/chaincode-java/build.gradle
+++ b/asset-transfer-sbe/chaincode-java/build.gradle
@@ -14,7 +14,8 @@ version '1.0-SNAPSHOT'
 
 dependencies {
     
-    compileOnly 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.+'
+    implementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.+'
+    implementation 'org.json:json:+'
     implementation 'com.owlike:genson:1.5'
     testImplementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.+'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.4.2'

--- a/asset-transfer-sbe/chaincode-java/build.gradle
+++ b/asset-transfer-sbe/chaincode-java/build.gradle
@@ -16,10 +16,11 @@ dependencies {
     
     implementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.+'
     implementation 'org.json:json:+'
-    implementation 'import org.hyperledger.fabric.protos.common'
+    implementation 'org.hyperledger.fabric.protos.common'
     implementation 'com.owlike:genson:1.5'
 
     testImplementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.+'
+    testImplementation 'org.hyperledger.fabric.protos.common'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.4.2'
     testImplementation 'org.assertj:assertj-core:3.11.1'
     testImplementation 'org.mockito:mockito-core:2.+'

--- a/asset-transfer-sbe/chaincode-java/build.gradle
+++ b/asset-transfer-sbe/chaincode-java/build.gradle
@@ -16,11 +16,11 @@ dependencies {
     
     implementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.+'
     implementation 'org.json:json:+'
-    implementation 'org.hyperledger.fabric.protos.common'
+    implementation 'com.google.protobuf:protobuf-java:3.+'
+    implementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-protos:2.+'
     implementation 'com.owlike:genson:1.5'
 
     testImplementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.+'
-    testImplementation 'org.hyperledger.fabric.protos.common'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.4.2'
     testImplementation 'org.assertj:assertj-core:3.11.1'
     testImplementation 'org.mockito:mockito-core:2.+'

--- a/asset-transfer-sbe/chaincode-java/build.gradle
+++ b/asset-transfer-sbe/chaincode-java/build.gradle
@@ -16,7 +16,9 @@ dependencies {
     
     implementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.+'
     implementation 'org.json:json:+'
+    implementation 'import org.hyperledger.fabric.protos.common'
     implementation 'com.owlike:genson:1.5'
+
     testImplementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.+'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.4.2'
     testImplementation 'org.assertj:assertj-core:3.11.1'


### PR DESCRIPTION
Json libraries were pulled into the project in fabric-chaincode-shim:2.+  BUT - they were declared in the project scope as compileOnly and/or testImplementation.
Fabric-chaincode-shim used to (2.2.3) declare the json dependency with scope compile. In 2.3.1 and 2.4.0-beta the transitive dependencies are declared as runtime, which means they won’t be available to the compiler.
Changed all java dependecies from 
"compileOnly 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.+'"
to
"implementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.+'
implementation 'org.json:json:+'"
Additionally declaration for transient dependency 'org.hyperledger.fabric.protos.common' was added
P.S. dependencies were already changed from compile only to implementatio in PR [#465](https://github.com/hyperledger/fabric-samples/pull/465) for other reason related to using fabric with microfab