### PR TITLE
Fix(commercial-paper): Fixed failed dependency

### DIFF
--- a/commercial-paper/organization/digibank/application-java/pom.xml
+++ b/commercial-paper/organization/digibank/application-java/pom.xml
@@ -75,7 +75,7 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>org.hyperledger.fabric-gateway-java</groupId>
+			<groupId>org.hyperledger</groupId>
 			<artifactId>fabric-gateway-java</artifactId>
 			<version>1.4.0-SNAPSHOT</version>
 		</dependency>


### PR DESCRIPTION
In branch release-1.4 , The path of "fabric-gateway-java" is no longer valid, fixed valid dependency

https://hyperledger.jfrog.io/ui/repos/tree/General/fabric-maven%2Forg%2Fhyperledger%2Ffabric-gateway-java%2F1.4.0-SNAPSHOT%2Ffabric-gateway-java-1.4.0-20200120.152501-1.pom

![image](https://user-images.githubusercontent.com/29918052/149764176-2d11300c-c767-4537-a1c6-9b685941da87.png)

