### PR TITLE
Remove bash dependency from test network nano

### DIFF
--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -98,6 +98,8 @@ jobs:
         inputs:
           versionSpec: $(NODE_VER)
         displayName: Install Node.js
+      - script: ./ci/scripts/shellcheck.sh
+        displayName: Lint Shell Scripts
       - script: ./ci/scripts/lint.sh
         displayName: Lint Code
 

--- a/ci/scripts/shellcheck.sh
+++ b/ci/scripts/shellcheck.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -euo pipefail
+
+scversion="v0.8.0" # or "stable", or "latest"
+wget -qO- "https://github.com/koalaman/shellcheck/releases/download/${scversion?}/shellcheck-${scversion?}.linux.x86_64.tar.xz" | tar -xJv "shellcheck-${scversion}/shellcheck"
+"./shellcheck-${scversion}/shellcheck" --version
+
+"./shellcheck-${scversion}/shellcheck" ./test-network-nano-bash/*.sh

--- a/test-network-nano-bash/generate_artifacts.sh
+++ b/test-network-nano-bash/generate_artifacts.sh
@@ -1,5 +1,5 @@
-#!/usr/bin/env bash
-set -euo pipefail
+#!/usr/bin/env sh
+set -eu
 
 # remove existing artifacts, or proceed on if the directories don't exist
 rm -r "${PWD}"/channel-artifacts || true

--- a/test-network-nano-bash/orderer1.sh
+++ b/test-network-nano-bash/orderer1.sh
@@ -1,5 +1,5 @@
-#!/usr/bin/env bash
-set -euo pipefail
+#!/usr/bin/env sh
+set -eu
 
 # look for binaries in local dev environment /build/bin directory and then in local samples /bin directory
 export PATH="${PWD}"/../../fabric/build/bin:"${PWD}"/../bin:"$PATH"

--- a/test-network-nano-bash/orderer2.sh
+++ b/test-network-nano-bash/orderer2.sh
@@ -1,5 +1,5 @@
-#!/usr/bin/env bash
-set -euo pipefail
+#!/usr/bin/env sh
+set -eu
 
 # look for binaries in local dev environment /build/bin directory and then in local samples /bin directory
 export PATH="${PWD}"/../../fabric/build/bin:"${PWD}"/../bin:"$PATH"

--- a/test-network-nano-bash/orderer3.sh
+++ b/test-network-nano-bash/orderer3.sh
@@ -1,5 +1,5 @@
-#!/usr/bin/env bash
-set -euo pipefail
+#!/usr/bin/env sh
+set -eu
 
 # look for binaries in local dev environment /build/bin directory and then in local samples /bin directory
 export PATH="${PWD}"/../../fabric/build/bin:"${PWD}"/../bin:"$PATH"

--- a/test-network-nano-bash/peer1.sh
+++ b/test-network-nano-bash/peer1.sh
@@ -1,7 +1,7 @@
-#!/usr/bin/env bash
-set -euo pipefail
+#!/usr/bin/env sh
+set -eu
 
-if [ "$(uname)" == "Linux" ] ; then
+if [ "$(uname)" = "Linux" ] ; then
   CCADDR="127.0.0.1"
 else
   CCADDR="host.docker.internal"

--- a/test-network-nano-bash/peer1admin.sh
+++ b/test-network-nano-bash/peer1admin.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 # look for binaries in local dev environment /build/bin directory and then in local samples /bin directory
 export PATH="${PWD}"/../../fabric/build/bin:"${PWD}"/../bin:"$PATH"

--- a/test-network-nano-bash/peer2.sh
+++ b/test-network-nano-bash/peer2.sh
@@ -1,7 +1,7 @@
-#!/usr/bin/env bash
-set -euo pipefail
+#!/usr/bin/env sh
+set -eu
 
-if [ "$(uname)" == "Linux" ] ; then
+if [ "$(uname)" = "Linux" ] ; then
   CCADDR="127.0.0.1"
 else
   CCADDR="host.docker.internal"

--- a/test-network-nano-bash/peer2admin.sh
+++ b/test-network-nano-bash/peer2admin.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 # look for binaries in local dev environment /build/bin directory and then in local samples /bin directory
 export PATH="${PWD}"/../../fabric/build/bin:"${PWD}"/../bin:"$PATH"

--- a/test-network-nano-bash/peer3.sh
+++ b/test-network-nano-bash/peer3.sh
@@ -1,7 +1,7 @@
-#!/usr/bin/env bash
-set -euo pipefail
+#!/usr/bin/env sh
+set -eu
 
-if [ "$(uname)" == "Linux" ] ; then
+if [ "$(uname)" = "Linux" ] ; then
   CCADDR="127.0.0.1"
 else
   CCADDR="host.docker.internal"

--- a/test-network-nano-bash/peer3admin.sh
+++ b/test-network-nano-bash/peer3admin.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 # look for binaries in local dev environment /build/bin directory and then in local samples /bin directory
 export PATH="${PWD}"/../../fabric/build/bin:"${PWD}"/../bin:"$PATH"

--- a/test-network-nano-bash/peer4.sh
+++ b/test-network-nano-bash/peer4.sh
@@ -1,7 +1,7 @@
-#!/usr/bin/env bash
-set -euo pipefail
+#!/usr/bin/env sh
+set -eu
 
-if [ "$(uname)" == "Linux" ] ; then
+if [ "$(uname)" = "Linux" ] ; then
   CCADDR="127.0.0.1"
 else
   CCADDR="host.docker.internal"

--- a/test-network-nano-bash/peer4admin.sh
+++ b/test-network-nano-bash/peer4admin.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 # look for binaries in local dev environment /build/bin directory and then in local samples /bin directory
 export PATH="${PWD}"/../../fabric/build/bin:"${PWD}"/../bin:"$PATH"


### PR DESCRIPTION
The scripts do not require bash so switch to sh and add shellcheck linting

Signed-off-by: James Taylor <jamest@uk.ibm.com>