### PR TITLE
Address Issue #511 with docs and better error handling

### DIFF
--- a/test-network-k8s/docs/KUBERNETES.md
+++ b/test-network-k8s/docs/KUBERNETES.md
@@ -165,6 +165,8 @@ export TEST_NETWORK_FABRIC_CA_VERSION=amd64-latest
 
 make docker    # in hyperledger/fabric 
 
+export TEST_NETWORK_FABRIC_VERSION=2.4.0
+
 ./network load-images 
 ./network up 
 ```

--- a/test-network-k8s/docs/KUBERNETES.md
+++ b/test-network-k8s/docs/KUBERNETES.md
@@ -131,8 +131,43 @@ to Pods deployed to the local cluster.
 
 For dev/test/CI based flows using an external registry, the traditional Kubernetes practice of 
 [Adding ImagePullSecrets to a service account](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#add-imagepullsecrets-to-a-service-account) 
-still applies. 
+still applies.
 
+In some environments, KIND may encounter issues loading the Fabric docker images from the public container 
+registries.  In addition, for Fabric development it can be advantageous to work with Docker images built 
+locally, bypassing the public images entirely.  For these scenarios, images may also be [directly loaded](https://kind.sigs.k8s.io/docs/user/quick-start/#loading-an-image-into-your-cluster)
+into the KIND image plane, bypassing the container registry.
+
+The `./network` script supports these additional modes via: 
+
+1.  For network-constrained environments, pull all images to the local docker cache and load to KIND: 
+```shell
+export TEST_NETWORK_STAGE_DOCKER_IMAGES=true 
+
+./network kind 
+./network up  
+```
+
+2.  For alternate registries (e.g. local or Fabric CI/CD builds): 
+```shell
+./network kind 
+
+export TEST_NETWORK_FABRIC_CONTAINER_REGISTRY=hyperledger-fabric.jfrog.io
+export TEST_NETWORK_FABRIC_VERSION=amd64-latest 
+export TEST_NETWORK_FABRIC_CA_VERSION=amd64-latest
+
+./network up  
+```
+
+3.  For working with Fabric images built locally: 
+```shell
+./network kind 
+
+make docker    # in hyperledger/fabric 
+
+./network load-images 
+./network up 
+```
 
 ## Cloud Vendors 
 

--- a/test-network-k8s/network
+++ b/test-network-k8s/network
@@ -35,7 +35,7 @@ STAGE_DOCKER_IMAGES=${TEST_NETWORK_STAGE_DOCKER_IMAGES:-false}
 NGINX_HTTP_PORT=${TEST_NETWORK_INGRESS_HTTP_PORT:-80}
 NGINX_HTTPS_PORT=${TEST_NETWORK_INGRESS_HTTPS_PORT:-443}
 CHAINCODE_NAME=${TEST_NETWORK_CHAINCODE_NAME:-asset-transfer-basic}
-CHAINCODE_IMAGE=${TEST_NETWORK_CHAINCODE_IMAGE:-localhost:5000/fabric-ccaas-asset-transfer-basic}
+CHAINCODE_IMAGE=${TEST_NETWORK_CHAINCODE_IMAGE:-ghcr.io/hyperledgendary/fabric-ccaas-asset-transfer-basic:latest}
 CHAINCODE_LABEL=${TEST_NETWORK_CHAINCODE_LABEL:-basic_1.0}
 
 # todo: more complicated config, as these bleed into the yaml descriptors (sed? kustomize? helm (no)? tkn? ansible?...) or other script locations
@@ -59,6 +59,7 @@ function print_help() {
   log "--- Cluster Information"
   log "Cluster name       \t\t: ${CLUSTER_NAME}"
   log "Cluster namespace    \t: ${NS}"
+  log "Fabric Registry      \t: ${FABRIC_CONTAINER_REGISTRY}"
   log "Local Registry     \t\t: ${LOCAL_REGISTRY_NAME}"
   log "Local Registry port  \t: ${LOCAL_REGISTRY_PORT}"
   log "nginx http port      \t: ${NGINX_HTTP_PORT}"
@@ -68,6 +69,7 @@ function print_help() {
   log "Log file           \t\t: ${LOG_FILE}"
   log "Debug log file     \t\t: ${DEBUG_FILE}"
   log
+
 
 
   echo todo: help output, parse mode, flags, env, etc.

--- a/test-network-k8s/scripts/chaincode.sh
+++ b/test-network-k8s/scripts/chaincode.sh
@@ -137,7 +137,8 @@ function invoke_chaincode() {
 # Normally the chaincode ID is emitted by the peer install command.  In this case, we'll generate the
 # package ID as the sha-256 checksum of the chaincode archive.
 function set_chaincode_id() {
-  local cc_sha256=$(shasum -a 256 build/chaincode/${CHAINCODE_NAME}.tgz | tr -s ' ' | cut -d ' ' -f 1)
+  local cc_package=build/chaincode/${CHAINCODE_NAME}.tgz
+  cc_sha256=$(shasum -a 256 ${cc_package} | tr -s ' ' | cut -d ' ' -f 1)
 
   CHAINCODE_ID=${CHAINCODE_LABEL}:${cc_sha256}
 }

--- a/test-network-k8s/scripts/utils.sh
+++ b/test-network-k8s/scripts/utils.sh
@@ -47,17 +47,23 @@ function log() {
 function pop_fn() {
 #  echo exiting ${FUNCNAME[1]}
 
-  local res=$1
   if [ $# -eq 0 ]; then
     echo -ne "\r✅"  >> ${LOG_FILE}
+    echo "" >> ${LOG_FILE}
+    return
+  fi
 
-  elif [ $res -eq 0 ]; then
+  local res=$1
+  if [ $res -eq 0 ]; then
     echo -ne "\r✅"  >> ${LOG_FILE}
 
   elif [ $res -eq 1 ]; then
     echo -ne "\r⚠️" >> ${LOG_FILE}
 
   elif [ $res -eq 2 ]; then
+    echo -ne "\r☠️" >> ${LOG_FILE}
+
+  elif [ $res -eq 127 ]; then
     echo -ne "\r☠️" >> ${LOG_FILE}
 
   else


### PR DESCRIPTION
The chaincode installation script had an error that was masking the lack of `shasum` on an end-user's machine.  This made it really hard to pick out the root cause of a downstream error.

This PR addresses the first part / root cause of Issue #511, which can be closed after this PR lands. 

This snippet will not crash with error.  $? is set to the return value of the `local` command.  
```
set -o errexit 

local foo=$(broken-command | tr -s ' ' | cut -d ' ' -f 1)
```

This snippet will error when `broken-command` terminates with a nonzero exit code: 
```
set -o errexit 

foo=$(broken-command | ...)
```


Signed-off-by: Josh Kneubuhl <jkneubuh@us.ibm.com>