### PR TITLE
Allow overrides of the docker registry for fabric images

### DIFF
--- a/test-network-k8s/kube/org0/org0-admin-cli.yaml
+++ b/test-network-k8s/kube/org0/org0-admin-cli.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: main
-          image: hyperledger/fabric-tools:{{FABRIC_VERSION}}
+          image: {{FABRIC_CONTAINER_REGISTRY}}/fabric-tools:{{FABRIC_VERSION}}
           imagePullPolicy: IfNotPresent
           env:
             - name: FABRIC_CFG_PATH

--- a/test-network-k8s/kube/org0/org0-ecert-ca.yaml
+++ b/test-network-k8s/kube/org0/org0-ecert-ca.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: main
-          image: hyperledger/fabric-ca:1.5.2
+          image: {{FABRIC_CONTAINER_REGISTRY}}/fabric-ca:{{FABRIC_CA_VERSION}}
           env:
             - name: FABRIC_CA_SERVER_CA_NAME
               value: "org0-ecert-ca"

--- a/test-network-k8s/kube/org0/org0-orderer1.yaml
+++ b/test-network-k8s/kube/org0/org0-orderer1.yaml
@@ -43,8 +43,8 @@ spec:
     spec:
       containers:
         - name: main
-          image: hyperledger/fabric-orderer:{{FABRIC_VERSION}}
-          imagePullPolicy: IfNotPresent
+          image: {{FABRIC_CONTAINER_REGISTRY}}/fabric-orderer:{{FABRIC_VERSION}}
+          imagePullPolicy: Always
           envFrom:
             - configMapRef:
                 name: org0-orderer1-env

--- a/test-network-k8s/kube/org0/org0-orderer2.yaml
+++ b/test-network-k8s/kube/org0/org0-orderer2.yaml
@@ -43,8 +43,8 @@ spec:
     spec:
       containers:
         - name: main
-          image: hyperledger/fabric-orderer:{{FABRIC_VERSION}}
-          imagePullPolicy: IfNotPresent
+          image: {{FABRIC_CONTAINER_REGISTRY}}/fabric-orderer:{{FABRIC_VERSION}}
+          imagePullPolicy: Always
           envFrom:
             - configMapRef:
                 name: org0-orderer2-env

--- a/test-network-k8s/kube/org0/org0-orderer3.yaml
+++ b/test-network-k8s/kube/org0/org0-orderer3.yaml
@@ -43,8 +43,8 @@ spec:
     spec:
       containers:
         - name: main
-          image: hyperledger/fabric-orderer:{{FABRIC_VERSION}}
-          imagePullPolicy: IfNotPresent
+          image: {{FABRIC_CONTAINER_REGISTRY}}/fabric-orderer:{{FABRIC_VERSION}}
+          imagePullPolicy: Always
           envFrom:
             - configMapRef:
                 name: org0-orderer3-env

--- a/test-network-k8s/kube/org0/org0-tls-ca.yaml
+++ b/test-network-k8s/kube/org0/org0-tls-ca.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: main
-          image: hyperledger/fabric-ca:1.5.2
+          image: {{FABRIC_CONTAINER_REGISTRY}}/fabric-ca:{{FABRIC_CA_VERSION}}
           env:
             - name: FABRIC_CA_SERVER_CA_NAME
               value: "org0-tls-ca"

--- a/test-network-k8s/kube/org1/org1-admin-cli.yaml
+++ b/test-network-k8s/kube/org1/org1-admin-cli.yaml
@@ -20,8 +20,8 @@ spec:
     spec:
       containers:
         - name: main
-          image: hyperledger/fabric-tools:{{FABRIC_VERSION}}
-          imagePullPolicy: IfNotPresent
+          image: {{FABRIC_CONTAINER_REGISTRY}}/fabric-tools:{{FABRIC_VERSION}}
+          imagePullPolicy: Always
           env:
             - name: FABRIC_CFG_PATH
               value: /var/hyperledger/fabric/config

--- a/test-network-k8s/kube/org1/org1-ecert-ca.yaml
+++ b/test-network-k8s/kube/org1/org1-ecert-ca.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: main
-          image: hyperledger/fabric-ca:1.5.2
+          image: {{FABRIC_CONTAINER_REGISTRY}}/fabric-ca:{{FABRIC_CA_VERSION}}
           env:
             - name: FABRIC_CA_SERVER_CA_NAME
               value: "org1-ecert-ca"

--- a/test-network-k8s/kube/org1/org1-peer1.yaml
+++ b/test-network-k8s/kube/org1/org1-peer1.yaml
@@ -46,8 +46,8 @@ spec:
     spec:
       containers:
         - name: main
-          image: hyperledger/fabric-peer:{{FABRIC_VERSION}}
-          imagePullPolicy: IfNotPresent
+          image: {{FABRIC_CONTAINER_REGISTRY}}/fabric-peer:{{FABRIC_VERSION}}
+          imagePullPolicy: Always
           envFrom:
             - configMapRef:
                 name: org1-peer1-config
@@ -67,7 +67,7 @@ spec:
       initContainers:
         - name: fabric-ccs-builder
           image: ghcr.io/hyperledgendary/fabric-ccs-builder
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           command: [sh, -c]
           args: ["cp /go/bin/* /var/hyperledger/fabric/chaincode/ccs-builder/bin/"]
           volumeMounts:

--- a/test-network-k8s/kube/org1/org1-peer2.yaml
+++ b/test-network-k8s/kube/org1/org1-peer2.yaml
@@ -46,8 +46,8 @@ spec:
     spec:
       containers:
         - name: main
-          image: hyperledger/fabric-peer:{{FABRIC_VERSION}}
-          imagePullPolicy: IfNotPresent
+          image: {{FABRIC_CONTAINER_REGISTRY}}/fabric-peer:{{FABRIC_VERSION}}
+          imagePullPolicy: Always
           envFrom:
             - configMapRef:
                 name: org1-peer2-config

--- a/test-network-k8s/kube/org1/org1-tls-ca.yaml
+++ b/test-network-k8s/kube/org1/org1-tls-ca.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: main
-          image: hyperledger/fabric-ca:1.5.2
+          image: {{FABRIC_CONTAINER_REGISTRY}}/fabric-ca:{{FABRIC_CA_VERSION}}
           env:
             - name: FABRIC_CA_SERVER_CA_NAME
               value: "org1-tls-ca"

--- a/test-network-k8s/kube/org2/org2-admin-cli.yaml
+++ b/test-network-k8s/kube/org2/org2-admin-cli.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: main
-          image: hyperledger/fabric-tools:{{FABRIC_VERSION}}
+          image: {{FABRIC_CONTAINER_REGISTRY}}/fabric-tools:{{FABRIC_VERSION}}
           imagePullPolicy: IfNotPresent
           env:
             - name: FABRIC_CFG_PATH

--- a/test-network-k8s/kube/org2/org2-ecert-ca.yaml
+++ b/test-network-k8s/kube/org2/org2-ecert-ca.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: main
-          image: hyperledger/fabric-ca:1.5.2
+          image: {{FABRIC_CONTAINER_REGISTRY}}/fabric-ca:{{FABRIC_CA_VERSION}}
           env:
             - name: FABRIC_CA_SERVER_CA_NAME
               value: "org2-ecert-ca"

--- a/test-network-k8s/kube/org2/org2-peer1.yaml
+++ b/test-network-k8s/kube/org2/org2-peer1.yaml
@@ -46,7 +46,7 @@ spec:
     spec:
       containers:
         - name: main
-          image: hyperledger/fabric-peer:{{FABRIC_VERSION}}
+          image: {{FABRIC_CONTAINER_REGISTRY}}/fabric-peer:{{FABRIC_VERSION}}
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:

--- a/test-network-k8s/kube/org2/org2-peer2.yaml
+++ b/test-network-k8s/kube/org2/org2-peer2.yaml
@@ -46,7 +46,7 @@ spec:
     spec:
       containers:
         - name: main
-          image: hyperledger/fabric-peer:{{FABRIC_VERSION}}
+          image: {{FABRIC_CONTAINER_REGISTRY}}/fabric-peer:{{FABRIC_VERSION}}
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:

--- a/test-network-k8s/kube/org2/org2-tls-ca.yaml
+++ b/test-network-k8s/kube/org2/org2-tls-ca.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: main
-          image: hyperledger/fabric-ca:1.5.2
+          image: {{FABRIC_CONTAINER_REGISTRY}}/fabric-ca:{{FABRIC_CA_VERSION}}
           env:
             - name: FABRIC_CA_SERVER_CA_NAME
               value: "org2-tls-ca"

--- a/test-network-k8s/network
+++ b/test-network-k8s/network
@@ -15,21 +15,22 @@ set -o errexit
 # todo: user:pass auth for tls and ecert bootstrap admins.  here and in the server-config.yaml
 # todo: set tls.certfiles= ... arg in deployment env / yaml
 # todo: refactor chaincode install to support other chaincode routines
-# todo: actually compile the chaincode archive, rather than reading a pre-canned one from chaincode/*.tgz (use sha256 to get CC ID)
 # todo: consider using templates for boilerplate network nodes (orderers, peers, ...)
 # todo: allow the user to specify the chaincode name (hardcoded as 'basic') both in install and invoke/query
 # todo: track down a nasty bug whereby the CA service endpoints (kube services) will occasionally reject TCP connections after network down/up.  This is patched by introducing a 10s sleep after the deployments are up...
 # todo: refactor query/invoke to specify chaincode name (-n param)
 
 FABRIC_VERSION=${TEST_NETWORK_FABRIC_VERSION:-2.3.2}
+FABRIC_CA_VERSION=${TEST_NETWORK_FABRIC_CA_VERSION:-1.5.2}
+FABRIC_CONTAINER_REGISTRY=${TEST_NETWORK_FABRIC_CONTAINER_REGISTRY:-hyperledger}
 NETWORK_NAME=${TEST_NETWORK_NAME:-test-network}
 CLUSTER_NAME=${TEST_NETWORK_KIND_CLUSTER_NAME:-kind}
 NS=${TEST_NETWORK_KUBE_NAMESPACE:-${NETWORK_NAME}}
 CHANNEL_NAME=${TEST_NETWORK_CHANNEL_NAME:-mychannel}
 LOG_FILE=${TEST_NETWORK_LOG_FILE:-network.log}
 DEBUG_FILE=${TEST_NETWORK_DEBUG_FILE:-network-debug.log}
-CONTAINER_REGISTRY_NAME=${TEST_NETWORK_CONTAINER_REGISTRY_NAME:-kind-registry}
-CONTAINER_REGISTRY_PORT=${TEST_NETWORK_CONTAINER_REGISTRY_PORT:-5000}
+LOCAL_REGISTRY_NAME=${TEST_NETWORK_LOCAL_REGISTRY_NAME:-kind-registry}
+LOCAL_REGISTRY_PORT=${TEST_NETWORK_LOCAL_REGISTRY_PORT:-5000}
 NGINX_HTTP_PORT=${TEST_NETWORK_INGRESS_HTTP_PORT:-80}
 NGINX_HTTPS_PORT=${TEST_NETWORK_INGRESS_HTTPS_PORT:-443}
 CHAINCODE_NAME=${TEST_NETWORK_CHAINCODE_NAME:-asset-transfer-basic}
@@ -37,7 +38,6 @@ CHAINCODE_IMAGE=${TEST_NETWORK_CHAINCODE_IMAGE:-ghcr.io/hyperledgendary/fabric-c
 CHAINCODE_LABEL=${TEST_NETWORK_CHAINCODE_LABEL:-basic_1.0}
 
 # todo: more complicated config, as these bleed into the yaml descriptors (sed? kustomize? helm (no)? tkn? ansible?...) or other script locations
-FABRIC_CA_VERSION=1.5.2
 TLSADMIN_AUTH=tlsadmin:tlsadminpw
 RCAADMIN_AUTH=rcaadmin:rcaadminpw
 

--- a/test-network-k8s/scripts/channel.sh
+++ b/test-network-k8s/scripts/channel.sh
@@ -69,9 +69,9 @@ function aggregate_channel_MSP() {
 function launch_admin_CLIs() {
   push_fn "Launching admin CLIs"
 
-  cat kube/org0/org0-admin-cli.yaml | sed 's,{{FABRIC_VERSION}},'${FABRIC_VERSION}',g' | kubectl -n $NS apply -f -
-  cat kube/org1/org1-admin-cli.yaml | sed 's,{{FABRIC_VERSION}},'${FABRIC_VERSION}',g' | kubectl -n $NS apply -f -
-  cat kube/org2/org2-admin-cli.yaml | sed 's,{{FABRIC_VERSION}},'${FABRIC_VERSION}',g' | kubectl -n $NS apply -f -
+  launch kube/org0/org0-admin-cli.yaml
+  launch kube/org1/org1-admin-cli.yaml
+  launch kube/org2/org2-admin-cli.yaml
 
   kubectl -n $NS rollout status deploy/org0-admin-cli
   kubectl -n $NS rollout status deploy/org1-admin-cli

--- a/test-network-k8s/scripts/fabric_CAs.sh
+++ b/test-network-k8s/scripts/fabric_CAs.sh
@@ -5,12 +5,20 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+function launch_CA() {
+  local yaml=$1
+  cat ${yaml} \
+    | sed 's,{{FABRIC_CONTAINER_REGISTRY}},'${FABRIC_CONTAINER_REGISTRY}',g' \
+    | sed 's,{{FABRIC_CA_VERSION}},'${FABRIC_CA_VERSION}',g' \
+    | kubectl -n $NS apply -f -
+}
+
 function launch_TLS_CAs() {
   push_fn "Launching TLS CAs"
 
-  kubectl -n $NS apply -f kube/org0/org0-tls-ca.yaml
-  kubectl -n $NS apply -f kube/org1/org1-tls-ca.yaml
-  kubectl -n $NS apply -f kube/org2/org2-tls-ca.yaml
+  launch_CA kube/org0/org0-tls-ca.yaml
+  launch_CA kube/org1/org1-tls-ca.yaml
+  launch_CA kube/org2/org2-tls-ca.yaml
 
   kubectl -n $NS rollout status deploy/org0-tls-ca
   kubectl -n $NS rollout status deploy/org1-tls-ca
@@ -25,9 +33,9 @@ function launch_TLS_CAs() {
 function launch_ECert_CAs() {
   push_fn "Launching ECert CAs"
 
-  kubectl -n $NS apply -f kube/org0/org0-ecert-ca.yaml
-  kubectl -n $NS apply -f kube/org1/org1-ecert-ca.yaml
-  kubectl -n $NS apply -f kube/org2/org2-ecert-ca.yaml
+  launch_CA kube/org0/org0-ecert-ca.yaml
+  launch_CA kube/org1/org1-ecert-ca.yaml
+  launch_CA kube/org2/org2-ecert-ca.yaml
 
   kubectl -n $NS rollout status deploy/org0-ecert-ca
   kubectl -n $NS rollout status deploy/org1-ecert-ca

--- a/test-network-k8s/scripts/kind.sh
+++ b/test-network-k8s/scripts/kind.sh
@@ -5,17 +5,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-function pull_docker_images() {
-  push_fn "Pulling docker images for Fabric ${FABRIC_VERSION}"
-
-  docker pull hyperledger/fabric-ca:$FABRIC_CA_VERSION
-  docker pull hyperledger/fabric-orderer:$FABRIC_VERSION
-  docker pull hyperledger/fabric-peer:$FABRIC_VERSION
-  docker pull hyperledger/fabric-tools:$FABRIC_VERSION
-
-  pop_fn
-}
-
 function apply_nginx_ingress() {
   push_fn "Launching Nginx ingress controller"
 
@@ -34,8 +23,8 @@ function kind_create() {
   # todo: always delete?  Maybe return no-op if the cluster already exists?
   kind delete cluster --name $CLUSTER_NAME
 
-  local reg_name=${CONTAINER_REGISTRY_NAME}
-  local reg_port=${CONTAINER_REGISTRY_PORT}
+  local reg_name=${LOCAL_REGISTRY_NAME}
+  local reg_port=${LOCAL_REGISTRY_PORT}
   local ingress_http_port=${NGINX_HTTP_PORT}
   local ingress_https_port=${NGINX_HTTPS_PORT}
 
@@ -71,11 +60,11 @@ EOF
 }
 
 function launch_docker_registry() {
-  push_fn "Launching container registry \"${CONTAINER_REGISTRY_NAME}\" at localhost:${CONTAINER_REGISTRY_PORT}"
+  push_fn "Launching container registry \"${LOCAL_REGISTRY_NAME}\" at localhost:${LOCAL_REGISTRY_PORT}"
 
   # create registry container unless it already exists
-  local reg_name=${CONTAINER_REGISTRY_NAME}
-  local reg_port=${CONTAINER_REGISTRY_PORT}
+  local reg_name=${LOCAL_REGISTRY_NAME}
+  local reg_port=${LOCAL_REGISTRY_PORT}
 
   running="$(docker inspect -f '{{.State.Running}}' "${reg_name}" 2>/dev/null || true)"
   if [ "${running}" != 'true' ]; then
@@ -123,7 +112,6 @@ function kind_init() {
   # todo: how to pass this through to push_fn ?
   set -o errexit
 
-  pull_docker_images
   kind_create
   apply_nginx_ingress
   launch_docker_registry

--- a/test-network-k8s/scripts/test_network.sh
+++ b/test-network-k8s/scripts/test_network.sh
@@ -10,7 +10,10 @@
 
 function launch() {
   local yaml=$1
-  cat ${yaml} | sed 's,{{FABRIC_VERSION}},'${FABRIC_VERSION}',g' | kubectl -n $NS apply -f -
+  cat ${yaml} \
+    | sed 's,{{FABRIC_CONTAINER_REGISTRY}},'${FABRIC_CONTAINER_REGISTRY}',g' \
+    | sed 's,{{FABRIC_VERSION}},'${FABRIC_VERSION}',g' \
+    | kubectl -n $NS apply -f -
 }
 
 function launch_orderers() {


### PR DESCRIPTION
The test-network-k8s had some cruft related to a build/edit/test workflow revolving around the KIND image plane to load docker Images into the cluster.  This change allows users to update the remote docker registry and run Fabric with: 

- The latest CI/CD images.  E.g.: 
```
export TEST_NETWORK_FABRIC_CA_VERSION="amd64-latest"
export TEST_NETWORK_FABRIC_CONTAINER_REGISTRY="hyperledger-fabric.jfrog.io"
export TEST_NETWORK_FABRIC_VERSION="amd64-latest"

./network up 
``` 


- Custom images created on a local workstation.  E.g.: 
```
fabric $ make docker 
fabric $ docker tag hyperledger/fabric-peer localhost:5000/hyperledger/fabic-peer:my-fancy-tag 
fabric $ docker push localhost:5000/hyperledger/fabric-peer:my-fancy-tag
...

test-network-k8s $ export TEST_NETWORK_FABRIC_CONTAINER_REGISTRY=localhost:5000/hyperledger 
test-network-k8s $ export TEST_NETWORK_FABRIC_VERSION=my-fancy-tag 

./network up 
```

Signed-off-by: Josh Kneubuhl <jkneubuh@us.ibm.com>