### PR TITLE
Use alpine based gradle image to build basic transfer java CC container

### DIFF
--- a/asset-transfer-basic/chaincode-java/Dockerfile
+++ b/asset-transfer-basic/chaincode-java/Dockerfile
@@ -1,5 +1,5 @@
 # the first stage 
-FROM gradle:jdk11 AS GRADLE_BUILD
+FROM gradle:jdk11-alpine AS GRADLE_BUILD
 
 # copy the build.gradle and src code to the container
 COPY src/ src/


### PR DESCRIPTION
This changes the base image used to build the chaincode-as-a-service
java container to the alpine version which is sufficient and less
taxing than using the full gradle:jdk11 one.

Signed-off-by: Arnaud J Le Hors <lehors@us.ibm.com>