### PR TITLE
Clarifies podman instructions for test-network

### DIFF
--- a/test-network/README.md
+++ b/test-network/README.md
@@ -35,13 +35,9 @@ To learn more about how to use the improvements to the Chaincode-as-a-service pl
 
 *Note - podman support should be considered experimental but the following has been reported to work with podman 4.1.1 on Mac. If you wish to use podman a LinuxVM is recommended.*
 
-Fabric's `bootstrap.sh` script has been enhanced to support using the `podman` command to pull down images and tag them rather than docker. The images are the same, just pulled differently. Simply ensure that `CONTAINER_CLI` is set as below when running `bootstrap.sh` script. 
+Fabric's `install-fabric.sh` script has been enhanced to support using `podman` to pull down images and tag them rather than docker. The images are the same, just pulled differently. Simply specify the 'podman' argument when running the `install-fabric.sh` script. 
 
-```bash
-CONTAINER_CLI=podman ./bootstrap.sh -s
-````
-
-Similarly, the `network.sh` script has been enhanced so that it can use `podman` and `podman-compose` instead of docker. Again, ensure that `CONTAINER_CLI` is set as below when running `network.sh` script. 
+Similarly, the `network.sh` script has been enhanced so that it can use `podman` and `podman-compose` instead of docker. Just set the environment variable `CONTAINER_CLI` to `podman` before running the `network.sh` script:
 
 ```bash
 CONTAINER_CLI=podman ./network.sh up


### PR DESCRIPTION
Also reverts to using install-fabric.sh which is preferred over bootstrap.sh.

Signed-off-by: Arnaud J Le Hors <lehors@us.ibm.com>