### PR TITLE
Adding examples of CCAAS and support into the test-network-k8s

### DIFF
--- a/test-network-k8s/chaincode/asset-transfer-basic/connection.json
+++ b/test-network-k8s/chaincode/asset-transfer-basic/connection.json
@@ -1,5 +1,5 @@
 {
-  "address": "org1-cc-asset-transfer-basic:9999",
+  "address": "{{.peername}}-cc-asset-transfer-basic:9999",
   "dial_timeout": "10s",
   "tls_required": false
 }

--- a/test-network-k8s/chaincode/asset-transfer-basic/metadata.json
+++ b/test-network-k8s/chaincode/asset-transfer-basic/metadata.json
@@ -1,4 +1,4 @@
 {
-  "type": "external",
+  "type": "ccaas",
   "label": "basic_1.0"
 }

--- a/test-network-k8s/config/org1/core.yaml
+++ b/test-network-k8s/config/org1/core.yaml
@@ -474,7 +474,7 @@ vm:
     # unix:///var/run/docker.sock
     # http://localhost:2375
     # https://localhost:2376
-    endpoint: unix:///var/run/docker.sock
+    # endpoint: unix:///var/run/docker.sock
 
     # settings for docker vms
     docker:
@@ -558,12 +558,11 @@ chaincode:
     # chaincode. The external builder detection processing will iterate over the
     # builders in the order specified below.
     externalBuilders:
-      - path: /var/hyperledger/fabric/chaincode/ccs-builder
-        name: ccs-builder
-        propagateEnvironment:
-          - HOME
-          - CORE_PEER_ID
-          - CORE_PEER_LOCALMSPID
+       - name: ccaas_builder
+         path: /opt/hyperledger/ccaas_builder
+         propagateEnvironment:
+           - CHAINCODE_AS_A_SERVICE_BUILDER_CONFIG
+
 
     # The maximum duration to wait for the chaincode build and install process
     # to complete.

--- a/test-network-k8s/config/org2/core.yaml
+++ b/test-network-k8s/config/org2/core.yaml
@@ -558,13 +558,11 @@ chaincode:
     # chaincode. The external builder detection processing will iterate over the
     # builders in the order specified below.
     externalBuilders:
-      - path: /var/hyperledger/fabric/chaincode/ccs-builder
-        name: ccs-builder
-        propagateEnvironment:
-          - HOME
-          - CORE_PEER_ID
-          - CORE_PEER_LOCALMSPID
-
+       - name: ccaas_builder
+         path: /opt/hyperledger/ccaas_builder
+         propagateEnvironment:
+           - CHAINCODE_AS_A_SERVICE_BUILDER_CONFIG
+          
     # The maximum duration to wait for the chaincode build and install process
     # to complete.
     installTimeout: 300s

--- a/test-network-k8s/kube/org1/org1-cc-template.yaml
+++ b/test-network-k8s/kube/org1/org1-cc-template.yaml
@@ -7,16 +7,16 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: org1-cc-{{CHAINCODE_NAME}}
+  name: org1{{PEER_NAME}}-cc-{{CHAINCODE_NAME}}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: org1-cc-{{CHAINCODE_NAME}}
+      app: org1{{PEER_NAME}}-cc-{{CHAINCODE_NAME}}
   template:
     metadata:
       labels:
-        app: org1-cc-{{CHAINCODE_NAME}}
+        app: org1{{PEER_NAME}}-cc-{{CHAINCODE_NAME}}
     spec:
       containers:
         - name: main
@@ -35,11 +35,11 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: org1-cc-{{CHAINCODE_NAME}}
+  name: org1{{PEER_NAME}}-cc-{{CHAINCODE_NAME}}
 spec:
   ports:
     - name: chaincode
       port: 9999
       protocol: TCP
   selector:
-    app: org1-cc-{{CHAINCODE_NAME}}
+    app: org1{{PEER_NAME}}-cc-{{CHAINCODE_NAME}}

--- a/test-network-k8s/kube/org1/org1-peer1.yaml
+++ b/test-network-k8s/kube/org1/org1-peer1.yaml
@@ -28,7 +28,7 @@ data:
   CORE_OPERATIONS_LISTENADDRESS: 0.0.0.0:9443
   CORE_PEER_FILESYSTEMPATH: /var/hyperledger/fabric/data/org1-peer1.org1.example.com
   CORE_LEDGER_SNAPSHOTS_ROOTDIR: /var/hyperledger/fabric/data/org1-peer1.org1.example.com/snapshots
-
+  CHAINCODE_AS_A_SERVICE_BUILDER_CONFIG: "{\"peername\":\"org1peer1\"}"
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -61,20 +61,6 @@ spec:
               mountPath: /var/hyperledger
             - name: fabric-config
               mountPath: /var/hyperledger/fabric/config
-            - name: ccs-builder
-              mountPath: /var/hyperledger/fabric/chaincode/ccs-builder/bin
-
-      # load the external chaincode builder into the peer image prior to peer launch.
-      initContainers:
-        - name: fabric-ccs-builder
-          image: ghcr.io/hyperledgendary/fabric-ccs-builder
-          imagePullPolicy: IfNotPresent
-          command: [sh, -c]
-          args: ["cp /go/bin/* /var/hyperledger/fabric/chaincode/ccs-builder/bin/"]
-          volumeMounts:
-            - name: ccs-builder
-              mountPath: /var/hyperledger/fabric/chaincode/ccs-builder/bin
-
       volumes:
         - name: fabric-volume
           persistentVolumeClaim:
@@ -82,8 +68,7 @@ spec:
         - name: fabric-config
           configMap:
             name: org1-config
-        - name: ccs-builder
-          emptyDir: {}
+
 ---
 apiVersion: v1
 kind: Service

--- a/test-network-k8s/kube/org1/org1-peer2.yaml
+++ b/test-network-k8s/kube/org1/org1-peer2.yaml
@@ -28,7 +28,7 @@ data:
   CORE_OPERATIONS_LISTENADDRESS: 0.0.0.0:9443
   CORE_PEER_FILESYSTEMPATH: /var/hyperledger/fabric/data/org1-peer2.org1.example.com
   CORE_LEDGER_SNAPSHOTS_ROOTDIR: /var/hyperledger/fabric/data/org1-peer2.org1.example.com/snapshots
-
+  CHAINCODE_AS_A_SERVICE_BUILDER_CONFIG: "{\"peername\":\"org1peer2\"}"
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/test-network-k8s/kube/org2/org2-peer1.yaml
+++ b/test-network-k8s/kube/org2/org2-peer1.yaml
@@ -28,7 +28,7 @@ data:
   CORE_OPERATIONS_LISTENADDRESS: 0.0.0.0:9443
   CORE_PEER_FILESYSTEMPATH: /var/hyperledger/fabric/data/org2-peer1.org2.example.com
   CORE_LEDGER_SNAPSHOTS_ROOTDIR: /var/hyperledger/fabric/data/org2-peer1.org2.example.com/snapshots
-
+  CHAINCODE_AS_A_SERVICE_BUILDER_CONFIG: "{\"peername\":\"org2peer1\"}"
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/test-network-k8s/kube/org2/org2-peer1.yaml
+++ b/test-network-k8s/kube/org2/org2-peer1.yaml
@@ -61,20 +61,6 @@ spec:
               mountPath: /var/hyperledger
             - name: fabric-config
               mountPath: /var/hyperledger/fabric/config
-            - name: ccs-builder
-              mountPath: /var/hyperledger/fabric/chaincode/ccs-builder/bin
-
-      # load the external chaincode builder into the peer image prior to peer launch.
-      initContainers:
-        - name: fabric-ccs-builder
-          image: ghcr.io/hyperledgendary/fabric-ccs-builder
-          imagePullPolicy: IfNotPresent
-          command: [sh, -c]
-          args: ["cp /go/bin/* /var/hyperledger/fabric/chaincode/ccs-builder/bin/"]
-          volumeMounts:
-            - name: ccs-builder
-              mountPath: /var/hyperledger/fabric/chaincode/ccs-builder/bin
-
       volumes:
         - name: fabric-volume
           persistentVolumeClaim:
@@ -82,8 +68,6 @@ spec:
         - name: fabric-config
           configMap:
             name: org2-config
-        - name: ccs-builder
-          emptyDir: {}
 
 ---
 apiVersion: v1

--- a/test-network-k8s/kube/org2/org2-peer2.yaml
+++ b/test-network-k8s/kube/org2/org2-peer2.yaml
@@ -28,7 +28,7 @@ data:
   CORE_OPERATIONS_LISTENADDRESS: 0.0.0.0:9443
   CORE_PEER_FILESYSTEMPATH: /var/hyperledger/fabric/data/org2-peer2.org2.example.com
   CORE_LEDGER_SNAPSHOTS_ROOTDIR: /var/hyperledger/fabric/data/org2-peer2.org2.example.com/snapshots
-
+  CHAINCODE_AS_A_SERVICE_BUILDER_CONFIG: "{\"peername\":\"org2peer2\"}"
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/test-network-k8s/network
+++ b/test-network-k8s/network
@@ -20,7 +20,7 @@ set -o errexit
 # todo: track down a nasty bug whereby the CA service endpoints (kube services) will occasionally reject TCP connections after network down/up.  This is patched by introducing a 10s sleep after the deployments are up...
 # todo: refactor query/invoke to specify chaincode name (-n param)
 
-FABRIC_VERSION=${TEST_NETWORK_FABRIC_VERSION:-2.3.2}
+FABRIC_VERSION=${TEST_NETWORK_FABRIC_VERSION:-2.4.1}
 FABRIC_CA_VERSION=${TEST_NETWORK_FABRIC_CA_VERSION:-1.5.2}
 FABRIC_CONTAINER_REGISTRY=${TEST_NETWORK_FABRIC_CONTAINER_REGISTRY:-hyperledger}
 NETWORK_NAME=${TEST_NETWORK_NAME:-test-network}

--- a/test-network-k8s/scripts/kind.sh
+++ b/test-network-k8s/scripts/kind.sh
@@ -12,7 +12,6 @@ function pull_docker_images() {
   docker pull ${FABRIC_CONTAINER_REGISTRY}/fabric-orderer:$FABRIC_VERSION
   docker pull ${FABRIC_CONTAINER_REGISTRY}/fabric-peer:$FABRIC_VERSION
   docker pull ${FABRIC_CONTAINER_REGISTRY}/fabric-tools:$FABRIC_VERSION
-  docker pull ghcr.io/hyperledgendary/fabric-ccs-builder:latest
   docker pull ghcr.io/hyperledgendary/fabric-ccaas-asset-transfer-basic:latest
 
   pop_fn
@@ -25,7 +24,6 @@ function load_docker_images() {
   kind load docker-image ${FABRIC_CONTAINER_REGISTRY}/fabric-orderer:$FABRIC_VERSION
   kind load docker-image ${FABRIC_CONTAINER_REGISTRY}/fabric-peer:$FABRIC_VERSION
   kind load docker-image ${FABRIC_CONTAINER_REGISTRY}/fabric-tools:$FABRIC_VERSION
-  kind load docker-image ghcr.io/hyperledgendary/fabric-ccs-builder:latest
   kind load docker-image ghcr.io/hyperledgendary/fabric-ccaas-asset-transfer-basic:latest
   
   pop_fn 

--- a/test-network/scripts/deployCC.sh
+++ b/test-network/scripts/deployCC.sh
@@ -44,8 +44,8 @@ elif [ -z "$CC_SRC_LANGUAGE" ] || [ "$CC_SRC_LANGUAGE" = "NA" ]; then
   fatalln "No chaincode language was provided. Valid call example: ./network.sh deployCC -ccn basic -ccp ../asset-transfer-basic/chaincode-go -ccl go"
 
 ## Make sure that the path to the chaincode exists
-elif [ ! -d "$CC_SRC_PATH" ]; then
-  fatalln "Path to chaincode does not exist. Please provide different path."
+elif [ ! -d "$CC_SRC_PATH" ] && [ ! -f "$CC_SRC_PATH" ]; then
+  fatalln "dfghPath to chaincode does not exist. Please provide different path."
 fi
 
 CC_SRC_LANGUAGE=$(echo "$CC_SRC_LANGUAGE" | tr [:upper:] [:lower:])


### PR DESCRIPTION
Using the variant of the peer's docker container from https://github.com/hyperledger/fabric/pull/2990  this PR adapts the K8S deployment to use this inbuilt chaincode builder.

- creates two deployments of the chaincode for each peer
- uses the builders ability to template the fields in the connection.json

Signed-off-by: Matthew B White <whitemat@uk.ibm.com>