### PR TITLE
Run basic-asset-transfer on the Kubernetes Test Network in an Azure CI pipeline 

### DIFF
--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -114,6 +114,27 @@ jobs:
         workingDirectory: test-network
         displayName: Run Test Network Basic Chaincode
 
+  - job: KubeTestNetworkBasic
+    displayName: Kube Test Network Basic
+    pool:
+      vmImage: ubuntu-20.04
+    strategy:
+      matrix:
+        Docker-Typescript:
+          CONTAINER_CLI: docker
+          CLIENT_LANGUAGE: typescript
+#        Podman-Typescript:
+#          CONTAINER_CLI: podman
+#          CLIENT_LANGUAGE: typescript
+#        Nerdctl-Typescript:
+#          CONTAINER_CLI: nerdctl
+#          CLIENT_LANGUAGE: typescript
+    steps:
+      - template: templates/install-k8s-deps.yml
+      - script: ../ci/scripts/run-k8s-test-network-basic.sh
+        workingDirectory: test-network-k8s
+        displayName: Run Kubernetes Test Network Basic Asset Transfer
+
   - job: TestNetworkLedger
     displayName: Test Network
     pool:

--- a/ci/scripts/pullFabricImages.sh
+++ b/ci/scripts/pullFabricImages.sh
@@ -1,15 +1,18 @@
 #!/bin/bash -e
 set -euo pipefail
 
+CONTAINER_CLI=${CONTAINER_CLI:-"docker"}
 FABRIC_VERSION=${FABRIC_VERSION:-2.4}
 STABLE_TAG=amd64-${FABRIC_VERSION}-stable
 
+echo "Pulling images with $CONTAINER_CLI"
+
 for image in baseos peer orderer ca tools orderer ccenv javaenv nodeenv tools; do
-	docker pull -q "hyperledger-fabric.jfrog.io/fabric-${image}:${STABLE_TAG}"
-	docker tag "hyperledger-fabric.jfrog.io/fabric-${image}:${STABLE_TAG}" hyperledger/fabric-${image}
-	docker tag "hyperledger-fabric.jfrog.io/fabric-${image}:${STABLE_TAG}" "hyperledger/fabric-${image}:${FABRIC_VERSION}"
-	docker rmi -f "hyperledger-fabric.jfrog.io/fabric-${image}:${STABLE_TAG}"
+	$CONTAINER_CLI pull -q "hyperledger-fabric.jfrog.io/fabric-${image}:${STABLE_TAG}"
+	$CONTAINER_CLI tag "hyperledger-fabric.jfrog.io/fabric-${image}:${STABLE_TAG}" hyperledger/fabric-${image}
+	$CONTAINER_CLI tag "hyperledger-fabric.jfrog.io/fabric-${image}:${STABLE_TAG}" "hyperledger/fabric-${image}:${FABRIC_VERSION}"
+	$CONTAINER_CLI rmi -f "hyperledger-fabric.jfrog.io/fabric-${image}:${STABLE_TAG}"
 done
 
-docker pull -q couchdb:3.1.1
-docker images | grep hyperledger
+$CONTAINER_CLI pull -q couchdb:3.1.1
+$CONTAINER_CLI images | grep hyperledger

--- a/ci/scripts/run-k8s-test-network-basic.sh
+++ b/ci/scripts/run-k8s-test-network-basic.sh
@@ -1,0 +1,122 @@
+#!/bin/bash -e
+#
+# Copyright IBM Corp All Rights Reserved
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+set -euo pipefail
+
+# Test matrix parameters
+# todo: compatibility with podman, k3s/rancher, docker, KIND, etc.
+export CONTAINER_CLI=${CONTAINER_CLI:-docker}
+export CLIENT_LANGUAGE=${CLIENT_LANGUAGE:-typescript}
+
+# Fabric version and Docker registry source: use the latest stable tag image from JFrog
+export FABRIC_VERSION=${FABRIC_VERSION:-2.4}
+export TEST_NETWORK_FABRIC_CONTAINER_REGISTRY=hyperledger-fabric.jfrog.io
+export TEST_NETWORK_FABRIC_VERSION=amd64-${FABRIC_VERSION}-stable
+export TEST_NETWORK_FABRIC_CA_VERSION=amd64-${FABRIC_VERSION}-stable
+
+# test-network-k8s parameters
+export TEST_TAG=$(git describe)
+export TEST_NETWORK_KIND_CLUSTER_NAME=${TEST_NETWORK_KIND_CLUSTER_NAME:-kind}
+export TEST_NETWORK_CHAINCODE_NAME=${TEST_NETWORK_CHAINCODE_NAME:-asset-transfer-basic}
+export TEST_NETWORK_CHAINCODE_IMAGE=${TEST_NETWORK_CHAINCODE_NAME}:${TEST_TAG}
+export TEST_NETWORK_CHAINCODE_PATH=${TEST_NETWORK_CHAINCODE_PATH:-../asset-transfer-basic/chaincode-external}
+
+# gateway client application parameters
+export GATEWAY_CLIENT_APPLICATION_PATH=${GATEWAY_CLIENT_APPLICATION_PATH:-../asset-transfer-basic/application-gateway-${CLIENT_LANGUAGE}}
+export CHANNEL_NAME=${TEST_NETWORK_CHANNEL_NAME:-mychannel}
+export CHAINCODE_NAME=${TEST_NETWORK_CHAINCODE_NAME:-basic-asset-transfer}
+export MSP_ID=${MSP_ID:-Org1MSP}
+export CRYPTO_PATH=${CRYPTO_PATH:-../../test-network-k8s/build/organizations/peerOrganizations/org1.example.com}
+export KEY_DIRECTORY_PATH=${KEY_DIRECTORY_PATH:-../../test-network-k8s/build/organizations/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/keystore}
+export CERT_PATH=${CERT_PATH:-../../test-network-k8s/build/organizations/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/signcerts/cert.pem}
+export TLS_CERT_PATH=${TLS_CERT_PATH:-../../test-network-k8s/build/organizations/peerOrganizations/org1.example.com/peers/org1-peer1.org1.example.com/tls/cacerts/org1-tls-ca.pem}
+export PEER_ENDPOINT=${PEER_ENDPOINT:-localhost:7051}
+export PEER_HOST_ALIAS=${PEER_HOST_ALIAS:-org1-peer1}
+
+function print() {
+  GREEN='\033[0;32m'
+  NC='\033[0m'
+  echo
+  echo -e "${GREEN}${1}${NC}"
+}
+
+function touteSuite() {
+  createCluster
+  buildChaincodeImage
+}
+
+function quitterLaScene() {
+  destroyCluster
+  scrubCCImages
+}
+
+function createCluster() {
+  print "Initializing KIND Kubernetes cluster"
+  ./network kind
+}
+
+function destroyCluster() {
+  print "Destroying KIND Kubernetes cluster"
+  ./network unkind
+}
+
+function buildChaincodeImage() {
+  print "Building chaincode image $TEST_NETWORK_CHAINCODE_IMAGE"
+  ${CONTAINER_CLI} build -t $TEST_NETWORK_CHAINCODE_IMAGE $TEST_NETWORK_CHAINCODE_PATH
+
+  # todo: work with local reg, or k3s, or KIND, or ...
+  kind load docker-image $TEST_NETWORK_CHAINCODE_IMAGE
+}
+
+function scrubCCImages() {
+  print "Scrubbing chaincode images"
+  ${CONTAINER_CLI} rmi $TEST_NETWORK_CHAINCODE_IMAGE
+}
+
+function createNetwork() {
+  print "Launching network"
+  ./network up
+  ./network channel create
+
+  print "Opening gateway port-forward to 'localhost:7051'"
+  kubectl -n test-network port-forward svc/org1-peer1 7051:7051 &
+
+  print "Deploying chaincode"
+  ./network chaincode deploy
+
+  print "Extracting certificates"
+  kubectl \
+    -n test-network \
+    exec deploy/org1-peer1 \
+    -c main \
+    -- tar zcvf - -C /var/hyperledger/fabric organizations/peerOrganizations/org1.example.com \
+    | tar zxvf - -C ../test-network-k8s/build/
+}
+
+function stopNetwork() {
+  pkill -f "port-forward"
+
+  print "Stopping network"
+  ./network down
+}
+
+# Set up the suite with a KIND cluster
+touteSuite
+trap "quitterLaScene" EXIT
+
+# Run the basic-asset-transfer basic application
+createNetwork
+print "Running Gateway client application"
+( pushd ${GATEWAY_CLIENT_APPLICATION_PATH} \
+  && npm install \
+  && npm start )
+stopNetwork
+
+# Run additional test ...
+# Run additional test ...
+# Run additional test ...
+
+# destroyCluster will be invoked on EXIT trap handler at the end of this suite.

--- a/ci/templates/install-k8s-deps.yml
+++ b/ci/templates/install-k8s-deps.yml
@@ -1,0 +1,9 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+steps:
+  - task: NodeTool@0
+    inputs:
+      versionSpec: $(NODE_VER)
+    displayName: Install Node.js

--- a/test-network-k8s/network
+++ b/test-network-k8s/network
@@ -20,6 +20,7 @@ set -o errexit
 # todo: track down a nasty bug whereby the CA service endpoints (kube services) will occasionally reject TCP connections after network down/up.  This is patched by introducing a 10s sleep after the deployments are up...
 # todo: refactor query/invoke to specify chaincode name (-n param)
 
+CONTAINER_CLI=${CONTAINER_CLI:-docker}
 FABRIC_VERSION=${TEST_NETWORK_FABRIC_VERSION:-2.4.1}
 FABRIC_CA_VERSION=${TEST_NETWORK_FABRIC_CA_VERSION:-1.5.2}
 FABRIC_CONTAINER_REGISTRY=${TEST_NETWORK_FABRIC_CONTAINER_REGISTRY:-hyperledger}

--- a/test-network-k8s/scripts/prereqs.sh
+++ b/test-network-k8s/scripts/prereqs.sh
@@ -8,9 +8,9 @@
 # Double check that kind, kubectl, docker, and all required images are present.
 function check_prereqs() {
 
-  docker version > /dev/null
+  ${CONTAINER_CLI} version > /dev/null
   if [[ $? -ne 0 ]]; then
-    echo "No 'docker' binary available? (https://www.docker.com)"
+    echo "No '${CONTAINER_CLI}' binary available?"
     exit 1
   fi
 

--- a/test-network-k8s/scripts/test_network.sh
+++ b/test-network-k8s/scripts/test_network.sh
@@ -116,8 +116,8 @@ function create_org1_local_MSP() {
   fabric-ca-client register --id.name org1-peer1 --id.secret peerpw --id.type peer --url https://org1-tls-ca --mspdir $FABRIC_CA_CLIENT_HOME/tls-ca/tlsadmin/msp
   fabric-ca-client register --id.name org1-peer2 --id.secret peerpw --id.type peer --url https://org1-tls-ca --mspdir $FABRIC_CA_CLIENT_HOME/tls-ca/tlsadmin/msp
 
-  fabric-ca-client enroll --url https://org1-peer1:peerpw@org1-tls-ca --csr.hosts org1-peer1 --mspdir /var/hyperledger/fabric/organizations/peerOrganizations/org1.example.com/peers/org1-peer1.org1.example.com/tls
-  fabric-ca-client enroll --url https://org1-peer2:peerpw@org1-tls-ca --csr.hosts org1-peer2 --mspdir /var/hyperledger/fabric/organizations/peerOrganizations/org1.example.com/peers/org1-peer2.org1.example.com/tls
+  fabric-ca-client enroll --url https://org1-peer1:peerpw@org1-tls-ca --csr.hosts localhost,org1-peer1 --mspdir /var/hyperledger/fabric/organizations/peerOrganizations/org1.example.com/peers/org1-peer1.org1.example.com/tls
+  fabric-ca-client enroll --url https://org1-peer2:peerpw@org1-tls-ca --csr.hosts localhost,org1-peer2 --mspdir /var/hyperledger/fabric/organizations/peerOrganizations/org1.example.com/peers/org1-peer2.org1.example.com/tls
 
   # Copy the TLS signing keys to a fixed path for convenience when launching the peers
   cp /var/hyperledger/fabric/organizations/peerOrganizations/org1.example.com/peers/org1-peer1.org1.example.com/tls/keystore/*_sk /var/hyperledger/fabric/organizations/peerOrganizations/org1.example.com/peers/org1-peer1.org1.example.com/tls/keystore/server.key
@@ -145,7 +145,6 @@ function create_org1_local_MSP() {
   cp /var/hyperledger/fabric/organizations/peerOrganizations/org1.example.com/peers/org1-peer1.org1.example.com/msp/config.yaml /var/hyperledger/fabric/organizations/peerOrganizations/org1.example.com/peers/org1-peer2.org1.example.com/msp/config.yaml
   cp /var/hyperledger/fabric/organizations/peerOrganizations/org1.example.com/peers/org1-peer1.org1.example.com/msp/config.yaml /var/hyperledger/fabric/organizations/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/config.yaml
   ' | exec kubectl -n $NS exec deploy/org1-ecert-ca -i -- /bin/sh
-
 }
 
 function create_org2_local_MSP() {
@@ -166,8 +165,8 @@ function create_org2_local_MSP() {
   fabric-ca-client register --id.name org2-peer1 --id.secret peerpw --id.type peer --url https://org2-tls-ca --mspdir $FABRIC_CA_CLIENT_HOME/tls-ca/tlsadmin/msp
   fabric-ca-client register --id.name org2-peer2 --id.secret peerpw --id.type peer --url https://org2-tls-ca --mspdir $FABRIC_CA_CLIENT_HOME/tls-ca/tlsadmin/msp
 
-  fabric-ca-client enroll --url https://org2-peer1:peerpw@org2-tls-ca --csr.hosts org2-peer1 --mspdir /var/hyperledger/fabric/organizations/peerOrganizations/org2.example.com/peers/org2-peer1.org2.example.com/tls
-  fabric-ca-client enroll --url https://org2-peer2:peerpw@org2-tls-ca --csr.hosts org2-peer2 --mspdir /var/hyperledger/fabric/organizations/peerOrganizations/org2.example.com/peers/org2-peer2.org2.example.com/tls
+  fabric-ca-client enroll --url https://org2-peer1:peerpw@org2-tls-ca --csr.hosts localhost,org2-peer1 --mspdir /var/hyperledger/fabric/organizations/peerOrganizations/org2.example.com/peers/org2-peer1.org2.example.com/tls
+  fabric-ca-client enroll --url https://org2-peer2:peerpw@org2-tls-ca --csr.hosts localhost,org2-peer2 --mspdir /var/hyperledger/fabric/organizations/peerOrganizations/org2.example.com/peers/org2-peer2.org2.example.com/tls
 
   # Copy the TLS signing keys to a fixed path for convenience when launching the peers
   cp /var/hyperledger/fabric/organizations/peerOrganizations/org2.example.com/peers/org2-peer1.org2.example.com/tls/keystore/*_sk /var/hyperledger/fabric/organizations/peerOrganizations/org2.example.com/peers/org2-peer1.org2.example.com/tls/keystore/server.key


### PR DESCRIPTION
This PR adds a CI test case to run an E2E validation of the basic-asset-transfer chaincode and Gateway application on the Kubernetes Test Network.  This suite exercise only ONE test case, primarily as an exercise in validating the mechanics  of running the Kube Test Network on an Azure image.  After the mechanics of running on Azure have been worked out, additional tests can follow, both for additional Fabric routines (e.g. Commercial Paper) and new container orchestration runtimes (e.g. containerd / podman / nerdctl / etc.) 

The suite runs a complete E2E, including: 

- Creates a KIND Kubernetes cluster and Nginx ingress controller.

- Configures the Kubernetes Test Network (3 org: 2x peers/org + 3x orderers) using JFrog / STABLE tag Fabric images.

- Compiles and deploys asset-transfer-basic/chaincode-external Chaincode-as-a-Service.

- Creates a localhost:7051 -> service/org1-peer1:7051 port forward.

- Compiles and runs the application-gateway-typescript example on the host OS.

- Tears down the port-forward, Test Network, KIND cluster, and scrubs chaincode docker images.


Signed-off-by: Josh Kneubuhl <jkneubuh@us.ibm.com>