### PR TITLE
test-network-k8s: High availability on application connection profiles 

### DIFF
--- a/test-network-k8s/kube/fabric-rest-sample.yaml
+++ b/test-network-k8s/kube/fabric-rest-sample.yaml
@@ -27,7 +27,7 @@ data:
             "Org1": {
                 "mspid": "Org1MSP",
                 "peers": [
-                    "org1-peer1"
+                    "org1-peers"
                 ],
                 "certificateAuthorities": [
                     "org1-ca"
@@ -35,15 +35,15 @@ data:
             }
         },
         "peers": {
-            "org1-peer1": {
-                "url": "grpcs://org1-peer1:7051",
+            "org1-peers": {
+                "url": "grpcs://org1-peer-gateway-svc:7051",
                 "tlsCACerts": {
                     "pem": "-----BEGIN CERTIFICATE-----\\nMIICvzCCAmWgAwIBAgIULJGws7jbEY6ruSgDuvi9L7VphvIwCgYIKoZIzj0EAwIw\\naDELMAkGA1UEBhMCVVMxFzAVBgNVBAgTDk5vcnRoIENhcm9saW5hMRQwEgYDVQQK\\nEwtIeXBlcmxlZGdlcjEPMA0GA1UECxMGRmFicmljMRkwFwYDVQQDExBmYWJyaWMt\\nY2Etc2VydmVyMB4XDTIxMDkyMDE2MDkwMFoXDTIyMDkyMDE2MTQwMFowYDELMAkG\\nA1UEBhMCVVMxFzAVBgNVBAgTDk5vcnRoIENhcm9saW5hMRQwEgYDVQQKEwtIeXBl\\ncmxlZGdlcjENMAsGA1UECxMEcGVlcjETMBEGA1UEAxMKb3JnMS1wZWVyMTBZMBMG\\nByqGSM49AgEGCCqGSM49AwEHA0IABL9e3GZBf1MeoObGxwSHkcgDEjMo+/13Qc4u\\nfSG2MKrveHBIEA4MRkHNqd+sTjoz0/1B15y2n+RiPo8uJvlyC/CjgfQwgfEwDgYD\\nVR0PAQH/BAQDAgOoMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAMBgNV\\nHRMBAf8EAjAAMB0GA1UdDgQWBBSeytspiXlEzMAsnF9/wxqc9fydETAfBgNVHSME\\nGDAWgBQwru1VH0OwH3dxfPdD8w74ZIlLRzAVBgNVHREEDjAMggpvcmcxLXBlZXIx\\nMFsGCCoDBAUGBwgBBE97ImF0dHJzIjp7ImhmLkFmZmlsaWF0aW9uIjoiIiwiaGYu\\nRW5yb2xsbWVudElEIjoib3JnMS1wZWVyMSIsImhmLlR5cGUiOiJwZWVyIn19MAoG\\nCCqGSM49BAMCA0gAMEUCIQDJEjPxceCfXU5B/emrHE4JbEzrZKxLVViBWCNMsHiR\\nFgIgY+8jsvr3rlBPkpRhl8CtT2DgaP7iWvovtMYsPKhLAqk=\\n-----END CERTIFICATE-----\\n"
                   },
                 "grpcOptions": {
                     "grpc-wait-for-ready-timeout": 100000,
-                    "ssl-target-name-override": "org1-peer1",
-                    "hostnameOverride": "org1-peer1"
+                    "ssl-target-name-override": "org1-peer-gateway-svc",
+                    "hostnameOverride": "org1-peer-gateway-svc"
                 }
             }
         },
@@ -103,7 +103,7 @@ data:
             "Org2": {
                 "mspid": "Org2MSP",
                 "peers": [
-                    "org2-peer1"
+                    "org2-peers"
                 ],
                 "certificateAuthorities": [
                     "org2-ca"
@@ -111,14 +111,14 @@ data:
             }
         },
         "peers": {
-            "org2-peer1": {
-                "url": "grpcs://org2-peer1:7051",
+            "org2-peers": {
+                "url": "grpcs://org2-peer-gateway-svc:7051",
                 "tlsCACerts": {
                     "pem": "-----BEGIN CERTIFICATE-----\\nMIICKDCCAc6gAwIBAgIUJJ4wGOSCfw8XOOIx29o67wBpFB4wCgYIKoZIzj0EAwIw\\naDELMAkGA1UEBhMCVVMxFzAVBgNVBAgTDk5vcnRoIENhcm9saW5hMRQwEgYDVQQK\\nEwtIeXBlcmxlZGdlcjEPMA0GA1UECxMGRmFicmljMRkwFwYDVQQDExBmYWJyaWMt\\nY2Etc2VydmVyMB4XDTIxMDkyMDExNDEwMFoXDTM2MDkxNjExNDEwMFowaDELMAkG\\nA1UEBhMCVVMxFzAVBgNVBAgTDk5vcnRoIENhcm9saW5hMRQwEgYDVQQKEwtIeXBl\\ncmxlZGdlcjEPMA0GA1UECxMGRmFicmljMRkwFwYDVQQDExBmYWJyaWMtY2Etc2Vy\\ndmVyMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEyzGJLZX6pe59QAIBacjfzU4I\\nHezBYLyEu4ySpFx4xwxNLE4BWqLhB1VaOuenSQATM8pmSAy7i1830oM9elKWK6NW\\nMFQwDgYDVR0PAQH/BAQDAgEGMBIGA1UdEwEB/wQIMAYBAf8CAQEwHQYDVR0OBBYE\\nFEoAAhmjq/3M8CFPc7N8SL53erL5MA8GA1UdEQQIMAaHBH8AAAEwCgYIKoZIzj0E\\nAwIDSAAwRQIhAJQ5PJOT4Gg8oiBU2KthMPkZqOLeu3Li4S3yBpLFgbsgAiB960P2\\nXPMu3HLoNXrktYOL9JzWlGyYRSPAnkap5Bsj0w==\\n-----END CERTIFICATE-----\\n"
                 },
                 "grpcOptions": {
-                    "ssl-target-name-override": "org2-peer1",
-                    "hostnameOverride": "org2-peer1"
+                    "ssl-target-name-override": "org2-peer-gateway-svc",
+                    "hostnameOverride": "org2-peer-gateway-svc"
                 }
             }
         },

--- a/test-network-k8s/kube/org1/org1-peer1.yaml
+++ b/test-network-k8s/kube/org1/org1-peer1.yaml
@@ -17,6 +17,7 @@ spec:
   dnsNames:
     - localhost
     - org1-peer1
+    - org1-peer-gateway-svc
     - org1-peer1.test-network.svc.cluster.local
   ipAddresses:
     - 127.0.0.1

--- a/test-network-k8s/kube/org1/org1-peer2.yaml
+++ b/test-network-k8s/kube/org1/org1-peer2.yaml
@@ -17,6 +17,7 @@ spec:
   dnsNames:
     - localhost
     - org1-peer2
+    - org1-peer-gateway-svc
     - org1-peer2.test-network.svc.cluster.local
   ipAddresses:
     - 127.0.0.1

--- a/test-network-k8s/kube/org2/org2-peer1.yaml
+++ b/test-network-k8s/kube/org2/org2-peer1.yaml
@@ -17,7 +17,7 @@ spec:
   dnsNames:
     - localhost
     - org2-peer1
-    - org1-peer-gateway-svc
+    - org2-peer-gateway-svc
     - org2-peer1.test-network.svc.cluster.local
   ipAddresses:
     - 127.0.0.1

--- a/test-network-k8s/kube/org2/org2-peer1.yaml
+++ b/test-network-k8s/kube/org2/org2-peer1.yaml
@@ -17,6 +17,7 @@ spec:
   dnsNames:
     - localhost
     - org2-peer1
+    - org1-peer-gateway-svc
     - org2-peer1.test-network.svc.cluster.local
   ipAddresses:
     - 127.0.0.1

--- a/test-network-k8s/kube/org2/org2-peer2.yaml
+++ b/test-network-k8s/kube/org2/org2-peer2.yaml
@@ -17,7 +17,7 @@ spec:
   dnsNames:
     - localhost
     - org2-peer2
-    - org1-peer-gateway-svc
+    - org2-peer-gateway-svc
     - org2-peer2.test-network.svc.cluster.local
   ipAddresses:
     - 127.0.0.1

--- a/test-network-k8s/kube/org2/org2-peer2.yaml
+++ b/test-network-k8s/kube/org2/org2-peer2.yaml
@@ -17,6 +17,7 @@ spec:
   dnsNames:
     - localhost
     - org2-peer2
+    - org1-peer-gateway-svc
     - org2-peer2.test-network.svc.cluster.local
   ipAddresses:
     - 127.0.0.1

--- a/test-network-k8s/scripts/ccp-template.json
+++ b/test-network-k8s/scripts/ccp-template.json
@@ -15,29 +15,29 @@
         "Org${ORG}": {
             "mspid": "Org${ORG}MSP",
             "peers": [
-                "org${ORG}-peer1"
+                "org${ORG}-peers"
             ],
             "certificateAuthorities": [
-                "org${ORG}-ecert-ca"
+                "org${ORG}-ca"
             ]
         }
     },
     "peers": {
-        "org${ORG}-peer1": {
-            "url": "grpcs://org${ORG}-peer1:7051",
+        "org${ORG}-peers": {
+            "url": "grpcs://org${ORG}-peer-gateway-svc:7051",
             "tlsCACerts": {
                 "pem": "${PEERPEM}"
             },
             "grpcOptions": {
-                "ssl-target-name-override": "org${ORG}-peer1",
-                "hostnameOverride": "org${ORG}-peer1"
+                "ssl-target-name-override": "org${ORG}-peer-gateway-svc",
+                "hostnameOverride": "org${ORG}-peer-gateway-svc"
             }
         }
     },
     "certificateAuthorities": {
-        "org${ORG}-ecert-ca": {
-            "url": "https://org${ORG}-ecert-ca",
-            "caName": "org${ORG}-ecert-ca",
+        "org${ORG}-ca": {
+            "url": "https://org${ORG}-ca",
+            "caName": "org${ORG}-ca",
             "tlsCACerts": {
                 "pem": ["${CAPEM}"]
             },


### PR DESCRIPTION
**Signed-off-by:** Charalarg <charalarg@gmail.com>

**Type of change:**

- New feature
- Bug fix

**Description:**

With these changes applications use the gateway-svc services in order to establish connection with any available peer on each organization rather than connecting manually to peer1. 

The service names need also to be added as dnsName in each peer TLS certificate configuration.

**Resolves:** #635 

