### PR TITLE
Update node version in CI

### DIFF
--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -11,7 +11,7 @@ variables:
   FABRIC_VERSION: 2.4
   GO_BIN: $(Build.Repository.LocalPath)/bin
   GO_VER: 1.16.7
-  NODE_VER: 12.x
+  NODE_VER: 16.x
   PATH: $(Build.Repository.LocalPath)/bin:/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin
 
 jobs:


### PR DESCRIPTION
Several Fabric projects have updated their supported node versions and 16.x is the active LTS version

Signed-off-by: James Taylor <jamest@uk.ibm.com>