### PR TITLE
Add external chaincode service for Nano Test Network

### DIFF
--- a/test-network-nano-bash/chaincode-external/connection.json
+++ b/test-network-nano-bash/chaincode-external/connection.json
@@ -1,0 +1,5 @@
+{
+  "address": "127.0.0.1:9999",
+  "dial_timeout": "10s",
+  "tls_required": false
+}

--- a/test-network-nano-bash/chaincode-external/metadata.json
+++ b/test-network-nano-bash/chaincode-external/metadata.json
@@ -1,0 +1,4 @@
+{
+    "type": "ccaas",
+    "label": "basic_1.0"
+}


### PR DESCRIPTION
This addresses Issue #504. This extends the test-network-nano-bash
sample to offer an option to run a fabric network without using any
containers at all. The chaincode is running as an external service
directly on the host machine.

Signed-off-by: Arnaud J Le Hors <lehors@us.ibm.com>