### PR TITLE
Fix type error when using the latest sort-keys-recursive

### DIFF
--- a/asset-transfer-basic/chaincode-javascript/package.json
+++ b/asset-transfer-basic/chaincode-javascript/package.json
@@ -20,7 +20,7 @@
         "fabric-contract-api": "^2.0.0",
         "fabric-shim": "^2.0.0",
         "json-stringify-deterministic": "^1.0.1",
-        "sort-keys-recursive": "^2.0.0"
+        "sort-keys-recursive": "^2.1.2"
     },
     "devDependencies": {
         "chai": "^4.1.2",

--- a/asset-transfer-basic/chaincode-typescript/package.json
+++ b/asset-transfer-basic/chaincode-typescript/package.json
@@ -23,8 +23,8 @@
     "dependencies": {
         "fabric-contract-api": "^2.0.0",
         "fabric-shim": "^2.0.0",
-        "json-stringify-deterministic":"^1.0.0",
-        "sort-keys-recursive":"^2.0.0"
+        "json-stringify-deterministic": "^1.0.0",
+        "sort-keys-recursive": "^2.1.2"
     },
     "devDependencies": {
         "@types/chai": "^4.1.7",

--- a/asset-transfer-basic/chaincode-typescript/src/assetTransfer.ts
+++ b/asset-transfer-basic/chaincode-typescript/src/assetTransfer.ts
@@ -3,8 +3,8 @@
  */
 // Deterministic JSON.stringify()
 import {Context, Contract, Info, Returns, Transaction} from 'fabric-contract-api';
-import * as stringify from 'json-stringify-deterministic';
-import * as sortKeysRecursive from 'sort-keys-recursive';
+import stringify from 'json-stringify-deterministic';
+import sortKeysRecursive from 'sort-keys-recursive';
 import {Asset} from './asset';
 
 @Info({title: 'AssetTransfer', description: 'Smart contract for trading assets'})

--- a/asset-transfer-basic/chaincode-typescript/tsconfig.json
+++ b/asset-transfer-basic/chaincode-typescript/tsconfig.json
@@ -6,6 +6,7 @@
         "target": "es2017",
         "moduleResolution": "node",
         "module": "commonjs",
+        "esModuleInterop": true,
         "declaration": true,
         "sourceMap": true
     },


### PR DESCRIPTION
## Descriptions
The latest version (2.1.2) of sort-keys-recursive adds TypeScript typing, which includes export default function.
This change has caused the TS2349 type error.

This patch modifies the import form in assetTransfer.ts to fix the error.

## Related information

The example of error logs is:
```javascript
github.com/fabric-samples/asset-transfer-basic/chaincode-typescript (main *)$ npm run build

> asset-transfer-basic@1.0.0 build /home/ubuntu/workspace/src/github.com/fabric-samples/asset-transfer-basic/chaincode-typescript
> tsc

src/assetTransfer.ts:66:69 - error TS2349: This expression is not callable.
  Type 'typeof import("sort-keys-recursive")' has no call signatures.

66             await ctx.stub.putState(asset.ID, Buffer.from(stringify(sortKeysRecursive(asset))));
                                                                       ~~~~~~~~~~~~~~~~~

src/assetTransfer.ts:87:59 - error TS2349: This expression is not callable.
  Type 'typeof import("sort-keys-recursive")' has no call signatures.

87         await ctx.stub.putState(id, Buffer.from(stringify(sortKeysRecursive(asset))));
                                                             ~~~~~~~~~~~~~~~~~

src/assetTransfer.ts:117:60 - error TS2349: This expression is not callable.
  Type 'typeof import("sort-keys-recursive")' has no call signatures.

117         return ctx.stub.putState(id, Buffer.from(stringify(sortKeysRecursive(updatedAsset))));
                                                               ~~~~~~~~~~~~~~~~~

src/assetTransfer.ts:145:59 - error TS2349: This expression is not callable.
  Type 'typeof import("sort-keys-recursive")' has no call signatures.

145         await ctx.stub.putState(id, Buffer.from(stringify(sortKeysRecursive(asset))));
                                                              ~~~~~~~~~~~~~~~~~


Found 4 errors.

npm ERR! code ELIFECYCLE
npm ERR! errno 2
npm ERR! asset-transfer-basic@1.0.0 build: `tsc`
npm ERR! Exit status 2
npm ERR! 
npm ERR! Failed at the asset-transfer-basic@1.0.0 build script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/ubuntu/.npm/_logs/2021-11-05T06_16_41_781Z-debug.log
```

Related update is:
https://github.com/Kikobeats/sort-keys-recursive/commit/41858bd2745ead6fcb38e281cc7c4eb00705c523
