### PR TITLE
test-network: Make the regexp of checking version more strict

### DIFF
--- a/test-network/network.sh
+++ b/test-network/network.sh
@@ -53,8 +53,8 @@ function checkPrereqs() {
   fi
   # use the fabric tools container to see if the samples and binaries match your
   # docker images
-  LOCAL_VERSION=$(peer version | sed -ne 's/ Version: //p')
-  DOCKER_IMAGE_VERSION=$(docker run --rm hyperledger/fabric-tools:latest peer version | sed -ne 's/ Version: //p' | head -1)
+  LOCAL_VERSION=$(peer version | sed -ne 's/^ Version: //p')
+  DOCKER_IMAGE_VERSION=$(docker run --rm hyperledger/fabric-tools:latest peer version | sed -ne 's/^ Version: //p')
 
   infoln "LOCAL_VERSION=$LOCAL_VERSION"
   infoln "DOCKER_IMAGE_VERSION=$DOCKER_IMAGE_VERSION"


### PR DESCRIPTION
Make the regular expression of checking version more strict in `test-network/network.sh` for comparing only the main version.

If the version string (by `'peer version'`) includes other "Version: " strings, the comparing version between `LOCAL_VERSION` and `DOCKER_IMAGE_VERSION` would be failed because of the cropping by '`head -1`'.
