### PR TITLE
Fix asset-transfer-events sample Java chaincode

### DIFF
--- a/asset-transfer-events/chaincode-java/settings.gradle
+++ b/asset-transfer-events/chaincode-java/settings.gradle
@@ -2,4 +2,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-rootProject.name = 'asset-transfer-events-java'
+rootProject.name = 'events'

--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -228,6 +228,9 @@ jobs:
         Events-Javascript:
           CHAINCODE_NAME: events
           CHAINCODE_LANGUAGE: javascript
+        Events-Java:
+          CHAINCODE_NAME: events
+          CHAINCODE_LANGUAGE: java
     steps:
       - template: templates/install-deps.yml
       - script: ../ci/scripts/run-test-network-events.sh


### PR DESCRIPTION
- chaincode-java Gradle project name did not match the instructions or the chaincode name used by the sample application code.
- Added test of Java chaincode to CI pipeline.