### PR TITLE
fix docker compose version 2 -> 2.1

### DIFF
--- a/test-network/addOrg3/docker/docker-compose-ca-org3.yaml
+++ b/test-network/addOrg3/docker/docker-compose-ca-org3.yaml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-version: '2'
+version:'2.1'
 
 networks:
   test:

--- a/test-network/addOrg3/docker/docker-compose-ca-org3.yaml
+++ b/test-network/addOrg3/docker/docker-compose-ca-org3.yaml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-version:'2.1'
+version: '2.1'
 
 networks:
   test:

--- a/test-network/addOrg3/docker/docker-compose-couch-org3.yaml
+++ b/test-network/addOrg3/docker/docker-compose-couch-org3.yaml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-version: '2'
+version:'2.1'
 
 networks:
   test:

--- a/test-network/addOrg3/docker/docker-compose-couch-org3.yaml
+++ b/test-network/addOrg3/docker/docker-compose-couch-org3.yaml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-version:'2.1'
+version: '2.1'
 
 networks:
   test:

--- a/test-network/addOrg3/docker/docker-compose-org3.yaml
+++ b/test-network/addOrg3/docker/docker-compose-org3.yaml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-version: '2'
+version:'2.1'
 
 volumes:
   peer0.org3.example.com:

--- a/test-network/addOrg3/docker/docker-compose-org3.yaml
+++ b/test-network/addOrg3/docker/docker-compose-org3.yaml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-version:'2.1'
+version: '2.1'
 
 volumes:
   peer0.org3.example.com:

--- a/test-network/docker/docker-compose-ca.yaml
+++ b/test-network/docker/docker-compose-ca.yaml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-version: '2'
+version:'2.1'
 
 networks:
   test:

--- a/test-network/docker/docker-compose-ca.yaml
+++ b/test-network/docker/docker-compose-ca.yaml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-version:'2.1'
+version: '2.1'
 
 networks:
   test:

--- a/test-network/docker/docker-compose-couch.yaml
+++ b/test-network/docker/docker-compose-couch.yaml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-version: '2'
+version:'2.1'
 
 networks:
   test:

--- a/test-network/docker/docker-compose-couch.yaml
+++ b/test-network/docker/docker-compose-couch.yaml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-version:'2.1'
+version: '2.1'
 
 networks:
   test:

--- a/test-network/docker/docker-compose-test-net.yaml
+++ b/test-network/docker/docker-compose-test-net.yaml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-version:'2.1'
+version: '2.1'
 
 volumes:
   orderer.example.com:

--- a/test-network/docker/docker-compose-test-net.yaml
+++ b/test-network/docker/docker-compose-test-net.yaml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-version: '2'
+version:'2.1'
 
 volumes:
   orderer.example.com:


### PR DESCRIPTION
Earlier compose version was giving a property error when running the [fabric-samples/test-network/network.sh](https://github.com/hyperledger/fabric-samples/blob/main/test-network/network.sh) script.
![compose_error](https://user-images.githubusercontent.com/16841301/154474662-ceb92110-ba54-4887-935d-bc0db32da006.png)

Docker Compose Documentation says that the property [networks:name](https://docs.docker.com/compose/compose-file/compose-file-v2/#name-1) was added in [v2.1](https://docs.docker.com/compose/compose-file/compose-versioning/#version-21) file format.
Signed-off-by: kaushikkumarbora <kaushikkumarbora@gmail.com>