### PR TITLE
Remove JCenter as a Gradle package repository

### DIFF
--- a/asset-transfer-basic/application-java/build.gradle
+++ b/asset-transfer-basic/application-java/build.gradle
@@ -18,9 +18,8 @@ ext {
 }
 
 repositories {
-    // Use jcenter for resolving dependencies.
     // You can declare any Maven/Ivy/file repository here.
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {

--- a/asset-transfer-basic/chaincode-java/build.gradle
+++ b/asset-transfer-basic/chaincode-java/build.gradle
@@ -24,10 +24,7 @@ dependencies {
 }
 
 repositories {
-    maven {
-        url "https://hyperledger.jfrog.io/hyperledger/fabric-maven"
-    }
-    jcenter()
+    mavenCentral()
     maven {
         url 'https://jitpack.io'
     }

--- a/asset-transfer-events/chaincode-java/build.gradle
+++ b/asset-transfer-events/chaincode-java/build.gradle
@@ -19,10 +19,7 @@ dependencies {
 }
 
 repositories {
-    maven {
-        url "https://hyperledger.jfrog.io/hyperledger/fabric-maven"
-    }
-    jcenter()
+    mavenCentral()
     maven {
         url 'https://jitpack.io'
     }

--- a/asset-transfer-ledger-queries/application-java/build.gradle
+++ b/asset-transfer-ledger-queries/application-java/build.gradle
@@ -18,9 +18,8 @@ ext {
 }
 
 repositories {
-    // Use jcenter for resolving dependencies.
     // You can declare any Maven/Ivy/file repository here.
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {

--- a/asset-transfer-private-data/chaincode-java/build.gradle
+++ b/asset-transfer-private-data/chaincode-java/build.gradle
@@ -24,10 +24,7 @@ dependencies {
 }
 
 repositories {
-    maven {
-        url "https://hyperledger.jfrog.io/hyperledger/fabric-maven"
-    }
-    jcenter()
+    mavenCentral()
     maven {
         url 'https://jitpack.io'
     }

--- a/asset-transfer-sbe/chaincode-java/build.gradle
+++ b/asset-transfer-sbe/chaincode-java/build.gradle
@@ -27,10 +27,7 @@ dependencies {
 }
 
 repositories {
-    maven {
-        url "https://hyperledger.jfrog.io/hyperledger/fabric-maven"
-    }
-    jcenter()
+    mavenCentral()
     maven {
         url 'https://jitpack.io'
     }

--- a/chaincode/abstore/java/build.gradle
+++ b/chaincode/abstore/java/build.gradle
@@ -14,11 +14,7 @@ version '1.0-SNAPSHOT'
 sourceCompatibility = 1.8
 
 repositories {
-    mavenLocal()
     mavenCentral()
-    maven {
-        url "https://hyperledger.jfrog.io/hyperledger/fabric-maven"
-    }
     maven {
         url 'https://jitpack.io'
     }

--- a/chaincode/fabcar/java/build.gradle
+++ b/chaincode/fabcar/java/build.gradle
@@ -22,10 +22,7 @@ dependencies {
 }
 
 repositories {
-    maven {
-        url "https://hyperledger.jfrog.io/hyperledger/fabric-maven"
-    }
-    jcenter()
+    mavenCentral()
     maven {
         url 'https://jitpack.io'
     }

--- a/commercial-paper/organization/digibank/contract-java/build.gradle
+++ b/commercial-paper/organization/digibank/contract-java/build.gradle
@@ -7,7 +7,6 @@ version '0.0.1'
 sourceCompatibility = 1.8
 
 repositories {
-    mavenLocal()
     mavenCentral()
     maven {
         url 'https://jitpack.io'

--- a/commercial-paper/organization/digibank/contract-java/shadow-build.gradle
+++ b/commercial-paper/organization/digibank/contract-java/shadow-build.gradle
@@ -12,7 +12,6 @@ version '0.0.1'
 sourceCompatibility = 1.8
 
 repositories {
-    mavenLocal()
     mavenCentral()
     maven {
         url 'https://jitpack.io'

--- a/commercial-paper/organization/magnetocorp/contract-java/build.gradle
+++ b/commercial-paper/organization/magnetocorp/contract-java/build.gradle
@@ -12,7 +12,6 @@ version '0.0.1'
 sourceCompatibility = 1.8
 
 repositories {
-    mavenLocal()
     mavenCentral()
     maven {
         url 'https://jitpack.io'


### PR DESCRIPTION
JCenter is deprecated, can no longer be published to, and is scheduled for removal. It is now causing build failures. Replace with Maven Central.

Also remove mavenLocal() as this is not recommended practice:
    
https://docs.gradle.org/current/userguide/declaring_repositories.html#sec:case-for-maven-local

Note that Jitpack still needs to be included as a package repository for Java chaincode since it has dependencies on an old version of com.github.everit-org.json-schema:org.everit.json.schema that is only published there.