### PR TITLE
Fix sample external chaincode Dockerfile

### DIFF
--- a/asset-transfer-basic/chaincode-typescript/Dockerfile
+++ b/asset-transfer-basic/chaincode-typescript/Dockerfile
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 FROM node:16 AS builder
-ARG CC_SERVER_PORT
 
 WORKDIR /usr/src/app
 
@@ -12,6 +11,7 @@ RUN npm ci && npm run package
 
 
 FROM node:16 AS production
+ARG CC_SERVER_PORT
 
 # Setup tini to work better handle signals
 ENV TINI_VERSION v0.19.0


### PR DESCRIPTION
Podman isn't as lenient as docker when it comes to the syntax of the
Dockerfile and insists on getting the ARG command properly scoped.
This fixes this error:
...
[2/2] STEP 12/15: EXPOSE $CC_SERVER_PORT
Error: error building at STEP "EXPOSE $CC_SERVER_PORT": EXPOSE requires at least one argument

Signed-off-by: Arnaud J Le Hors <lehors@us.ibm.com>