### PR TITLE
System Channel missing

### DIFF
--- a/test-network/configtx/configtx.yaml
+++ b/test-network/configtx/configtx.yaml
@@ -300,6 +300,20 @@ Channel: &ChannelDefaults
 ################################################################################
 Profiles:
 
+    TwoOrgsOrdererGenesis:
+        <<: *ChannelDefaults
+        Orderer:
+            <<: *OrdererDefaults
+            Organizations:
+                - *OrdererOrg
+            Capabilities:
+                <<: *OrdererCapabilities
+        Consortiums:
+            SampleConsortium:
+                Organizations:
+                    - *Org1
+                    - *Org2
+
     TwoOrgsApplicationGenesis:
         <<: *ChannelDefaults
         Orderer:


### PR DESCRIPTION
Added missing function to generate genesis block. As far I understand , Orderer use genesis.block to start the network  but in the code genesis.block is not being generated. 

Further more when I clone this code and try to create a application channel it is falling. 