### PR TITLE
test-network-k8s: Support for Loading images for rest sample to KIND

### DIFF
--- a/test-network-k8s/network
+++ b/test-network-k8s/network
@@ -174,6 +174,11 @@ elif [ "${MODE}" == "chaincode" ]; then
 elif [ "${MODE}" == "anchor" ]; then
   update_anchor_peers $@
 
+elif [ "${MODE}" == "load-images-for-rest-easy" ]; then
+  log "Loading images for fabric-rest-sample to KIND:"
+  load_docker_images_for_rest_sample
+  log "🏁 - Images loaded."
+
 elif [ "${MODE}" == "rest-easy" ]; then
   log "Launching fabric-rest-sample application:"
   launch_rest_sample

--- a/test-network-k8s/scripts/kind.sh
+++ b/test-network-k8s/scripts/kind.sh
@@ -13,6 +13,7 @@ function pull_docker_images() {
   docker pull ${FABRIC_CONTAINER_REGISTRY}/fabric-peer:$FABRIC_VERSION
   docker pull ${FABRIC_CONTAINER_REGISTRY}/fabric-tools:$FABRIC_VERSION
   docker pull ghcr.io/hyperledgendary/fabric-ccaas-asset-transfer-basic:latest
+  docker pull couchdb:3.2.1
 
   pop_fn
 }
@@ -26,9 +27,28 @@ function load_docker_images() {
   kind load docker-image ${FABRIC_CONTAINER_REGISTRY}/fabric-tools:$FABRIC_VERSION
   kind load docker-image ghcr.io/hyperledgendary/fabric-ccaas-asset-transfer-basic:latest
   kind load docker-image couchdb:3.2.1
-  
-  pop_fn 
+
+  pop_fn
 }
+
+function pull_docker_images_for_rest_sample() {
+  push_fn "Pulling docker images for fabric-rest-sample"
+
+  docker pull ghcr.io/hyperledger/fabric-rest-sample:latest
+  docker pull redis:6.2.5
+
+  pop_fn
+}
+
+function load_docker_images_for_rest_sample() {
+  push_fn "Loading docker images for fabric-rest-sample to KIND control plane"
+
+  kind load docker-image ghcr.io/hyperledgendary/fabric-ccaas-asset-transfer-basic:latest
+  kind load docker-image redis:6.2.5
+
+  pop_fn
+}
+
 
 function apply_nginx_ingress() {
   push_fn "Launching ingress controller"
@@ -181,8 +201,10 @@ function kind_init() {
   launch_docker_registry
 
   if [ "${STAGE_DOCKER_IMAGES}" == true ]; then
-    pull_docker_images 
-    load_docker_images 
+    pull_docker_images
+    load_docker_images
+    pull_docker_images_for_rest_sample
+    load_docker_images_for_rest_sample
   fi
 
   wait_for_cert_manager


### PR DESCRIPTION
This patch supports for pulling all images to the local docker cache and loading to KIND.

Also, this adds the missing docker image pulling (couchdb) for Fabric.

Signed-off-by: Tatsuya Sato <tatsuya.sato.so@hitachi.com>