### PR TITLE
Update podman support information

### DIFF
--- a/test-network/README.md
+++ b/test-network/README.md
@@ -33,18 +33,20 @@ To learn more about how to use the improvements to the Chaincode-as-a-service pl
 
 ## Podman
 
-*Note - podman support should be considered experimental. There are issues with volume mounting on MacOS that prevent this working. If wish to use podman a LinuxVM is suggested.*
+*Note - podman support should be considered experimental but the following has been reported to work with podman 4.1.1 on Mac. If you wish to use podman a LinuxVM is recommended.*
 
-A copy of the `install_fabric.sh` script is in the `test-network` directory. This has been enhanced to support a `podman` argument; if used it will use the `podman` command to pull down images and tag them rather than docker. The images are the same, just pulled differently
+Fabric's `bootstrap.sh` script has been enhanced to support using the `podman` command to pull down images and tag them rather than docker. The images are the same, just pulled differently. Simply ensure that `CONTAINER_CLI` is set as below when running `bootstrap.sh` script. 
 
-The `network.sh` script has been enhanced so that it can use `podman` and `podman-compose` instead of docker. Ensure that `CONTAINER_CLI` is set as below when running `network.sh` script. 
+```bash
+CONTAINER_CLI=podman ./bootstrap.sh -s
+````
+
+Similarly, the `network.sh` script has been enhanced so that it can use `podman` and `podman-compose` instead of docker. Again, ensure that `CONTAINER_CLI` is set as below when running `network.sh` script. 
 
 ```bash
 CONTAINER_CLI=podman ./network.sh up
 ````
 
-As there is no Docker-Daemon when using podman, only the `./network.sh deployCCAAS` command will work.
-
-
+As there is no Docker-Daemon when using podman, only the `./network.sh deployCCAAS` command will work. Following the Chaincode-as-a-service Tutorial above should work. 
 
 

--- a/test-network/scripts/deployCCAAS.sh
+++ b/test-network/scripts/deployCCAAS.sh
@@ -112,6 +112,7 @@ buildDockerImages() {
   if [ "$CCAAS_DOCKER_RUN" = "true" ]; then
     # build the docker container
     infoln "Building Chaincode-as-a-Service docker image '${CC_NAME}' '${CC_SRC_PATH}'"
+    infoln "This may take several minutes..."
     set -x
     ${CONTAINER_CLI} build -f $CC_SRC_PATH/Dockerfile -t ${CC_NAME}_ccaas_image:latest --build-arg CC_SERVER_PORT=9999 $CC_SRC_PATH >&log.txt
     res=$?
@@ -149,7 +150,12 @@ startDockerContainer() {
   else
   
     infoln "Not starting docker containers; these are the commands we would have run"
-    infoln "    docker run --rm -d --name peer0org1_${CC_NAME}_ccaas  \
+    infoln "    ${CONTAINER_CLI} run --rm -d --name peer0org1_${CC_NAME}_ccaas  \
+                  --network fabric_test \
+                  -e CHAINCODE_SERVER_ADDRESS=0.0.0.0:${CCAAS_SERVER_PORT} \
+                  -e CHAINCODE_ID=$PACKAGE_ID -e CORE_CHAINCODE_ID_NAME=$PACKAGE_ID \
+                    ${CC_NAME}_ccaas_image:latest"
+    infoln "    ${CONTAINER_CLI} run --rm -d --name peer0org2_${CC_NAME}_ccaas  \
                   --network fabric_test \
                   -e CHAINCODE_SERVER_ADDRESS=0.0.0.0:${CCAAS_SERVER_PORT} \
                   -e CHAINCODE_ID=$PACKAGE_ID -e CORE_CHAINCODE_ID_NAME=$PACKAGE_ID \


### PR DESCRIPTION
This change updates the test-network README with up-to-date information
about using podman on Mac and improves support for podman in deployCCAAS.sh

Signed-off-by: Arnaud J Le Hors <lehors@us.ibm.com>