### PR TITLE
Bump chaincode builder to v0.6.0 : +couchdb indexes

### DIFF
--- a/test-network-k8s/kube/fabric-builder-role.yaml
+++ b/test-network-k8s/kube/fabric-builder-role.yaml
@@ -19,5 +19,8 @@ rules:
       - secrets
     verbs:
       - get
+      - list
       - watch
       - create
+      - delete
+      - patch

--- a/test-network-k8s/network
+++ b/test-network-k8s/network
@@ -33,7 +33,7 @@ export CHANNEL_NAME=${TEST_NETWORK_CHANNEL_NAME:-mychannel}
 export ORDERER_TIMEOUT=${TEST_NETWORK_ORDERER_TIMEOUT:-10s}         # see https://github.com/hyperledger/fabric/issues/3372
 export TEMP_DIR=${PWD}/build
 export CHAINCODE_BUILDER=${TEST_NETWORK_CHAINCODE_BUILDER:-ccaas}   # see https://github.com/hyperledgendary/fabric-builder-k8s/blob/main/docs/TEST_NETWORK_K8S.md
-export K8S_CHAINCODE_BUILDER_VERSION=${TEST_NETWORK_K8S_CHAINCODE_BUILDER_VERSION:-v0.4.0}
+export K8S_CHAINCODE_BUILDER_VERSION=${TEST_NETWORK_K8S_CHAINCODE_BUILDER_VERSION:-v0.6.0}
 
 LOG_FILE=${TEST_NETWORK_LOG_FILE:-network.log}
 DEBUG_FILE=${TEST_NETWORK_DEBUG_FILE:-network-debug.log}


### PR DESCRIPTION
This PR updates the k8s chaincode builder for the sample network to use [v0.6.0](https://github.com/hyperledgendary/fabric-builder-k8s/releases/tag/v0.6.0), including support for couchbase index configuration for chaincode packages with `type=k8s` 

Signed-off-by: Josh Kneubuhl <jkneubuh@us.ibm.com>