### PR TITLE
Fix markdown logical structure in asset-transfer-events/README.md

### DIFF
--- a/asset-transfer-events/README.md
+++ b/asset-transfer-events/README.md
@@ -15,7 +15,7 @@ page in the Fabric documentation.
 
 ## About the sample
 
-This sample includes smart contract and application code in multiple languages. In a use-case similar to basic asset transfer (see `../asset-transfer-basic` folder) this sample shows sending and receiving of events during create / update / delete of an asset, and during transfer of an asset to a new owner.
+This sample includes smart contract and application code in multiple languages. In a use-case similar to basic asset transfer (see [asset-transfer-basic](../asset-transfer-basic) folder) this sample shows sending and receiving of events during create / update / delete of an asset, and during transfer of an asset to a new owner.
 
 ### Application
 
@@ -43,25 +43,25 @@ Note that the asset transfer implemented by the smart contract is a simplified s
 Like other samples, the Fabric test network is used to deploy and run this sample. Follow these steps in order:
 
 1. Create the test network and a channel (from the `test-network` folder).
-``` 
-./network.sh up createChannel -c mychannel -ca
-```
+   ``` 
+   ./network.sh up createChannel -c mychannel -ca
+   ```
 
-2. Deploy one of the smart contract implementations (from the `test-network` folder).
-``` 
-# To deploy the JavaScript chaincode implementation
-./network.sh deployCC -ccn events -ccp ../asset-transfer-events/chaincode-javascript/ -ccl javascript -ccep "OR('Org1MSP.peer','Org2MSP.peer')"
+1. Deploy one of the smart contract implementations (from the `test-network` folder).
+   ``` 
+   # To deploy the JavaScript chaincode implementation
+   ./network.sh deployCC -ccn events -ccp ../asset-transfer-events/chaincode-javascript/ -ccl javascript -ccep "OR('Org1MSP.peer','Org2MSP.peer')"
 
-# To deploy the Java chaincode implementation
-./network.sh deployCC -ccn events -ccp ../asset-transfer-events/chaincode-java/ -ccl java -ccep "OR('Org1MSP.peer','Org2MSP.peer')"
-```
+   # To deploy the Java chaincode implementation
+   ./network.sh deployCC -ccn events -ccp ../asset-transfer-events/chaincode-java/ -ccl java -ccep "OR('Org1MSP.peer','Org2MSP.peer')"
+   ```
 
-3. Run the application (from the `asset-transfer-events` folder).
-```
-# To run the Go sample application
-cd application-gateway-go
-go run .
-```
+1. Run the application (from the `asset-transfer-events` folder).
+   ```
+   # To run the Go sample application
+   cd application-gateway-go
+   go run .
+   ```
 
 ## Clean up
 


### PR DESCRIPTION
Fenced code blocks within a list were at the wrong level if indentation and so logically terminated the list.