### PR TITLE
Fix namespace in k8s configuration files

### DIFF
--- a/test-network-k8s/config/org0/fabric-ca-server-config.yaml
+++ b/test-network-k8s/config/org0/fabric-ca-server-config.yaml
@@ -321,7 +321,7 @@ csr:
     - localhost
     - 127.0.0.1
     - org0-ca
-    - org0-ca.test-network.svc.cluster.local
+    - org0-ca.${NS}.svc.cluster.local
   ca:
     expiry: 131400h
     pathlength: 1

--- a/test-network-k8s/config/org1/fabric-ca-server-config.yaml
+++ b/test-network-k8s/config/org1/fabric-ca-server-config.yaml
@@ -321,7 +321,7 @@ csr:
     - localhost
     - 127.0.0.1
     - org1-ca
-    - org1-ca.test-network.svc.cluster.local
+    - org1-ca.${NS}.svc.cluster.local
   ca:
     expiry: 131400h
     pathlength: 1

--- a/test-network-k8s/config/org2/fabric-ca-server-config.yaml
+++ b/test-network-k8s/config/org2/fabric-ca-server-config.yaml
@@ -321,7 +321,7 @@ csr:
     - localhost
     - 127.0.0.1
     - org2-ca
-    - org2-ca.test-network.svc.cluster.local
+    - org2-ca.${NS}.svc.cluster.local
   ca:
     expiry: 131400h
     pathlength: 1

--- a/test-network-k8s/kube/fabric-rest-sample.yaml
+++ b/test-network-k8s/kube/fabric-rest-sample.yaml
@@ -11,7 +11,7 @@ metadata:
 data:
   HLF_CONNECTION_PROFILE_ORG1: |
     {
-        "name": "test-network-org1",
+        "name": "${NS}-org1",
         "version": "1.0.0",
         "client": {
             "organization": "Org1",
@@ -87,7 +87,7 @@ data:
     -----END PRIVATE KEY-----
   HLF_CONNECTION_PROFILE_ORG2: |
     {
-        "name": "test-network-org2",
+        "name": "${NS}-org2",
         "version": "1.0.0",
         "client": {
             "organization": "Org2",

--- a/test-network-k8s/kube/org0/org0-ca.yaml
+++ b/test-network-k8s/kube/org0/org0-ca.yaml
@@ -16,7 +16,7 @@ spec:
   dnsNames:
     - localhost
     - org0-ca
-    - org0-ca.test-network.svc.cluster.local
+    - org0-ca.${NS}.svc.cluster.local
     - org0-ca.${DOMAIN}
   ipAddresses:
     - 127.0.0.1

--- a/test-network-k8s/kube/org1/org1-ca.yaml
+++ b/test-network-k8s/kube/org1/org1-ca.yaml
@@ -16,7 +16,7 @@ spec:
   dnsNames:
     - localhost
     - org1-ca
-    - org1-ca.test-network.svc.cluster.local
+    - org1-ca.${NS}.svc.cluster.local
     - org1-ca.${DOMAIN}
   ipAddresses:
     - 127.0.0.1

--- a/test-network-k8s/kube/org1/org1-peer1.yaml
+++ b/test-network-k8s/kube/org1/org1-peer1.yaml
@@ -8,7 +8,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: org1-peer1-tls-cert
-  namespace: test-network
+  namespace: ${NS}
 spec:
   isCA: false
   privateKey:
@@ -17,7 +17,7 @@ spec:
   dnsNames:
     - localhost
     - org1-peer1
-    - org1-peer1.test-network.svc.cluster.local
+    - org1-peer1.${NS}.svc.cluster.local
     - org1-peer1.${DOMAIN}
     - org1-peer-gateway-svc
     - org1-peer-gateway-svc.${DOMAIN}

--- a/test-network-k8s/kube/org1/org1-peer2.yaml
+++ b/test-network-k8s/kube/org1/org1-peer2.yaml
@@ -8,7 +8,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: org1-peer2-tls-cert
-  namespace: test-network
+  namespace: ${NS}
 spec:
   isCA: false
   privateKey:
@@ -18,7 +18,7 @@ spec:
     - localhost
     - org1-peer2
     - org1-peer-gateway-svc
-    - org1-peer2.test-network.svc.cluster.local
+    - org1-peer2.${NS}.svc.cluster.local
     - org1-peer2.${DOMAIN}
   ipAddresses:
     - 127.0.0.1

--- a/test-network-k8s/kube/org2/org2-ca.yaml
+++ b/test-network-k8s/kube/org2/org2-ca.yaml
@@ -16,7 +16,7 @@ spec:
   dnsNames:
     - localhost
     - org2-ca
-    - org2-ca.test-network.svc.cluster.local
+    - org2-ca.${NS}.svc.cluster.local
     - org2-ca.${DOMAIN}
   ipAddresses:
     - 127.0.0.1

--- a/test-network-k8s/kube/org2/org2-cc-template.yaml
+++ b/test-network-k8s/kube/org2/org2-cc-template.yaml
@@ -1,0 +1,46 @@
+#
+# Copyright IBM Corp. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: org2{{PEER_NAME}}-ccaas-{{CHAINCODE_NAME}}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: org2{{PEER_NAME}}-ccaas-{{CHAINCODE_NAME}}
+  template:
+    metadata:
+      labels:
+        app: org2{{PEER_NAME}}-ccaas-{{CHAINCODE_NAME}}
+    spec:
+      containers:
+        - name: main
+          image: {{CHAINCODE_IMAGE}}
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: CHAINCODE_SERVER_ADDRESS
+              value: 0.0.0.0:9999
+            - name: CHAINCODE_ID
+              value: {{CHAINCODE_ID}}
+            - name: CORE_CHAINCODE_ID_NAME
+              value: {{CHAINCODE_ID}}
+          ports:
+            - containerPort: 9999
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: org2{{PEER_NAME}}-ccaas-{{CHAINCODE_NAME}}
+spec:
+  ports:
+    - name: chaincode
+      port: 9999
+      protocol: TCP
+  selector:
+    app: org2{{PEER_NAME}}-ccaas-{{CHAINCODE_NAME}}

--- a/test-network-k8s/kube/org2/org2-cc.yaml
+++ b/test-network-k8s/kube/org2/org2-cc.yaml
@@ -1,6 +1,0 @@
-#
-# Copyright IBM Corp. All Rights Reserved.
-#
-# SPDX-License-Identifier: Apache-2.0
-#
-

--- a/test-network-k8s/kube/org2/org2-peer1.yaml
+++ b/test-network-k8s/kube/org2/org2-peer1.yaml
@@ -8,7 +8,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: org2-peer1-tls-cert
-  namespace: test-network
+  namespace: ${NS}
 spec:
   isCA: false
   privateKey:
@@ -17,7 +17,7 @@ spec:
   dnsNames:
     - localhost
     - org2-peer1
-    - org2-peer1.test-network.svc.cluster.local
+    - org2-peer1.${NS}.svc.cluster.local
     - org2-peer1.${DOMAIN}
     - org2-peer-gateway-svc
     - org2-peer-gateway-svc.${DOMAIN}

--- a/test-network-k8s/kube/org2/org2-peer2.yaml
+++ b/test-network-k8s/kube/org2/org2-peer2.yaml
@@ -8,7 +8,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: org2-peer2-tls-cert
-  namespace: test-network
+  namespace: ${NS}
 spec:
   isCA: false
   privateKey:
@@ -18,7 +18,7 @@ spec:
     - localhost
     - org2-peer2
     - org2-peer-gateway-svc
-    - org2-peer2.test-network.svc.cluster.local
+    - org2-peer2.${NS}.svc.cluster.local
     - org2-peer2.${DOMAIN}
   ipAddresses:
     - 127.0.0.1

--- a/test-network-k8s/scripts/ccp-template.json
+++ b/test-network-k8s/scripts/ccp-template.json
@@ -1,5 +1,5 @@
 {
-    "name": "test-network-org${ORG}",
+    "name": "${NS}-org${ORG}",
     "version": "1.0.0",
     "client": {
         "organization": "Org${ORG}",


### PR DESCRIPTION
Issues:
1. When the name of NETWORK_NAME or NS in file "network" (i.e., the namespace in k8s) is changed from "test-network", the resources in the k8s cluster cannot be created successfully when the command "./network up" is executed.
Error message: error: the namespace from the provided object "test-network" does not match the namespace "xxxxxx". You must pass '--namespace=test-network' to perform this operation.
2. org2-cc.yaml is not completed.

Fix:
1. Replace "test-network" in yaml files in folder "kube" with "${NS}".
2. Complete "org2-cc-template.yaml" by referring to "org1-cc-template.yaml".