### PR TITLE
Update application-gateway-typescript

### DIFF
--- a/asset-transfer-basic/application-gateway-typescript/package.json
+++ b/asset-transfer-basic/application-gateway-typescript/package.json
@@ -20,7 +20,7 @@
     "author": "Hyperledger",
     "license": "Apache-2.0",
     "dependencies": {
-        "fabric-gateway": "0.1.0-dev.20211006.12"
+        "@hyperledger/fabric-gateway": "^0.1.0"
     },
     "devDependencies": {
         "@tsconfig/node12": "^1.0.9",

--- a/asset-transfer-basic/application-gateway-typescript/src/app.ts
+++ b/asset-transfer-basic/application-gateway-typescript/src/app.ts
@@ -6,7 +6,7 @@
 
 import * as grpc from '@grpc/grpc-js';
 import * as crypto from 'crypto';
-import { connect, Identity, Signer, signers ,Contract} from 'fabric-gateway';
+import { connect, Identity, Signer, signers ,Contract} from '@hyperledger/fabric-gateway';
 import { promises as fs } from 'fs';
 import * as path from 'path';
 


### PR DESCRIPTION
The fabric-gateway node module has been renamed to @hyperledger/fabric-gateway

Signed-off-by: James Taylor <jamest@uk.ibm.com>