### PR TITLE
Fix: remove `shift` after `-verbose` 

### DIFF
--- a/test-network/addOrg3/addOrg3.sh
+++ b/test-network/addOrg3/addOrg3.sh
@@ -228,7 +228,6 @@ while [[ $# -ge 1 ]] ; do
     ;;
   -verbose )
     VERBOSE=true
-    shift
     ;;
   * )
     errorln "Unknown flag: $key"

--- a/test-network/network.sh
+++ b/test-network/network.sh
@@ -441,7 +441,6 @@ while [[ $# -ge 1 ]] ; do
     ;;
   -verbose )
     VERBOSE=true
-    shift
     ;;
   * )
     errorln "Unknown flag: $key"


### PR DESCRIPTION
There are no argument after `-verbose`. So, it should not run `shift`.
If `-verbose` is not latest parameter, it will throw errro.
![image](https://user-images.githubusercontent.com/88102592/149860351-dac5abe4-c670-4e5b-b092-93f5d2c37b29.png)
