### PR TITLE
Override default port of CA connection on CCP teample

### DIFF
--- a/test-network-k8s/scripts/ccp-template.json
+++ b/test-network-k8s/scripts/ccp-template.json
@@ -36,7 +36,7 @@
     },
     "certificateAuthorities": {
         "org${ORG}-ca": {
-            "url": "https://org${ORG}-ca",
+            "url": "https://org${ORG}-ca:443",
             "caName": "org${ORG}-ca",
             "tlsCACerts": {
                 "pem": ["${CAPEM}"]


### PR DESCRIPTION
**Signed-off-by**: Charalarg [charalarg@gmail.com](mailto:charalarg@gmail.com)

**Type of change**:
- Bug fix

**Description**:

In test-network-k8s the certificate authorities are deployed with TLS enabled under the port 443. But the connection profile template implements a connection to the default (7054) port of the certificate authority. 