### PR TITLE
Run a basic-asset-transfer CI test on Kubernetes

### DIFF
--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -127,6 +127,20 @@ jobs:
         workingDirectory: test-network
         displayName: Run Test Network Basic Chaincode
 
+  - job: KubeTestNetworkBasic
+    displayName: Kube Test Network Basic
+    pool:
+      vmImage: ubuntu-20.04
+    strategy:
+      matrix:
+        Docker-Typescript:
+          CLIENT_LANGUAGE: typescript
+    steps:
+      - template: templates/install-k8s-deps.yml
+      - script: ../ci/scripts/run-k8s-test-network-basic.sh
+        workingDirectory: test-network-k8s
+        displayName: Run Kubernetes Test Network Basic Asset Transfer
+
   - job: TestNetworkLedger
     displayName: Test Network
     pool:

--- a/ci/scripts/run-k8s-test-network-basic.sh
+++ b/ci/scripts/run-k8s-test-network-basic.sh
@@ -1,0 +1,144 @@
+#!/bin/bash -e
+#
+# Copyright IBM Corp All Rights Reserved
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+set -euo pipefail
+
+# Test matrix parameters
+export CONTAINER_CLI=${CONTAINER_CLI:-docker}
+export CLIENT_LANGUAGE=${CLIENT_LANGUAGE:-typescript}
+
+# Fabric version and Docker registry source: use the latest stable tag image from JFrog
+export FABRIC_VERSION=${FABRIC_VERSION:-2.4}
+export TEST_NETWORK_FABRIC_CONTAINER_REGISTRY=hyperledger-fabric.jfrog.io
+export TEST_NETWORK_FABRIC_VERSION=amd64-${FABRIC_VERSION}-stable
+export TEST_NETWORK_FABRIC_CA_VERSION=amd64-${FABRIC_VERSION}-stable
+
+# test-network-k8s parameters
+export TEST_TAG=$(git describe)
+export TEST_NETWORK_KIND_CLUSTER_NAME=${TEST_NETWORK_KIND_CLUSTER_NAME:-kind}
+export TEST_NETWORK_CHAINCODE_NAME=${TEST_NETWORK_CHAINCODE_NAME:-asset-transfer-basic}
+export TEST_NETWORK_CHAINCODE_IMAGE=${TEST_NETWORK_CHAINCODE_NAME}:${TEST_TAG}
+export TEST_NETWORK_CHAINCODE_PATH=${TEST_NETWORK_CHAINCODE_PATH:-../asset-transfer-basic/chaincode-external}
+
+# gateway client application parameters
+export GATEWAY_CLIENT_APPLICATION_PATH=${GATEWAY_CLIENT_APPLICATION_PATH:-../asset-transfer-basic/application-gateway-${CLIENT_LANGUAGE}}
+export CHANNEL_NAME=${TEST_NETWORK_CHANNEL_NAME:-mychannel}
+export CHAINCODE_NAME=${TEST_NETWORK_CHAINCODE_NAME:-asset-transfer-basic}
+export MSP_ID=${MSP_ID:-Org1MSP}
+export CRYPTO_PATH=${CRYPTO_PATH:-../../test-network-k8s/build/organizations/peerOrganizations/org1.example.com}
+export KEY_DIRECTORY_PATH=${KEY_DIRECTORY_PATH:-../../test-network-k8s/build/organizations/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/keystore}
+export CERT_PATH=${CERT_PATH:-../../test-network-k8s/build/organizations/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/signcerts/cert.pem}
+export TLS_CERT_PATH=${TLS_CERT_PATH:-../../test-network-k8s/build/organizations/peerOrganizations/org1.example.com/msp/tlscacerts/org1-tls-ca.pem}
+export PEER_ENDPOINT=${PEER_ENDPOINT:-localhost:7051}
+export PEER_HOST_ALIAS=${PEER_HOST_ALIAS:-org1-peer1}
+
+function print() {
+  GREEN='\033[0;32m'
+  NC='\033[0m'
+  echo
+  echo -e "${GREEN}${1}${NC}"
+}
+
+function touteSuite() {
+  createCluster
+  buildChaincodeImage
+}
+
+function quitterLaScene() {
+  destroyCluster
+  scrubCCImages
+}
+
+function createCluster() {
+  print "Initializing KIND Kubernetes cluster"
+  ./network kind
+}
+
+function destroyCluster() {
+  print "Destroying KIND Kubernetes cluster"
+  ./network unkind
+}
+
+function buildChaincodeImage() {
+  print "Building chaincode image $TEST_NETWORK_CHAINCODE_IMAGE"
+  ${CONTAINER_CLI} build -t $TEST_NETWORK_CHAINCODE_IMAGE $TEST_NETWORK_CHAINCODE_PATH
+
+  # todo: work with local reg, or k3s, or KIND, or ...
+  kind load docker-image $TEST_NETWORK_CHAINCODE_IMAGE
+}
+
+function scrubCCImages() {
+  print "Scrubbing chaincode images"
+  ${CONTAINER_CLI} rmi $TEST_NETWORK_CHAINCODE_IMAGE
+}
+
+function createNetwork() {
+  print "Launching network"
+  ./network up
+  ./network channel create
+
+  print "Opening gateway port-forward to 'localhost:7051'"
+  kubectl -n test-network port-forward svc/org1-peer1 7051:7051 &
+
+  print "Deploying chaincode"
+  ./network chaincode deploy
+
+  print "Extracting certificates"
+  kubectl \
+    -n test-network \
+    exec deploy/org1-peer1 \
+    -c main \
+    -- tar zcf - -C /var/hyperledger/fabric organizations/peerOrganizations/org1.example.com \
+    | tar zxvf - -C ../test-network-k8s/build/
+}
+
+function stopNetwork() {
+  pkill -f "port-forward"
+
+  print "Stopping network"
+  ./network down
+
+  print "Cleaning client certificates"
+  rm -rf ../test-network-k8s/build/
+}
+
+# Set up the suite with a KIND cluster
+touteSuite
+trap "quitterLaScene" EXIT
+
+# invoke / query
+createNetwork
+
+print "Inserting and querying assets"
+( ./network chaincode invoke '{"Args":["InitLedger"]}' \
+  && sleep 5 \
+  && ./network chaincode query '{"Args":["ReadAsset","asset1"]}' )
+print "OK"
+
+print "Running rest-easy test"
+( ./network rest-easy \
+  && sleep 5 \
+  && export SAMPLE_APIKEY='97834158-3224-4CE7-95F9-A148C886653E' \
+  && curl -s --header "X-Api-Key: ${SAMPLE_APIKEY}" "http://localhost/api/assets/asset1" | jq \
+  && curl -s --insecure --header "X-Api-Key: ${SAMPLE_APIKEY}" "https://localhost/api/assets/asset1" | jq )
+print "OK"
+
+stopNetwork
+
+# Run the basic-asset-transfer basic application
+createNetwork
+print "Running Gateway client application"
+( pushd ${GATEWAY_CLIENT_APPLICATION_PATH} \
+  && npm install \
+  && npm start )
+print "OK"
+stopNetwork
+
+# Run additional test ...
+# Run additional test ...
+# Run additional test ...
+
+# destroyCluster will be invoked on EXIT trap handler at the end of this suite.

--- a/ci/templates/install-k8s-deps.yml
+++ b/ci/templates/install-k8s-deps.yml
@@ -1,0 +1,9 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+steps:
+  - task: NodeTool@0
+    inputs:
+      versionSpec: $(NODE_VER)
+    displayName: Install Node.js

--- a/test-network-k8s/scripts/test_network.sh
+++ b/test-network-k8s/scripts/test_network.sh
@@ -91,8 +91,8 @@ function create_org1_local_MSP() {
   fabric-ca-client register --id.name org1-peer2 --id.secret peerpw --id.type peer --url https://org1-ca --mspdir $FABRIC_CA_CLIENT_HOME/org1-ca/rcaadmin/msp
   fabric-ca-client register --id.name org1-admin --id.secret org1adminpw  --id.type admin   --url https://org1-ca --mspdir $FABRIC_CA_CLIENT_HOME/org1-ca/rcaadmin/msp --id.attrs "hf.Registrar.Roles=client,hf.Registrar.Attributes=*,hf.Revoker=true,hf.GenCRL=true,admin=true:ecert,abac.init=true:ecert"
 
-  fabric-ca-client enroll --url https://org1-peer1:peerpw@org1-ca --csr.hosts org1-peer1,org1-peer-gateway-svc --mspdir /var/hyperledger/fabric/organizations/peerOrganizations/org1.example.com/peers/org1-peer1.org1.example.com/msp
-  fabric-ca-client enroll --url https://org1-peer2:peerpw@org1-ca --csr.hosts org1-peer2,org1-peer-gateway-svc --mspdir /var/hyperledger/fabric/organizations/peerOrganizations/org1.example.com/peers/org1-peer2.org1.example.com/msp
+  fabric-ca-client enroll --url https://org1-peer1:peerpw@org1-ca --csr.hosts localhost,org1-peer1,org1-peer-gateway-svc --mspdir /var/hyperledger/fabric/organizations/peerOrganizations/org1.example.com/peers/org1-peer1.org1.example.com/msp
+  fabric-ca-client enroll --url https://org1-peer2:peerpw@org1-ca --csr.hosts localhost,org1-peer2,org1-peer-gateway-svc --mspdir /var/hyperledger/fabric/organizations/peerOrganizations/org1.example.com/peers/org1-peer2.org1.example.com/msp
   fabric-ca-client enroll --url https://org1-admin:org1adminpw@org1-ca  --mspdir /var/hyperledger/fabric/organizations/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp
 
   cp /var/hyperledger/fabric/organizations/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/keystore/*_sk /var/hyperledger/fabric/organizations/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/keystore/server.key
@@ -130,8 +130,8 @@ function create_org2_local_MSP() {
   fabric-ca-client register --id.name org2-peer2 --id.secret peerpw --id.type peer --url https://org2-ca --mspdir $FABRIC_CA_CLIENT_HOME/org2-ca/rcaadmin/msp
   fabric-ca-client register --id.name org2-admin --id.secret org2adminpw  --id.type admin   --url https://org2-ca --mspdir $FABRIC_CA_CLIENT_HOME/org2-ca/rcaadmin/msp --id.attrs "hf.Registrar.Roles=client,hf.Registrar.Attributes=*,hf.Revoker=true,hf.GenCRL=true,admin=true:ecert,abac.init=true:ecert"
 
-  fabric-ca-client enroll --url https://org2-peer1:peerpw@org2-ca --csr.hosts org2-peer1,org2-peer-gateway-svc --mspdir /var/hyperledger/fabric/organizations/peerOrganizations/org2.example.com/peers/org2-peer1.org2.example.com/msp
-  fabric-ca-client enroll --url https://org2-peer2:peerpw@org2-ca --csr.hosts org2-peer2,org2-peer-gateway-svc --mspdir /var/hyperledger/fabric/organizations/peerOrganizations/org2.example.com/peers/org2-peer2.org2.example.com/msp
+  fabric-ca-client enroll --url https://org2-peer1:peerpw@org2-ca --csr.hosts localhost,org2-peer1,org2-peer-gateway-svc --mspdir /var/hyperledger/fabric/organizations/peerOrganizations/org2.example.com/peers/org2-peer1.org2.example.com/msp
+  fabric-ca-client enroll --url https://org2-peer2:peerpw@org2-ca --csr.hosts localhost,org2-peer2,org2-peer-gateway-svc --mspdir /var/hyperledger/fabric/organizations/peerOrganizations/org2.example.com/peers/org2-peer2.org2.example.com/msp
   fabric-ca-client enroll --url https://org2-admin:org2adminpw@org2-ca  --mspdir /var/hyperledger/fabric/organizations/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp
 
   cp /var/hyperledger/fabric/organizations/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp/keystore/*_sk /var/hyperledger/fabric/organizations/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp/keystore/server.key


### PR DESCRIPTION
This PR adds a CI test case to run an E2E validation of the basic-asset-transfer chaincode and Gateway application on the Kubernetes Test Network. This suite exercise only ONE test case, primarily as an exercise in validating the mechanics of running the Kube Test Network on an Azure image. After the mechanics of running on Azure have been worked out, additional tests can follow, both for additional Fabric routines (e.g. Commercial Paper) and new container orchestration runtimes (e.g. containerd / podman / nerdctl / etc.)

The suite runs a complete E2E, including:

- Creates a KIND Kubernetes cluster and Nginx ingress controller.

- Configures the Kubernetes Test Network (3 org: 2x peers/org + 3x orderers) using JFrog / STABLE tag Fabric images.

- Compiles and deploys asset-transfer-basic/chaincode-external Chaincode-as-a-Service.

- Creates a localhost:7051 -> service/org1-peer1:7051 port forward.

- Compiles and runs the application-gateway-typescript example on the host OS.

- Tears down the port-forward, Test Network, KIND cluster, and scrubs chaincode docker images.

Signed-off-by: Josh Kneubuhl [jkneubuh@us.ibm.com](mailto:jkneubuh@us.ibm.com)