### PR TITLE
Update secured asset transfer sample

### DIFF
--- a/asset-transfer-secured-agreement/application-gateway-typescript/src/app.ts
+++ b/asset-transfer-secured-agreement/application-gateway-typescript/src/app.ts
@@ -108,7 +108,7 @@ async function main(): Promise<void> {
             assetId: assetKey,
             price: 110,
             tradeId: now,
-        }, mspIdOrg2);
+        });
 
         // Check the private information about the asset from Org2. Org1 would have to send Org2 asset details,
         // so the hash of the details may be checked by the chaincode.
@@ -141,12 +141,12 @@ async function main(): Promise<void> {
         // Org1 will try to transfer the asset to Org2
         // This will fail due to the sell price and the bid price are not the same.
         try{
-            await contractWrapperOrg1.transferAsset({ assetId: assetKey, price: 110, tradeId: now}, mspIdOrg1, mspIdOrg2);
+            await contractWrapperOrg1.transferAsset({ assetId: assetKey, price: 110, tradeId: now}, [ mspIdOrg1, mspIdOrg2 ], mspIdOrg1, mspIdOrg2);
         } catch(e) {
             console.log(`${RED}*** Failed: transferAsset - ${e}${RESET}`);
         }
         // Agree to a sell by Org1, the seller will agree to the bid price of Org2.
-        await contractWrapperOrg1.agreeToSell({assetId:assetKey, price:100, tradeId:now}, mspIdOrg2);
+        await contractWrapperOrg1.agreeToSell({assetId:assetKey, price:100, tradeId:now});
 
         // Read the public details by  org1.
         await contractWrapperOrg1.readAsset(assetKey, mspIdOrg1);
@@ -166,14 +166,14 @@ async function main(): Promise<void> {
         // Org2 user will try to transfer the asset to Org1.
         // This will fail as the owner is Org1.
         try{
-            await contractWrapperOrg2.transferAsset({ assetId: assetKey, price: 100, tradeId: now}, mspIdOrg1, mspIdOrg2);
+            await contractWrapperOrg2.transferAsset({ assetId: assetKey, price: 100, tradeId: now}, [ mspIdOrg1, mspIdOrg2 ], mspIdOrg1, mspIdOrg2);
         } catch(e) {
             console.log(`${RED}*** Failed: transferAsset - ${e}${RESET}`);
         }
 
         // Org1 will transfer the asset to Org2.
         // This will now complete as the sell price and the bid price are the same.
-        await contractWrapperOrg1.transferAsset({ assetId: assetKey, price: 100, tradeId: now}, mspIdOrg1, mspIdOrg2);
+        await contractWrapperOrg1.transferAsset({ assetId: assetKey, price: 100, tradeId: now}, [ mspIdOrg1, mspIdOrg2 ], mspIdOrg1, mspIdOrg2);
 
         // Read the public details by  org1.
         await contractWrapperOrg1.readAsset(assetKey, mspIdOrg2);

--- a/asset-transfer-secured-agreement/application-gateway-typescript/src/contractWrapper.ts
+++ b/asset-transfer-secured-agreement/application-gateway-typescript/src/contractWrapper.ts
@@ -136,7 +136,7 @@ export class ContractWrapper {
         console.log(`*** Result: committed, Desc: ${asset.publicDescription}`);
     }
 
-    public async agreeToSell(assetPrice: AssetPrice, buyerOrgID: string): Promise<void> {
+    public async agreeToSell(assetPrice: AssetPrice): Promise<void> {
 
         console.log(`${GREEN}--> Submit Transaction: AgreeToSell, ${assetPrice.assetId} as ${this.#org} - endorsed by ${this.#org}.${RESET}`);
         const assetPriceJSON: AssetPriceJSON = {
@@ -146,15 +146,10 @@ export class ContractWrapper {
         };
 
         await this.#contract.submit('AgreeToSell', {
-            arguments:[assetPrice.assetId, buyerOrgID],
+            arguments:[assetPrice.assetId],
             transientData: {asset_price: JSON.stringify(assetPriceJSON)},
             endorsingOrganizations: this.#endorsingOrgs[assetPrice.assetId]
         });
-
-        //update local record of sbe to inlcude buyer org if not already
-        if (this.#endorsingOrgs[assetPrice.assetId].indexOf('buyerOrgID') == -1){
-            this.#endorsingOrgs[assetPrice.assetId].push(buyerOrgID);
-        }
 
         console.log(`*** Result: committed, ${this.#org} has agreed to sell asset ${assetPrice.assetId} for ${assetPrice.price}`);
     }
@@ -258,7 +253,7 @@ export class ContractWrapper {
         console.log('*** Result: GetAssetBidPrice', result);
     }
 
-    public async transferAsset(assetPrice: AssetPrice, ownerOrgID: string, buyerOrgID: string): Promise<void> {
+    public async transferAsset(assetPrice: AssetPrice, endorsingOrganizations: string[], ownerOrgID: string, buyerOrgID: string): Promise<void> {
 
         console.log(`${GREEN}--> Submit Transaction: TransferAsset, ${assetPrice.assetId} as ${this.#org } - endorsed by ${this.#org} and ${buyerOrgID}.${RESET}`);
 
@@ -273,7 +268,7 @@ export class ContractWrapper {
         await this.#contract.submit('TransferAsset', {
             arguments:[assetPrice.assetId, buyerOrgID],
             transientData: { asset_price: JSON.stringify(assetPriceJSON) },
-            endorsingOrganizations: this.#endorsingOrgs[assetPrice.assetId]
+            endorsingOrganizations: endorsingOrganizations
         });
 
         console.log(`${GREEN}*** Result: committed, ${this.#org} has transfered the asset ${assetPrice.assetId} to ${buyerOrgID}.${RESET}`);

--- a/asset-transfer-secured-agreement/application-javascript/app.js
+++ b/asset-transfer-secured-agreement/application-javascript/app.js
@@ -312,8 +312,8 @@ async function main() {
 				transaction.setTransient({
 					asset_price: Buffer.from(asset_price_string)
 				});
-				//call agree to sell with desired price and target buyer organization
-				await transaction.submit(assetKey, org2);
+				//call agree to sell with desired price
+				await transaction.submit(assetKey);
 				console.log(`*** Result: committed, Org1 has agreed to sell asset ${assetKey} for 110`);
 			} catch (sellError) {
 				console.log(`${RED}*** Failed: AgreeToSell - ${sellError}${RESET}`);
@@ -368,7 +368,7 @@ async function main() {
 				const asset_properties_string = JSON.stringify(asset_properties);
 				console.log(`${GREEN}--> Submit Transaction: AgreeToBuy, ${assetKey} as Org2 - endorsed by Org2${RESET}`);
 				transaction = contractOrg2.createTransaction('AgreeToBuy');
-				transaction.setEndorsingOrganizations(org1, org2);
+				transaction.setEndorsingOrganizations(org2);
 				transaction.setTransient({
 					asset_price: Buffer.from(asset_price_string),
 					asset_properties: Buffer.from(asset_properties_string)
@@ -431,11 +431,11 @@ async function main() {
 				const asset_price_string = JSON.stringify(asset_price);
 				console.log(`${GREEN}--> Submit Transaction: AgreeToSell, ${assetKey} as Org1 - endorsed by Org1${RESET}`);
 				transaction = contractOrg1.createTransaction('AgreeToSell');
-				transaction.setEndorsingOrganizations(org1, org2);
+				transaction.setEndorsingOrganizations(org1);
 				transaction.setTransient({
 					asset_price: Buffer.from(asset_price_string)
 				});
-				await transaction.submit(assetKey, org2);
+				await transaction.submit(assetKey);
 				console.log(`*** Result: committed, Org1 has agreed to sell asset ${assetKey} for 100`);
 			} catch (sellError) {
 				console.log(`${RED}*** Failed: AgreeToSell - ${sellError}${RESET}`);

--- a/asset-transfer-secured-agreement/chaincode-go/asset_transfer_queries.go
+++ b/asset-transfer-secured-agreement/chaincode-go/asset_transfer_queries.go
@@ -47,8 +47,8 @@ func (s *SmartContract) ReadAsset(ctx contractapi.TransactionContextInterface, a
 
 // GetAssetPrivateProperties returns the immutable asset properties from owner's private data collection
 func (s *SmartContract) GetAssetPrivateProperties(ctx contractapi.TransactionContextInterface, assetID string) (string, error) {
-	// In this scenario, client is only authorized to read/write private data from its own peer.
-	collection, err := getClientImplicitCollectionName(ctx)
+
+	collection, err := getClientImplicitCollectionNameAndVerifyClientOrg(ctx)
 	if err != nil {
 		return "", err
 	}
@@ -76,7 +76,8 @@ func (s *SmartContract) GetAssetBidPrice(ctx contractapi.TransactionContextInter
 
 // getAssetPrice gets the bid or ask price from caller's implicit private data collection
 func getAssetPrice(ctx contractapi.TransactionContextInterface, assetID string, priceType string) (string, error) {
-	collection, err := getClientImplicitCollectionName(ctx)
+
+	collection, err := getClientImplicitCollectionNameAndVerifyClientOrg(ctx)
 	if err != nil {
 		return "", err
 	}
@@ -108,7 +109,7 @@ func (s *SmartContract) QueryAssetBuyAgreements(ctx contractapi.TransactionConte
 }
 
 func queryAgreementsByType(ctx contractapi.TransactionContextInterface, agreeType string) ([]Agreement, error) {
-	collection, err := getClientImplicitCollectionName(ctx)
+	collection, err := getClientImplicitCollectionNameAndVerifyClientOrg(ctx)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
A recent commit added the potential buyer to an asset's state based endorsement policy.
That change was problematic because if the transfer fell through, the buyer lost control of the asset,
in that they could no longer update the asset or change the sell price or sell to somebody else.

The asset state based endorsement policy is now based on the seller only, and we document
that additional parties could be added such as a trusted third party (although no
such party exists in test network at this time).

This commit also re-adds some necessary verifications, and make other minor edits and
comments to help users understand the sample.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>