### PR TITLE
Use maven central for gateway client dependencies

### DIFF
--- a/commercial-paper/organization/digibank/application-java/dependency-reduced-pom.xml
+++ b/commercial-paper/organization/digibank/application-java/dependency-reduced-pom.xml
@@ -43,19 +43,14 @@
   </build>
   <repositories>
     <repository>
-      <id>hyperledger</id>
-      <name>Hyperledger Artifactory</name>
-      <url>https://hyperledger.jfrog.io/hyperledger/fabric-maven</url>
-    </repository>
-    <repository>
       <id>jitpack.io</id>
       <url>https://jitpack.io</url>
     </repository>
   </repositories>
   <properties>
     <fabric-chaincode-java.version>1.4.2</fabric-chaincode-java.version>
-    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <java.version>1.8</java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>
 </project>

--- a/commercial-paper/organization/digibank/application-java/pom.xml
+++ b/commercial-paper/organization/digibank/application-java/pom.xml
@@ -62,12 +62,6 @@
 
 	<repositories>
 		<repository>
-			<id>hyperledger</id>
-			<name>Hyperledger Artifactory</name>
-			<url>https://hyperledger.jfrog.io/hyperledger/fabric-maven</url>
-		</repository>
-
-		<repository>
 			<id>jitpack.io</id>
 			<url>https://jitpack.io</url>
 		</repository>
@@ -75,9 +69,9 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>org.hyperledger.fabric-gateway-java</groupId>
+			<groupId>org.hyperledger.fabric</groupId>
 			<artifactId>fabric-gateway-java</artifactId>
-			<version>1.4.0-SNAPSHOT</version>
+			<version>1.4.5</version>
 		</dependency>
 
 		<!-- Used for datatype annotations only -->

--- a/commercial-paper/organization/magnetocorp/application-java/dependency-reduced-pom.xml
+++ b/commercial-paper/organization/magnetocorp/application-java/dependency-reduced-pom.xml
@@ -43,19 +43,14 @@
   </build>
   <repositories>
     <repository>
-      <id>hyperledger</id>
-      <name>Hyperledger Artifactory</name>
-      <url>https://hyperledger.jfrog.io/hyperledger/fabric-maven</url>
-    </repository>
-    <repository>
       <id>jitpack.io</id>
       <url>https://jitpack.io</url>
     </repository>
   </repositories>
   <properties>
     <fabric-chaincode-java.version>1.4.2</fabric-chaincode-java.version>
-    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <java.version>1.8</java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>
 </project>

--- a/commercial-paper/organization/magnetocorp/application-java/pom.xml
+++ b/commercial-paper/organization/magnetocorp/application-java/pom.xml
@@ -62,12 +62,6 @@
 
 	<repositories>
 		<repository>
-			<id>hyperledger</id>
-			<name>Hyperledger Artifactory</name>
-			<url>https://hyperledger.jfrog.io/hyperledger/fabric-maven</url>
-		</repository>
-
-		<repository>
 			<id>jitpack.io</id>
 			<url>https://jitpack.io</url>
 		</repository>
@@ -75,9 +69,9 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>org.hyperledger.fabric-gateway-java</groupId>
+			<groupId>org.hyperledger.fabric</groupId>
 			<artifactId>fabric-gateway-java</artifactId>
-			<version>1.4.0-SNAPSHOT</version>
+			<version>1.4.5</version>
 		</dependency>
 
 		<!-- Used for datatype annotations only -->


### PR DESCRIPTION
This PR updates the release-1.4 commercial paper client applications to pull the gateway jars from Maven central.

This PR supersedes PR #585 (abandoned / closed) 
    
Signed-off-by: lyd <luoyaodong98@gmail.com>

Co-authored-by: Josh Kneubuhl <jkneubuh@us.ibm.com>
