### PR TITLE
Add .env with DOCKER_SOCK variable

### DIFF
--- a/test-network/docker/.env
+++ b/test-network/docker/.env
@@ -1,0 +1,6 @@
+COMPOSE_PROJECT_NAME=net
+IMAGE_TAG=latest
+SYS_CHANNEL=system-channel
+
+# Unix socket for curl requests to Docker API
+DOCKER_SOCK=/var/run/docker.sock


### PR DESCRIPTION
Signed-off-by: Aditya Hajare <aditya43@gmail.com>

Added .env file with DOCKER_SOCK variable set to Unix socket for curl requests to Docker API.
Without this variable, following error was encountered:
```
docker-compose -f docker-compose-test-net.yaml up   
WARNING: The DOCKER_SOCK variable is not set. Defaulting to a blank string.
orderer.example.com is up-to-date
Creating peer0.org2.example.com ... error
Creating peer0.org1.example.com ... 

ERROR: for peer0.org2.example.com  Cannot create container for service peer0.org2.example.com: create .: volume name is too short, names should be at least two alphanumeric chaCreating peer0.org1.example.com ... error

ERROR: for peer0.org1.example.com  Cannot create container for service peer0.org1.example.com: create .: volume name is too short, names should be at least two alphanumeric characters

ERROR: for peer0.org2.example.com  Cannot create container for service peer0.org2.example.com: create .: volume name is too short, names should be at least two alphanumeric characters

ERROR: for peer0.org1.example.com  Cannot create container for service peer0.org1.example.com: create .: volume name is too short, names should be at least two alphanumeric characters
ERROR: Encountered errors while bringing up the project.
```