### PR TITLE
[release-2.2] Missing await in asset-transfer-basic chaincode

### DIFF
--- a/asset-transfer-basic/chaincode-javascript/lib/assetTransfer.js
+++ b/asset-transfer-basic/chaincode-javascript/lib/assetTransfer.js
@@ -72,7 +72,7 @@ class AssetTransfer extends Contract {
             Owner: owner,
             AppraisedValue: appraisedValue,
         };
-        ctx.stub.putState(id, Buffer.from(JSON.stringify(asset)));
+        await ctx.stub.putState(id, Buffer.from(JSON.stringify(asset)));
         return JSON.stringify(asset);
     }
 


### PR DESCRIPTION
Missing an `await` on the asset-transfer-basic javascript chaincode.

This has been fixed in the main branch but needs to be fixed in the
release-2.2 branch

Signed-off-by: D <d_kelsey@uk.ibm.com>