### PR TITLE
fix wrong indentationin in the connection profile  generated for Org 3

### DIFF
--- a/test-network/addOrg3/ccp-generate.sh
+++ b/test-network/addOrg3/ccp-generate.sh
@@ -23,7 +23,7 @@ function yaml_ccp {
         -e "s/\${CAPORT}/$3/" \
         -e "s#\${PEERPEM}#$PP#" \
         -e "s#\${CAPEM}#$CP#" \
-        ccp-template.yaml | sed -e $'s/\\\\n/\\\n        /g'
+        ccp-template.yaml | sed -e $'s/\\\\n/\\\n          /g'
 }
 
 ORG=3

--- a/test-network/addOrg3/ccp-template.yaml
+++ b/test-network/addOrg3/ccp-template.yaml
@@ -19,7 +19,7 @@ peers:
     url: grpcs://localhost:${P0PORT}
     tlsCACerts:
       pem: |
-        ${PEERPEM}
+          ${PEERPEM}
     grpcOptions:
       ssl-target-name-override: peer0.org${ORG}.example.com
       hostnameOverride: peer0.org${ORG}.example.com
@@ -28,7 +28,8 @@ certificateAuthorities:
     url: https://localhost:${CAPORT}
     caName: ca-org${ORG}
     tlsCACerts:
-      pem: |
-        ${CAPEM}
+      pem: 
+        - |
+          ${CAPEM}
     httpOptions:
       verify: false


### PR DESCRIPTION
The connection profile file(yaml) generated for Org3 is having wrong indentation and the Fabric Go SDK fails to parse it. This PR fixes the issue.