### PR TITLE
Issue 602

### DIFF
--- a/test-network/network.sh
+++ b/test-network/network.sh
@@ -267,9 +267,25 @@ function networkUp() {
 # call the script to create the channel, join the peers of org1 and org2,
 # and then update the anchor peers for each organization
 function createChannel() {
-  # Bring up the network if it is not already up.
+  # Bring up the network if it is not already up. 
+  bringUpNetwork="false"
 
-   if [ ! -d "organizations/peerOrganizations" ] || ! $CONTAINER_CLI info > /dev/null 2>&1; then
+  if ! $CONTAINER_CLI info > /dev/null 2>&1 ; then
+    fatalln "$CONTAINER_CLI network is required to be running to create a channel"
+  fi
+
+  # check if all containers are present 
+  CONTAINERS=($($CONTAINER_CLI ps | grep hyperledger/ | awk '{print $2}'))
+  len=$(echo ${#CONTAINERS[@]})
+  
+  if [[ $len -ge 4 ]] && [[ ! -d "organizations/peerOrganizations" ]]; then
+    echo "Bringing network down to sync certs with containers"
+    networkDown 
+  fi
+
+  [[ $len -lt 4 ]] || [[ ! -d "organizations/peerOrganizations" ]] && bringUpNetwork="true" || echo "Network Running Already"
+
+  if [ $bringUpNetwork == "true"  ]; then
     infoln "Bringing up network"
     networkUp
   fi

--- a/test-network/network.sh
+++ b/test-network/network.sh
@@ -269,7 +269,7 @@ function networkUp() {
 function createChannel() {
   # Bring up the network if it is not already up.
 
-  if [ ! -d "organizations/peerOrganizations" ]; then
+   if [ ! -d "organizations/peerOrganizations" ] || ! $CONTAINER_CLI info > /dev/null 2>&1; then
     infoln "Bringing up network"
     networkUp
   fi


### PR DESCRIPTION
Flow:

Check if docker network is running. 
If network is not running exit
If running, and containers are present + certs are present skip network up
If running, containers are not present then we should networkUp
If containers exist but certs don’t, bring network down and then networkUp

When containers are running but for some reason peerOrganisation dir was not present, the following error: 
`Failed to generate channel configuration transaction...` may be awkward to debug. So this is why there is a check to see if peerOrg does not exist but the containers do. 


Test Cases: 

1) Docker is not running 
```
./network.sh up createChannel -ca
Using docker and docker-compose
Creating channel 'mychannel'.
If network is not up, starting nodes with CLI timeout of '5' tries and CLI delay of '3' seconds and using database 'leveldb 
docker network is required to be running to create a channel
```

2) Docker is running but containers are not, peerOrganizations directory exists
```
./network.sh up createChannel -ca
Using docker and docker-compose
Creating channel 'mychannel'.
If network is not up, starting nodes with CLI timeout of '5' tries and CLI delay of '3' seconds and using database 'leveldb 
Bringing up network
LOCAL_VERSION=2.4.1
DOCKER_IMAGE_VERSION=2.4.1
CA_LOCAL_VERSION=1.5.2
CA_DOCKER_IMAGE_VERSION=1.5.2
WARN[0000] Found orphan containers ([ca_org2 ca_org1 ca_orderer]) for this project. If you removed or renamed this service in your compose file, you can run this command with the --remove-orphans flag to clean it up. 
[+] Running 4/4
 ⠿ Container peer0.org2.example.com  Started                                                                                                                                                                                                                               0.6s
 ⠿ Container peer0.org1.example.com  Started                                                                                                                                                                                                                               0.6s
 ⠿ Container orderer.example.com     Started                                                                                                                                                                                                                               0.6s
 ⠿ Container cli                     Started  
```
3) Containers running but  peerOrganizations directory does not exist
```
./network.sh up createChannel -ca
Using docker and docker-compose
Creating channel 'mychannel'.
If network is not up, starting nodes with CLI timeout of '5' tries and CLI delay of '3' seconds and using database 'leveldb with crypto from 'Certificate Authorities'
Decomposing compose-test-net.yaml
[+] Running 10/7
 ⠿ Container orderer.example.com          Removed                                                                                                                                                                                                                          0.2s
 ⠿ Container cli                          Removed                                                                                                                                                                                                                         10.2s
 ⠿ Container peer0.org1.example.com       Removed                                                                                                                                                                                                                          0.3s
 ⠿ Container peer0.org2.example.com       Removed                                                                                                                                                                                                                          0.3s
 ⠿ Container ca_orderer                   Removed                                                                                                                                                                                                                          0.3s
 ⠿ Container ca_org2                      Removed                                                                                                                                                                                                                          0.3s
 ⠿ Container ca_org1                      Removed                                                                                                                                                                                                                          0.3s
 ⠿ Volume compose_peer0.org2.example.com  Removed                                                                                                                                                                                                                          0.0s
 ⠿ Volume compose_peer0.org1.example.com  Removed                                                                                                                                                                                                                          0.0s
 ⠿ Volume compose_orderer.example.com     Removed                                                                                                                                                                                                                          0.0s
Decomposing compose-couch.yaml
service "peer0.org1.example.com" has neither an image nor a build context specified: invalid compose project
Decomposing compose-ca.yaml
[+] Running 1/0
 ⠿ compose  Warning: No resource found to remove                                                                                                                                                                                                                           0.0s
Error: No such volume: docker_orderer.example.com
Error: No such volume: docker_peer0.org1.example.com
Error: No such volume: docker_peer0.org2.example.com
Removing remaining containers
Removing generated chaincode docker images
"docker kill" requires at least 1 argument.
See 'docker kill --help'.

Usage:  docker kill [OPTIONS] CONTAINER [CONTAINER...]

Kill one or more running containers
Bringing up network
LOCAL_VERSION=2.4.1
DOCKER_IMAGE_VERSION=2.4.1
CA_LOCAL_VERSION=1.5.2
...
```

Signed-off-by: Kieran O Mahony [Kieran.O.Mahony1@ibm.com](mailto:Kieran.O.Mahony1@ibm.com)
