### PR TITLE
fix to replace 443 with NGINX_HTTPS_PORT

### DIFF
--- a/test-network-k8s/scripts/chaincode.sh
+++ b/test-network-k8s/scripts/chaincode.sh
@@ -161,7 +161,7 @@ function invoke_chaincode() {
     -n              $cc_name \
     -C              $CHANNEL_NAME \
     -c              $@ \
-    --orderer       org0-orderer1.${DOMAIN}:443 \
+    --orderer       org0-orderer1.${DOMAIN}:${NGINX_HTTPS_PORT} \
     --connTimeout   ${ORDERER_TIMEOUT} \
     --tls --cafile  ${TEMP_DIR}/channel-msp/ordererOrganizations/org0/orderers/org0-orderer1/tls/signcerts/tls-cert.pem
 
@@ -301,7 +301,7 @@ function approve_chaincode() {
     --version       1 \
     --package-id    ${cc_id} \
     --sequence      1 \
-    --orderer       org0-orderer1.${DOMAIN}:443 \
+    --orderer       org0-orderer1.${DOMAIN}:${NGINX_HTTPS_PORT} \
     --connTimeout   ${ORDERER_TIMEOUT} \
     --tls --cafile  ${TEMP_DIR}/channel-msp/ordererOrganizations/org0/orderers/org0-orderer1/tls/signcerts/tls-cert.pem
 
@@ -323,7 +323,7 @@ function commit_chaincode() {
     --name          ${cc_name} \
     --version       1 \
     --sequence      1 \
-    --orderer       org0-orderer1.${DOMAIN}:443 \
+    --orderer       org0-orderer1.${DOMAIN}:${NGINX_HTTPS_PORT} \
     --connTimeout   ${ORDERER_TIMEOUT} \
     --tls --cafile  ${TEMP_DIR}/channel-msp/ordererOrganizations/org0/orderers/org0-orderer1/tls/signcerts/tls-cert.pem
 

--- a/test-network-k8s/scripts/channel.sh
+++ b/test-network-k8s/scripts/channel.sh
@@ -105,7 +105,7 @@ function enroll_org_admin() {
 
   CA_AUTH=${username}:${password}
   CA_HOST=${CA_NAME}.${DOMAIN}
-  CA_PORT=443
+  CA_PORT=${NGINX_HTTPS_PORT}
   CA_URL=https://${CA_AUTH}@${CA_HOST}:${CA_PORT}
 
   # Read the CA's TLS certificate from the cert-manager CA secret
@@ -183,7 +183,7 @@ function create_channel_org_MSP() {
   # extract the CA's signing authority from the CA/cainfo response
   curl -s \
     --cacert ${TEMP_DIR}/cas/${ca_name}/tlsca-cert.pem \
-    https://${ca_name}.${DOMAIN}/cainfo \
+    https://${ca_name}.${DOMAIN}:${NGINX_HTTPS_PORT}/cainfo \
     | jq -r .result.CAChain \
     | base64 -d \
     > ${ORG_MSP_DIR}/cacerts/ca-signcert.pem
@@ -249,7 +249,7 @@ function join_channel_orderer() {
   # The client certificate presented in this case is the admin user's enrollment key.  This is a stronger assertion
   # of identity than the Docker Compose network, which transmits the orderer node's TLS key pair directly
   osnadmin channel join \
-    --orderer-address ${org}-${orderer}-admin.${DOMAIN} \
+    --orderer-address ${org}-${orderer}-admin.${DOMAIN}:${NGINX_HTTPS_PORT} \
     --ca-file         ${TEMP_DIR}/channel-msp/ordererOrganizations/${org}/orderers/${org}-${orderer}/tls/signcerts/tls-cert.pem \
     --client-cert     ${TEMP_DIR}/enrollments/${org}/users/${org}admin/msp/signcerts/cert.pem \
     --client-key      ${TEMP_DIR}/enrollments/${org}/users/${org}admin/msp/keystore/key.pem \

--- a/test-network-k8s/scripts/utils.sh
+++ b/test-network-k8s/scripts/utils.sh
@@ -100,7 +100,7 @@ function export_peer_context() {
   local peer=$2
 
   export FABRIC_CFG_PATH=${PWD}/config/${org}
-  export CORE_PEER_ADDRESS=${org}-${peer}.${DOMAIN}:443
+  export CORE_PEER_ADDRESS=${org}-${peer}.${DOMAIN}:${NGINX_HTTPS_PORT}
   export CORE_PEER_MSPCONFIGPATH=${TEMP_DIR}/enrollments/${org}/users/${org}admin/msp
   export CORE_PEER_TLS_ROOTCERT_FILE=${TEMP_DIR}/channel-msp/peerOrganizations/${org}/msp/tlscacerts/tlsca-signcert.pem
 }


### PR DESCRIPTION
this fix replace hardcoded port 443 with NGINX_HTTPS_PORT which is useful in case ingress is installed on non conventional ports