### PR TITLE
fix to prometheus-grafana docker compose

### DIFF
--- a/test-network/prometheus-grafana/docker-compose.yaml
+++ b/test-network/prometheus-grafana/docker-compose.yaml
@@ -62,7 +62,7 @@ services:
       - 9100:9100
     restart: always
 
-networks:
-  default:
-      external: true
-      name: fabric_test
+    networks:
+        default:
+            external:
+                name: test_network


### PR DESCRIPTION
Due to an update in docker-compose, the networking properties and format had changed and broke the docker-compose file for the Prometheus and Grafana network, this small pr fixes it.

Signed-off-by: fraVlaca <ocsenarf@outlook.com>