### PR TITLE
Update marbles_chaincode.go example

### DIFF
--- a/chaincode/marbles02/go/marbles_chaincode.go
+++ b/chaincode/marbles02/go/marbles_chaincode.go
@@ -62,14 +62,14 @@
 
 // Index for docType, owner.
 //
-// Example curl command line to define index in the CouchDB channel_chaincode database
-// curl -i -X POST -H "Content-Type: application/json" -d "{\"index\":{\"fields\":[\"docType\",\"owner\"]},\"name\":\"indexOwner\",\"ddoc\":\"indexOwnerDoc\",\"type\":\"json\"}" http://hostname:port/myc1_marbles/_index
+// Example curl command line to define index in the CouchDB channel_chaincode database. Default user_name/password in couchdb is admin/adminpw
+// curl -i -X POST -H "Content-Type: application/json" -d "{\"index\":{\"fields\":[\"docType\",\"owner\"]},\"name\":\"indexOwner\",\"ddoc\":\"indexOwnerDoc\",\"type\":\"json\"}" user_name:password@hostname:port/myc1_marbles/_index
 //
 
 // Index for docType, owner, size (descending order).
 //
-// Example curl command line to define index in the CouchDB channel_chaincode database
-// curl -i -X POST -H "Content-Type: application/json" -d "{\"index\":{\"fields\":[{\"size\":\"desc\"},{\"docType\":\"desc\"},{\"owner\":\"desc\"}]},\"ddoc\":\"indexSizeSortDoc\", \"name\":\"indexSizeSortDesc\",\"type\":\"json\"}" http://hostname:port/myc1_marbles/_index
+// Example curl command line to define index in the CouchDB channel_chaincode database. Default user_name/password in couchdb is admin/adminpw
+// curl -i -X POST -H "Content-Type: application/json" -d "{\"index\":{\"fields\":[{\"size\":\"desc\"},{\"docType\":\"desc\"},{\"owner\":\"desc\"}]},\"ddoc\":\"indexSizeSortDoc\", \"name\":\"indexSizeSortDesc\",\"type\":\"json\"}" user_name:password@hostname:port/myc1_marbles/_index
 
 // Rich Query with index design doc and index name specified (Only supported if CouchDB is used as state database):
 //   peer chaincode query -C myc1 -n marbles -c '{"Args":["queryMarbles","{\"selector\":{\"docType\":\"marble\",\"owner\":\"tom\"}, \"use_index\":[\"_design/indexOwnerDoc\", \"indexOwner\"]}"]}'


### PR DESCRIPTION
Running examples should work off-the-shelf. CouchDB now forces to use user_name & password for authentication. This patch fixes an existing example (marbles_chaincode) to work with the current requirements of CouchDB.

Signed-off-by: Obadah Hammoud <obadah.hammoud@outlook.com>