### PR TITLE
Add an option to stage docker images locally to KIND

### DIFF
--- a/test-network-k8s/docs/TEST_NETWORK.md
+++ b/test-network-k8s/docs/TEST_NETWORK.md
@@ -135,7 +135,7 @@ from a public container registry, copying the external builders into the target 
 ```yaml
       initContainers:
         - name: fabric-ccs-builder
-          image: {{LOCAL_CONTAINER_REGISTRY}}/fabric-ccs-builder
+          image: {{FABRIC_CONTAINER_REGISTRY}}/fabric-ccs-builder
           command: [sh, -c]
           args: ["cp /go/bin/* /var/hyperledger/fabric/chaincode/ccs-builder/bin/"]
           volumeMounts:

--- a/test-network-k8s/kube/org0/org0-admin-cli.yaml
+++ b/test-network-k8s/kube/org0/org0-admin-cli.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: main
-          image: {{LOCAL_CONTAINER_REGISTRY}}/fabric-tools:{{FABRIC_VERSION}}
+          image: {{FABRIC_CONTAINER_REGISTRY}}/fabric-tools:{{FABRIC_VERSION}}
           imagePullPolicy: IfNotPresent
           env:
             - name: FABRIC_CFG_PATH

--- a/test-network-k8s/kube/org0/org0-ecert-ca.yaml
+++ b/test-network-k8s/kube/org0/org0-ecert-ca.yaml
@@ -20,7 +20,8 @@ spec:
     spec:
       containers:
         - name: main
-          image: {{LOCAL_CONTAINER_REGISTRY}}/fabric-ca:{{FABRIC_CA_VERSION}}
+          image: {{FABRIC_CONTAINER_REGISTRY}}/fabric-ca:{{FABRIC_CA_VERSION}}
+          imagePullPolicy: IfNotPresent
           env:
             - name: FABRIC_CA_SERVER_CA_NAME
               value: "org0-ecert-ca"

--- a/test-network-k8s/kube/org0/org0-orderer1.yaml
+++ b/test-network-k8s/kube/org0/org0-orderer1.yaml
@@ -43,8 +43,8 @@ spec:
     spec:
       containers:
         - name: main
-          image: {{LOCAL_CONTAINER_REGISTRY}}/fabric-orderer:{{FABRIC_VERSION}}
-          imagePullPolicy: Always
+          image: {{FABRIC_CONTAINER_REGISTRY}}/fabric-orderer:{{FABRIC_VERSION}}
+          imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:
                 name: org0-orderer1-env

--- a/test-network-k8s/kube/org0/org0-orderer2.yaml
+++ b/test-network-k8s/kube/org0/org0-orderer2.yaml
@@ -43,8 +43,8 @@ spec:
     spec:
       containers:
         - name: main
-          image: {{LOCAL_CONTAINER_REGISTRY}}/fabric-orderer:{{FABRIC_VERSION}}
-          imagePullPolicy: Always
+          image: {{FABRIC_CONTAINER_REGISTRY}}/fabric-orderer:{{FABRIC_VERSION}}
+          imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:
                 name: org0-orderer2-env

--- a/test-network-k8s/kube/org0/org0-orderer3.yaml
+++ b/test-network-k8s/kube/org0/org0-orderer3.yaml
@@ -43,8 +43,8 @@ spec:
     spec:
       containers:
         - name: main
-          image: {{LOCAL_CONTAINER_REGISTRY}}/fabric-orderer:{{FABRIC_VERSION}}
-          imagePullPolicy: Always
+          image: {{FABRIC_CONTAINER_REGISTRY}}/fabric-orderer:{{FABRIC_VERSION}}
+          imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:
                 name: org0-orderer3-env

--- a/test-network-k8s/kube/org0/org0-tls-ca.yaml
+++ b/test-network-k8s/kube/org0/org0-tls-ca.yaml
@@ -20,7 +20,8 @@ spec:
     spec:
       containers:
         - name: main
-          image: {{LOCAL_CONTAINER_REGISTRY}}/fabric-ca:{{FABRIC_CA_VERSION}}
+          image: {{FABRIC_CONTAINER_REGISTRY}}/fabric-ca:{{FABRIC_CA_VERSION}}
+          imagePullPolicy: IfNotPresent
           env:
             - name: FABRIC_CA_SERVER_CA_NAME
               value: "org0-tls-ca"

--- a/test-network-k8s/kube/org1/org1-admin-cli.yaml
+++ b/test-network-k8s/kube/org1/org1-admin-cli.yaml
@@ -20,8 +20,8 @@ spec:
     spec:
       containers:
         - name: main
-          image: {{LOCAL_CONTAINER_REGISTRY}}/fabric-tools:{{FABRIC_VERSION}}
-          imagePullPolicy: Always
+          image: {{FABRIC_CONTAINER_REGISTRY}}/fabric-tools:{{FABRIC_VERSION}}
+          imagePullPolicy: IfNotPresent
           env:
             - name: FABRIC_CFG_PATH
               value: /var/hyperledger/fabric/config

--- a/test-network-k8s/kube/org1/org1-ecert-ca.yaml
+++ b/test-network-k8s/kube/org1/org1-ecert-ca.yaml
@@ -20,7 +20,8 @@ spec:
     spec:
       containers:
         - name: main
-          image: {{LOCAL_CONTAINER_REGISTRY}}/fabric-ca:{{FABRIC_CA_VERSION}}
+          image: {{FABRIC_CONTAINER_REGISTRY}}/fabric-ca:{{FABRIC_CA_VERSION}}
+          imagePullPolicy: IfNotPresent
           env:
             - name: FABRIC_CA_SERVER_CA_NAME
               value: "org1-ecert-ca"

--- a/test-network-k8s/kube/org1/org1-peer1.yaml
+++ b/test-network-k8s/kube/org1/org1-peer1.yaml
@@ -46,8 +46,8 @@ spec:
     spec:
       containers:
         - name: main
-          image: {{LOCAL_CONTAINER_REGISTRY}}/fabric-peer:{{FABRIC_VERSION}}
-          imagePullPolicy: Always
+          image: {{FABRIC_CONTAINER_REGISTRY}}/fabric-peer:{{FABRIC_VERSION}}
+          imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:
                 name: org1-peer1-config
@@ -66,8 +66,8 @@ spec:
       # load the external chaincode builder into the peer image prior to peer launch.
       initContainers:
         - name: fabric-ccs-builder
-          image: {{LOCAL_CONTAINER_REGISTRY}}/fabric-ccs-builder
-          imagePullPolicy: Always
+          image: ghcr.io/hyperledgendary/fabric-ccs-builder
+          imagePullPolicy: IfNotPresent
           command: [sh, -c]
           args: ["cp /go/bin/* /var/hyperledger/fabric/chaincode/ccs-builder/bin/"]
           volumeMounts:

--- a/test-network-k8s/kube/org1/org1-peer2.yaml
+++ b/test-network-k8s/kube/org1/org1-peer2.yaml
@@ -46,8 +46,8 @@ spec:
     spec:
       containers:
         - name: main
-          image: {{LOCAL_CONTAINER_REGISTRY}}/fabric-peer:{{FABRIC_VERSION}}
-          imagePullPolicy: Always
+          image: {{FABRIC_CONTAINER_REGISTRY}}/fabric-peer:{{FABRIC_VERSION}}
+          imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:
                 name: org1-peer2-config

--- a/test-network-k8s/kube/org1/org1-tls-ca.yaml
+++ b/test-network-k8s/kube/org1/org1-tls-ca.yaml
@@ -20,7 +20,8 @@ spec:
     spec:
       containers:
         - name: main
-          image: {{LOCAL_CONTAINER_REGISTRY}}/fabric-ca:{{FABRIC_CA_VERSION}}
+          image: {{FABRIC_CONTAINER_REGISTRY}}/fabric-ca:{{FABRIC_CA_VERSION}}
+          imagePullPolicy: IfNotPresent
           env:
             - name: FABRIC_CA_SERVER_CA_NAME
               value: "org1-tls-ca"

--- a/test-network-k8s/kube/org2/org2-admin-cli.yaml
+++ b/test-network-k8s/kube/org2/org2-admin-cli.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: main
-          image: {{LOCAL_CONTAINER_REGISTRY}}/fabric-tools:{{FABRIC_VERSION}}
+          image: {{FABRIC_CONTAINER_REGISTRY}}/fabric-tools:{{FABRIC_VERSION}}
           imagePullPolicy: IfNotPresent
           env:
             - name: FABRIC_CFG_PATH

--- a/test-network-k8s/kube/org2/org2-ecert-ca.yaml
+++ b/test-network-k8s/kube/org2/org2-ecert-ca.yaml
@@ -20,7 +20,8 @@ spec:
     spec:
       containers:
         - name: main
-          image: {{LOCAL_CONTAINER_REGISTRY}}/fabric-ca:{{FABRIC_CA_VERSION}}
+          image: {{FABRIC_CONTAINER_REGISTRY}}/fabric-ca:{{FABRIC_CA_VERSION}}
+          imagePullPolicy: IfNotPresent
           env:
             - name: FABRIC_CA_SERVER_CA_NAME
               value: "org2-ecert-ca"

--- a/test-network-k8s/kube/org2/org2-peer1.yaml
+++ b/test-network-k8s/kube/org2/org2-peer1.yaml
@@ -46,7 +46,7 @@ spec:
     spec:
       containers:
         - name: main
-          image: {{LOCAL_CONTAINER_REGISTRY}}/fabric-peer:{{FABRIC_VERSION}}
+          image: {{FABRIC_CONTAINER_REGISTRY}}/fabric-peer:{{FABRIC_VERSION}}
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:
@@ -66,7 +66,7 @@ spec:
       # load the external chaincode builder into the peer image prior to peer launch.
       initContainers:
         - name: fabric-ccs-builder
-          image: {{LOCAL_CONTAINER_REGISTRY}}/fabric-ccs-builder
+          image: ghcr.io/hyperledgendary/fabric-ccs-builder
           imagePullPolicy: IfNotPresent
           command: [sh, -c]
           args: ["cp /go/bin/* /var/hyperledger/fabric/chaincode/ccs-builder/bin/"]

--- a/test-network-k8s/kube/org2/org2-peer2.yaml
+++ b/test-network-k8s/kube/org2/org2-peer2.yaml
@@ -46,7 +46,7 @@ spec:
     spec:
       containers:
         - name: main
-          image: {{LOCAL_CONTAINER_REGISTRY}}/fabric-peer:{{FABRIC_VERSION}}
+          image: {{FABRIC_CONTAINER_REGISTRY}}/fabric-peer:{{FABRIC_VERSION}}
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:

--- a/test-network-k8s/kube/org2/org2-tls-ca.yaml
+++ b/test-network-k8s/kube/org2/org2-tls-ca.yaml
@@ -20,7 +20,8 @@ spec:
     spec:
       containers:
         - name: main
-          image: {{LOCAL_CONTAINER_REGISTRY}}/fabric-ca:{{FABRIC_CA_VERSION}}
+          image: {{FABRIC_CONTAINER_REGISTRY}}/fabric-ca:{{FABRIC_CA_VERSION}}
+          imagePullPolicy: IfNotPresent
           env:
             - name: FABRIC_CA_SERVER_CA_NAME
               value: "org2-tls-ca"

--- a/test-network-k8s/network
+++ b/test-network-k8s/network
@@ -22,7 +22,6 @@ set -o errexit
 
 FABRIC_VERSION=${TEST_NETWORK_FABRIC_VERSION:-2.3.2}
 FABRIC_CA_VERSION=${TEST_NETWORK_FABRIC_CA_VERSION:-1.5.2}
-LOCAL_CONTAINER_REGISTRY=localhost:5000
 FABRIC_CONTAINER_REGISTRY=${TEST_NETWORK_FABRIC_CONTAINER_REGISTRY:-hyperledger}
 NETWORK_NAME=${TEST_NETWORK_NAME:-test-network}
 CLUSTER_NAME=${TEST_NETWORK_KIND_CLUSTER_NAME:-kind}
@@ -32,6 +31,7 @@ LOG_FILE=${TEST_NETWORK_LOG_FILE:-network.log}
 DEBUG_FILE=${TEST_NETWORK_DEBUG_FILE:-network-debug.log}
 LOCAL_REGISTRY_NAME=${TEST_NETWORK_LOCAL_REGISTRY_NAME:-kind-registry}
 LOCAL_REGISTRY_PORT=${TEST_NETWORK_LOCAL_REGISTRY_PORT:-5000}
+STAGE_DOCKER_IMAGES=${TEST_NETWORK_STAGE_DOCKER_IMAGES:-false}
 NGINX_HTTP_PORT=${TEST_NETWORK_INGRESS_HTTP_PORT:-80}
 NGINX_HTTPS_PORT=${TEST_NETWORK_INGRESS_HTTPS_PORT:-443}
 CHAINCODE_NAME=${TEST_NETWORK_CHAINCODE_NAME:-asset-transfer-basic}
@@ -105,6 +105,11 @@ if [ "${MODE}" == "kind" ]; then
   log "Initializing KIND cluster \"${CLUSTER_NAME}\":"
   kind_init
   log "🏁 - Cluster is ready."
+
+elif [ "${MODE}" == "load-images" ]; then
+  log "Loading images to KIND:"
+  load_docker_images
+  log "🏁 - Images loaded."
 
 elif [ "${MODE}" == "unkind" ]; then
   log "Deleting cluster \"${CLUSTER_NAME}\":"

--- a/test-network-k8s/scripts/fabric_CAs.sh
+++ b/test-network-k8s/scripts/fabric_CAs.sh
@@ -8,7 +8,7 @@
 function launch_CA() {
   local yaml=$1
   cat ${yaml} \
-    | sed 's,{{LOCAL_CONTAINER_REGISTRY}},'${LOCAL_CONTAINER_REGISTRY}',g' \
+    | sed 's,{{FABRIC_CONTAINER_REGISTRY}},'${FABRIC_CONTAINER_REGISTRY}',g' \
     | sed 's,{{FABRIC_CA_VERSION}},'${FABRIC_CA_VERSION}',g' \
     | kubectl -n $NS apply -f -
 }

--- a/test-network-k8s/scripts/kind.sh
+++ b/test-network-k8s/scripts/kind.sh
@@ -18,23 +18,17 @@ function pull_docker_images() {
   pop_fn
 }
 
-function push_images_to_local() {
-  push_fn "Push docker images to local image repository"
+function load_docker_images() {
+  push_fn "Loading docker images to KIND control plane"
 
-  docker tag ${FABRIC_CONTAINER_REGISTRY}/fabric-ca:$FABRIC_CA_VERSION ${LOCAL_CONTAINER_REGISTRY}/fabric-ca:$FABRIC_CA_VERSION
-  docker push ${LOCAL_CONTAINER_REGISTRY}/fabric-ca:$FABRIC_CA_VERSION
-  docker tag ${FABRIC_CONTAINER_REGISTRY}/fabric-orderer:$FABRIC_VERSION ${LOCAL_CONTAINER_REGISTRY}/fabric-orderer:$FABRIC_VERSION
-  docker push ${LOCAL_CONTAINER_REGISTRY}/fabric-orderer:$FABRIC_VERSION
-  docker tag ${FABRIC_CONTAINER_REGISTRY}/fabric-peer:$FABRIC_VERSION ${LOCAL_CONTAINER_REGISTRY}/fabric-peer:$FABRIC_VERSION
-  docker push ${LOCAL_CONTAINER_REGISTRY}/fabric-peer:$FABRIC_VERSION
-  docker tag ${FABRIC_CONTAINER_REGISTRY}/fabric-tools:$FABRIC_VERSION ${LOCAL_CONTAINER_REGISTRY}/fabric-tools:$FABRIC_VERSION
-  docker push ${LOCAL_CONTAINER_REGISTRY}/fabric-tools:$FABRIC_VERSION
-  docker tag ghcr.io/hyperledgendary/fabric-ccs-builder:latest ${LOCAL_CONTAINER_REGISTRY}/fabric-ccs-builder:latest
-  docker push ${LOCAL_CONTAINER_REGISTRY}/fabric-ccs-builder:latest
-  docker tag ghcr.io/hyperledgendary/fabric-ccaas-asset-transfer-basic:latest ${LOCAL_CONTAINER_REGISTRY}/fabric-ccaas-asset-transfer-basic:latest
-  docker push ${LOCAL_CONTAINER_REGISTRY}/fabric-ccaas-asset-transfer-basic:latest
-
-  pop_fn
+  kind load docker-image ${FABRIC_CONTAINER_REGISTRY}/fabric-ca:$FABRIC_CA_VERSION
+  kind load docker-image ${FABRIC_CONTAINER_REGISTRY}/fabric-orderer:$FABRIC_VERSION
+  kind load docker-image ${FABRIC_CONTAINER_REGISTRY}/fabric-peer:$FABRIC_VERSION
+  kind load docker-image ${FABRIC_CONTAINER_REGISTRY}/fabric-tools:$FABRIC_VERSION
+  kind load docker-image ghcr.io/hyperledgendary/fabric-ccs-builder:latest
+  kind load docker-image ghcr.io/hyperledgendary/fabric-ccaas-asset-transfer-basic:latest
+  
+  pop_fn 
 }
 
 function apply_nginx_ingress() {
@@ -143,8 +137,10 @@ function kind_init() {
   apply_nginx_ingress
   launch_docker_registry
 
-  pull_docker_images
-  push_images_to_local
+  if [ "${STAGE_DOCKER_IMAGES}" == true ]; then
+    pull_docker_images 
+    load_docker_images 
+  fi 
 }
 
 function kind_unkind() {

--- a/test-network-k8s/scripts/test_network.sh
+++ b/test-network-k8s/scripts/test_network.sh
@@ -11,7 +11,7 @@
 function launch() {
   local yaml=$1
   cat ${yaml} \
-    | sed 's,{{LOCAL_CONTAINER_REGISTRY}},'${LOCAL_CONTAINER_REGISTRY}',g' \
+    | sed 's,{{FABRIC_CONTAINER_REGISTRY}},'${FABRIC_CONTAINER_REGISTRY}',g' \
     | sed 's,{{FABRIC_VERSION}},'${FABRIC_VERSION}',g' \
     | kubectl -n $NS apply -f -
 }


### PR DESCRIPTION
This PR addresses a compromise for development workflows requiring different patterns for loading images into the KIND / kubernetes cluster. 

- For casual / default usage, the docker images are loaded from the public container registries (docker.io and ghcr.io)

- For developers with network issues connecting to public registries, this PR allows for an offline "pull" and stage to the KIND control plane: 
```
export TEST_NETWORK_STAGE_DOCKER_IMAGES=true
./network kind     # << this will pull from the public repos, and run kind load docker-image ...  

./network up 
```

- For test/development of the CI latest build outputs, the container registry and revision can be overridden: 
```
export TEST_NETWORK_FABRIC_VERSION=amd64-latest 
export TEST_NETWORK_FABRIC_CA_VERSION=amd64-latest 
export TEST_NETWORK_FABRIC_CONTAINER_REGISTRY=hyperledger-fabric.jfrog.io

./network up 
```

- For active development of core Fabric images (e.g. peer, orderer), the KIND control plane can be directly loaded with local builds: 
```
make docker # (in fabric) 

export TEST_NETWORK_FABRIC_VERSION=2.4.0 

./network load-images 
./network up 
``` 


@mbwhite and @SamYuan1990 can you please give this PR a test run to double-check that it meets your target use cases?   Matthew I had some difficulty testing out PR #507 and the `candidate-use-builtin-ccs-builder` branch with the mainline network scripts.  I think this is a better fit for that workflow. 


Signed-off-by: Josh Kneubuhl <jkneubuh@us.ibm.com>