### PR TITLE
Extend test network to support prometheus/grafana performances framework. Fixes hyperledger/fabric-test#347

### DIFF
--- a/test-network/docker/docker-compose-test-net.yaml
+++ b/test-network/docker/docker-compose-test-net.yaml
@@ -43,7 +43,8 @@ services:
       - ORDERER_ADMIN_TLS_ROOTCAS=[/var/hyperledger/orderer/tls/ca.crt]
       - ORDERER_ADMIN_TLS_CLIENTROOTCAS=[/var/hyperledger/orderer/tls/ca.crt]
       - ORDERER_ADMIN_LISTENADDRESS=0.0.0.0:7053
-      - ORDERER_OPERATIONS_LISTENADDRESS=0.0.0.0:17050
+      - ORDERER_OPERATIONS_LISTENADDRESS=orderer.example.com:9443
+      - ORDERER_METRICS_PROVIDER=prometheus
     working_dir: /opt/gopath/src/github.com/hyperledger/fabric
     command: orderer
     volumes:
@@ -54,7 +55,7 @@ services:
     ports:
       - 7050:7050
       - 7053:7053
-      - 17050:17050
+      - 9443:9443
     networks:
       - test
 
@@ -83,7 +84,8 @@ services:
       - CORE_PEER_GOSSIP_BOOTSTRAP=peer0.org1.example.com:7051
       - CORE_PEER_GOSSIP_EXTERNALENDPOINT=peer0.org1.example.com:7051
       - CORE_PEER_LOCALMSPID=Org1MSP
-      - CORE_OPERATIONS_LISTENADDRESS=0.0.0.0:17051
+      - CORE_OPERATIONS_LISTENADDRESS=peer0.org1.example.com:9444
+      - CORE_METRICS_PROVIDER=prometheus
     volumes:
         - ${DOCKER_SOCK}:/host/var/run/docker.sock
         - ../organizations/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/msp:/etc/hyperledger/fabric/msp
@@ -93,7 +95,7 @@ services:
     command: peer node start
     ports:
       - 7051:7051
-      - 17051:17051
+      - 9444:9444
     networks:
       - test
 
@@ -122,7 +124,8 @@ services:
       - CORE_PEER_GOSSIP_EXTERNALENDPOINT=peer0.org2.example.com:9051
       - CORE_PEER_GOSSIP_BOOTSTRAP=peer0.org2.example.com:9051
       - CORE_PEER_LOCALMSPID=Org2MSP
-      - CORE_OPERATIONS_LISTENADDRESS=0.0.0.0:19051
+      - CORE_OPERATIONS_LISTENADDRESS=peer0.org2.example.com:9445
+      - CORE_METRICS_PROVIDER=prometheus
     volumes:
         - ${DOCKER_SOCK}:/host/var/run/docker.sock
         - ../organizations/peerOrganizations/org2.example.com/peers/peer0.org2.example.com/msp:/etc/hyperledger/fabric/msp
@@ -132,7 +135,7 @@ services:
     command: peer node start
     ports:
       - 9051:9051
-      - 19051:19051
+      - 9445:9445
     networks:
       - test
 


### PR DESCRIPTION
Signed-off-by: fraVlaca <ocsenarf@outlook.com>