### PR TITLE
Added missing prerequisite

### DIFF
--- a/test-network-k8s/README.md
+++ b/test-network-k8s/README.md
@@ -20,6 +20,7 @@ _Fabric, Ahoy!_
 - [Docker](https://www.docker.com)
 - [kubectl](https://kubernetes.io/docs/tasks/tools/)
 - [kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation)
+- [jq](https://stedolan.github.io/jq/)
 
 
 ## Quickstart


### PR DESCRIPTION
`jq` is often not installed on most linux systems, so it must be listed under pre-requisite. If not mentioned, CC installation fails without any descriptive errors.