### PR TITLE
Fix Linting: Add in a `-not -path` option to find 

### DIFF
--- a/ci/scripts/lint.sh
+++ b/ci/scripts/lint.sh
@@ -10,7 +10,7 @@ function print() {
 
 go install golang.org/x/tools/cmd/goimports@latest
 
-dirs=("$(find . -name "*-go" -o -name "*-java" -o -name "*-javascript" -o -name "*-typescript")")
+dirs=("$(find . -name "*-go" -o -name "*-java" -o -name "*-javascript" -o -name "*-typescript"  -not -path '*/.*')")
 for dir in $dirs; do
   if [[ -d $dir ]] && [[ ! $dir =~ node_modules  ]]; then
     print "Linting $dir"


### PR DESCRIPTION
Fix errors like this that occur from time to time..
```
Linting ./.git/refs/remotes/origin/dependabot/npm_and_yarn/asset-transfer-basic/rest-api-typescript
~/work/1/s/.git/refs/remotes/origin/dependabot/npm_and_yarn/asset-transfer-basic/rest-api-typescript ~/work/1/s
```




Signed-off-by: Matthew B White <whitemat@uk.ibm.com>