### PR TITLE
Enable engine-strict checks for TypeScript Gateway samples

### DIFF
--- a/asset-transfer-basic/application-gateway-typescript/.npmrc
+++ b/asset-transfer-basic/application-gateway-typescript/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/asset-transfer-events/application-gateway-typescript/.npmrc
+++ b/asset-transfer-events/application-gateway-typescript/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/asset-transfer-private-data/application-gateway-typescript/.npmrc
+++ b/asset-transfer-private-data/application-gateway-typescript/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true


### PR DESCRIPTION
Use an .npmrc to enable engine-strict checks so that `npm install` will fail for projects when an incompatible Node version is used, rather than confusing errors about unsupported language features occuring at runtime.

Signed-off-by: Mark S. Lewis <mark_lewis@uk.ibm.com>