### PR TITLE
Retire dormant maintainers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -6,10 +6,7 @@ fabric-samples uses a non-author code review policy, requiring a single approval
 | Name                      | GitHub           | Chat           | email                               |
 |---------------------------|------------------|----------------|-------------------------------------|
 | Arnaud Le Hors            | lehors           | lehors         | lehors@us.ibm.com                   |
-| Bret Harrison             | harrisob         | bretharrison   | harrisob@us.ibm.com                 |
-| Chris Ferris              | christo4ferris   | cbf            | chris.ferris@gmail.com              |
 | Dave Enyeart              | denyeart         | dave.enyeart   | enyeart@us.ibm.com                  |
-| Gari Singh                | mastersingh24    | mastersingh24  | gari.r.singh@gmail.com              |
 | Matthew B White           | mbwhite          | mbwhite        | whitemat@uk.ibm.com                 |
 | Nikhil Gupta              | nikhil550        | negupta        | nikhilg550@gmail.com                |
 


### PR DESCRIPTION
Several fabric-samples maintainers have moved on to other projects.
See maintainer policies at
https://hyperledger-fabric.readthedocs.io/en/latest/CONTRIBUTING.html#becoming-a-maintainer

Signed-off-by: David Enyeart <enyeart@us.ibm.com>