### PR TITLE
test-network: Make the regexp of checking version more strict (backpo…

### DIFF
--- a/asset-transfer-basic/chaincode-java/build.gradle
+++ b/asset-transfer-basic/chaincode-java/build.gradle
@@ -13,7 +13,8 @@ version '1.0-SNAPSHOT'
 
 dependencies {
     
-    compileOnly 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.+'
+    implementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.+'
+    implementation 'org.json:json:+'
     implementation 'com.owlike:genson:1.5'
     testImplementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.+'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.4.2'

--- a/asset-transfer-basic/chaincode-java/build.gradle
+++ b/asset-transfer-basic/chaincode-java/build.gradle
@@ -12,11 +12,11 @@ group 'org.hyperledger.fabric.samples'
 version '1.0-SNAPSHOT'
 
 dependencies {
-    
-    implementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.+'
+
+    implementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.2.+'
     implementation 'org.json:json:+'
     implementation 'com.owlike:genson:1.5'
-    testImplementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.+'
+    testImplementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.2.+'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.4.2'
     testImplementation 'org.assertj:assertj-core:3.11.1'
     testImplementation 'org.mockito:mockito-core:2.+'

--- a/asset-transfer-events/chaincode-java/build.gradle
+++ b/asset-transfer-events/chaincode-java/build.gradle
@@ -12,7 +12,8 @@ group 'org.hyperledger.fabric.samples'
 version '1.0-SNAPSHOT'
 
 dependencies {
-    compileOnly 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.+'
+    implementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.+'
+    implementation 'org.json:json:+'
     testImplementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.+'
 }
 

--- a/asset-transfer-events/chaincode-java/build.gradle
+++ b/asset-transfer-events/chaincode-java/build.gradle
@@ -12,9 +12,9 @@ group 'org.hyperledger.fabric.samples'
 version '1.0-SNAPSHOT'
 
 dependencies {
-    implementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.+'
+    implementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.2.+'
     implementation 'org.json:json:+'
-    testImplementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.+'
+    testImplementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.2.+'
 }
 
 repositories {

--- a/asset-transfer-private-data/chaincode-java/build.gradle
+++ b/asset-transfer-private-data/chaincode-java/build.gradle
@@ -12,11 +12,11 @@ group 'org.hyperledger.fabric.samples'
 version '1.0-SNAPSHOT'
 
 dependencies {
-    
-    implementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.+'
+
+    implementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.2.+'
     implementation 'org.json:json:+'
 
-    testImplementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.+'
+    testImplementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.2.+'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.4.2'
     testImplementation 'org.assertj:assertj-core:3.11.1'
     testImplementation 'org.mockito:mockito-core:2.+'

--- a/asset-transfer-private-data/chaincode-java/build.gradle
+++ b/asset-transfer-private-data/chaincode-java/build.gradle
@@ -13,7 +13,8 @@ version '1.0-SNAPSHOT'
 
 dependencies {
     
-    compileOnly 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.+'
+    implementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.+'
+    implementation 'org.json:json:+'
 
     testImplementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.+'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.4.2'

--- a/asset-transfer-sbe/chaincode-java/build.gradle
+++ b/asset-transfer-sbe/chaincode-java/build.gradle
@@ -12,14 +12,14 @@ group 'org.hyperledger.fabric.samples'
 version '1.0-SNAPSHOT'
 
 dependencies {
-    
-    implementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.+'
+
+    implementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.2.+'
     implementation 'org.json:json:+'
     implementation 'com.google.protobuf:protobuf-java:3.+'
-    implementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-protos:2.+'
+    implementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-protos:2.2.+'
     implementation 'com.owlike:genson:1.5'
 
-    testImplementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.+'
+    testImplementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.2.+'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.4.2'
     testImplementation 'org.assertj:assertj-core:3.11.1'
     testImplementation 'org.mockito:mockito-core:2.+'

--- a/asset-transfer-sbe/chaincode-java/build.gradle
+++ b/asset-transfer-sbe/chaincode-java/build.gradle
@@ -13,8 +13,12 @@ version '1.0-SNAPSHOT'
 
 dependencies {
     
-    compileOnly 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.+'
+    implementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.+'
+    implementation 'org.json:json:+'
+    implementation 'com.google.protobuf:protobuf-java:3.+'
+    implementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-protos:2.+'
     implementation 'com.owlike:genson:1.5'
+
     testImplementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.+'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.4.2'
     testImplementation 'org.assertj:assertj-core:3.11.1'

--- a/test-network/network.sh
+++ b/test-network/network.sh
@@ -61,8 +61,8 @@ function checkPrereqs() {
   fi
   # use the fabric tools container to see if the samples and binaries match your
   # docker images
-  LOCAL_VERSION=$(peer version | sed -ne 's/ Version: //p')
-  DOCKER_IMAGE_VERSION=$(docker run --rm hyperledger/fabric-tools:$IMAGETAG peer version | sed -ne 's/ Version: //p' | head -1)
+  LOCAL_VERSION=$(peer version | sed -ne 's/^ Version: //p')
+  DOCKER_IMAGE_VERSION=$(docker run --rm hyperledger/fabric-tools:$IMAGETAG peer version | sed -ne 's/^ Version: //p')
 
   infoln "LOCAL_VERSION=$LOCAL_VERSION"
   infoln "DOCKER_IMAGE_VERSION=$DOCKER_IMAGE_VERSION"


### PR DESCRIPTION
(Backport #515)

Make the regular expression of checking version more strict in `test-network/network.sh` for comparing only the main version.

If the version string (by `'peer version'`) includes other "Version: " strings, the comparing version between `LOCAL_VERSION` and `DOCKER_IMAGE_VERSION` would be failed because of the cropping by '`head -1`'.
