### PR TITLE
Update k8s CC builder to v7.2; Use *.localho.st loopback domain; Optionally bind docker reg to 0.0.0.0

### DIFF
--- a/ci/scripts/run-k8s-test-network-basic.sh
+++ b/ci/scripts/run-k8s-test-network-basic.sh
@@ -30,8 +30,8 @@ export CRYPTO_PATH=${CRYPTO_PATH:-../../test-network-k8s/build/channel-msp/peerO
 export KEY_DIRECTORY_PATH=${KEY_DIRECTORY_PATH:-../../test-network-k8s/build/enrollments/org1/users/org1admin/msp/keystore}
 export CERT_PATH=${CERT_PATH:-../../test-network-k8s/build/enrollments/org1/users/org1admin/msp/signcerts/cert.pem}
 export TLS_CERT_PATH=${TLS_CERT_PATH:-../../test-network-k8s/build/channel-msp/peerOrganizations/org1/msp/tlscacerts/tlsca-signcert.pem}
-export PEER_ENDPOINT=${PEER_ENDPOINT:-org1-peer1.vcap.me:443}
-export PEER_HOST_ALIAS=${PEER_HOST_ALIAS:-org1-peer1.vcap.me}
+export PEER_ENDPOINT=${PEER_ENDPOINT:-org1-peer1.localho.st:443}
+export PEER_HOST_ALIAS=${PEER_HOST_ALIAS:-org1-peer1.localho.st}
 
 function print() {
   GREEN='\033[0;32m'
@@ -90,7 +90,7 @@ print "Running rest-easy test"
 ( ./network rest-easy \
   && sleep 5 \
   && export SAMPLE_APIKEY='97834158-3224-4CE7-95F9-A148C886653E' \
-  && curl -s --header "X-Api-Key: ${SAMPLE_APIKEY}" "http://fabric-rest-sample.vcap.me/api/assets/asset1" | jq )
+  && curl -s --header "X-Api-Key: ${SAMPLE_APIKEY}" "http://fabric-rest-sample.localho.st/api/assets/asset1" | jq )
 print "OK"
 
 stopNetwork

--- a/test-network-k8s/README.md
+++ b/test-network-k8s/README.md
@@ -95,16 +95,16 @@ Workarounds to improve DNS resolution time on OSX:
 
 - Add manual DNS overrides for virtual hosts by adding to /etc/hosts:
 ```
-127.0.0.1 org0-ca.vcap.me
-127.0.0.1 org1-ca.vcap.me
-127.0.0.1 org2-ca.vcap.me
-127.0.0.1 org0-orderer1.vcap.me
-127.0.0.1 org0-orderer2.vcap.me
-127.0.0.1 org0-orderer3.vcap.me
-127.0.0.1 org1-peer1.vcap.me
-127.0.0.1 org1-peer2.vcap.me
-127.0.0.1 org2-peer1.vcap.me
-127.0.0.1 org2-peer2.vcap.me
+127.0.0.1 org0-ca.localho.st
+127.0.0.1 org1-ca.localho.st
+127.0.0.1 org2-ca.localho.st
+127.0.0.1 org0-orderer1.localho.st
+127.0.0.1 org0-orderer2.localho.st
+127.0.0.1 org0-orderer3.localho.st
+127.0.0.1 org1-peer1.localho.st
+127.0.0.1 org1-peer2.localho.st
+127.0.0.1 org2-peer1.localho.st
+127.0.0.1 org2-peer2.localho.st
 ```
 
 - Reduce the system resolver timeout from the default 5s by adding to /etc/resolv.conf:

--- a/test-network-k8s/docs/APPLICATIONS.md
+++ b/test-network-k8s/docs/APPLICATIONS.md
@@ -23,7 +23,7 @@ $ export SAMPLE_APIKEY=97834158-3224-4CE7-95F9-A148C886653E
 
 $ ./network chaincode invoke asset-transfer-basic '{"Args":["CreateAsset","1","blue","35","tom","1000"]}' 
 
-$ curl -s --header "X-Api-Key: ${SAMPLE_APIKEY}" http://fabric-rest-sample.vcap.me/api/assets | jq 
+$ curl -s --header "X-Api-Key: ${SAMPLE_APIKEY}" http://fabric-rest-sample.localho.st/api/assets | jq 
 [
   {
     "Key": "1",

--- a/test-network-k8s/docs/CHANNELS.md
+++ b/test-network-k8s/docs/CHANNELS.md
@@ -73,9 +73,9 @@ services to register the channel genesis block configuration on the ordering nod
 ```shell
 configtxgen -profile TwoOrgsApplicationGenesis -channelID '${CHANNEL_NAME}' -outputBlock genesis_block.pb
 
-osnadmin channel join --orderer-address org0-orderer1-admin.vcap.me --channelID '${CHANNEL_NAME}' --config-block genesis_block.pb
-osnadmin channel join --orderer-address org0-orderer2-admin.vcap.me --channelID '${CHANNEL_NAME}' --config-block genesis_block.pb
-osnadmin channel join --orderer-address org0-orderer3-admin.vcap.me --channelID '${CHANNEL_NAME}' --config-block genesis_block.pb
+osnadmin channel join --orderer-address org0-orderer1-admin.localho.st --channelID '${CHANNEL_NAME}' --config-block genesis_block.pb
+osnadmin channel join --orderer-address org0-orderer2-admin.localho.st --channelID '${CHANNEL_NAME}' --config-block genesis_block.pb
+osnadmin channel join --orderer-address org0-orderer3-admin.localho.st --channelID '${CHANNEL_NAME}' --config-block genesis_block.pb
 ```
 
 
@@ -95,7 +95,7 @@ by retrieving the genesis block from the orderers and then joining the channel:
     fetch oldest \
     genesis_block.pb \
     -c '${CHANNEL_NAME}' \
-    -o org0-orderer1.vcap.me \
+    -o org0-orderer1.localho.st \
     --tls --cafile /var/hyperledger/fabric/organizations/ordererOrganizations/org0.example.com/msp/tlscacerts/org0-tls-ca.pem
 
   # Join peer1 to the channel.
@@ -103,7 +103,7 @@ by retrieving the genesis block from the orderers and then joining the channel:
   peer channel \
     join \
     -b genesis_block.pb \
-    -o org0-orderer1.vcap.me \
+    -o org0-orderer1.localho.st \
     --tls --cafile /var/hyperledger/fabric/organizations/ordererOrganizations/org0.example.com/msp/tlscacerts/org0-tls-ca.pem
 
   # Join peer2 to the channel.
@@ -111,7 +111,7 @@ by retrieving the genesis block from the orderers and then joining the channel:
   peer channel \
     join \
     -b genesis_block.pb \
-    -o org0-orderer1.vcap.me \
+    -o org0-orderer1.localho.st \
     --tls --cafile /var/hyperledger/fabric/organizations/ordererOrganizations/org0.example.com/msp/tlscacerts/org0-tls-ca.pem
 ```
 

--- a/test-network-k8s/docs/KUBERNETES.md
+++ b/test-network-k8s/docs/KUBERNETES.md
@@ -220,19 +220,16 @@ secure access to services, client applications must present the TLS root certifi
 organization when connecting to peers, orderers, and CAs.
 
 
-## What is `*.vcap.me` ? 
+## What is `*.localho.st` ? 
 
 In order to expose a dynamic set of DNS host aliases matching the Nginx ingress controller, the test network 
-employs the public DNS wildcard domain `*.vcap.me` to resolve host and subdomains to the local loopback 
+employs the public DNS wildcard domain `*.localho.st` to resolve host and subdomains to the local loopback 
 address 127.0.0.1.  
 
-The vcap.me domain is managed by VMWare and is associated with the 
-[VMWare Cloud Application Platform](https://github.com/cloudfoundry-attic/vcap) (VCAP).
-
-Using this DNS wildcard alias means that all ingress points bound to the *.vcap.me domain will resolve to your 
+Using this DNS wildcard alias means that all ingress points bound to the *.localho.st domain will resolve to your 
 local host, conveniently routing traffic into the KIND cluster on ports :80 and :443. 
 
-To override the *.vcap.me network ingress domain (for example in cloud-based environments supporting a DNS 
+To override the *.localho.st network ingress domain (for example in cloud-based environments supporting a DNS 
 wildcard resolver) set the `TEST_NETWORK_DOMAIN` environment variable before invoking `./network` 
 targets.   E.g.: 
 

--- a/test-network-k8s/kube/org1/org1-install-k8s-builder.yaml
+++ b/test-network-k8s/kube/org1/org1-install-k8s-builder.yaml
@@ -18,7 +18,7 @@ spec:
       restartPolicy: "Never"
       containers:
         - name: main
-          image: ghcr.io/hyperledgendary/k8s-fabric-peer:${K8S_CHAINCODE_BUILDER_VERSION}
+          image: ${K8S_CHAINCODE_BUILDER_IMAGE}:${K8S_CHAINCODE_BUILDER_VERSION}
           imagePullPolicy: IfNotPresent
           command:
             - sh

--- a/test-network-k8s/kube/org2/org2-install-k8s-builder.yaml
+++ b/test-network-k8s/kube/org2/org2-install-k8s-builder.yaml
@@ -18,7 +18,7 @@ spec:
       restartPolicy: "Never"
       containers:
         - name: main
-          image: ghcr.io/hyperledgendary/k8s-fabric-peer:${K8S_CHAINCODE_BUILDER_VERSION}
+          image: ${K8S_CHAINCODE_BUILDER_IMAGE}:${K8S_CHAINCODE_BUILDER_VERSION}
           imagePullPolicy: IfNotPresent
           command:
             - sh

--- a/test-network-k8s/network
+++ b/test-network-k8s/network
@@ -41,7 +41,7 @@ context NETWORK_NAME                  test-network
 context CLUSTER_NAME                  kind
 context KUBE_NAMESPACE                ${NETWORK_NAME}
 context NS                            ${KUBE_NAMESPACE}
-context DOMAIN                        vcap.me
+context DOMAIN                        localho.st
 context CHANNEL_NAME                  mychannel
 context ORDERER_TIMEOUT               10s                   # see https://github.com/hyperledger/fabric/issues/3372
 context TEMP_DIR                      ${PWD}/build

--- a/test-network-k8s/network
+++ b/test-network-k8s/network
@@ -46,7 +46,8 @@ context CHANNEL_NAME                  mychannel
 context ORDERER_TIMEOUT               10s                   # see https://github.com/hyperledger/fabric/issues/3372
 context TEMP_DIR                      ${PWD}/build
 context CHAINCODE_BUILDER             ccaas                 # see https://github.com/hyperledgendary/fabric-builder-k8s/blob/main/docs/TEST_NETWORK_K8S.md
-context K8S_CHAINCODE_BUILDER_VERSION v0.6.0
+context K8S_CHAINCODE_BUILDER_IMAGE   ghcr.io/hyperledger-labs/k8s-fabric-peer
+context K8S_CHAINCODE_BUILDER_VERSION v0.7.2
 
 context LOG_FILE                      network.log
 context DEBUG_FILE                    network-debug.log

--- a/test-network-k8s/network
+++ b/test-network-k8s/network
@@ -53,6 +53,7 @@ context LOG_FILE                      network.log
 context DEBUG_FILE                    network-debug.log
 context LOG_ERROR_LINES               2
 context LOCAL_REGISTRY_NAME           kind-registry
+context LOCAL_REGISTRY_INTERFACE      127.0.0.1
 context LOCAL_REGISTRY_PORT           5000
 context STAGE_DOCKER_IMAGES           false
 context NGINX_HTTP_PORT               80

--- a/test-network-k8s/scripts/kind.sh
+++ b/test-network-k8s/scripts/kind.sh
@@ -80,11 +80,15 @@ function launch_docker_registry() {
   # create registry container unless it already exists
   local reg_name=${LOCAL_REGISTRY_NAME}
   local reg_port=${LOCAL_REGISTRY_PORT}
+  local reg_interface=${LOCAL_REGISTRY_INTERFACE}
 
   running="$(docker inspect -f '{{.State.Running}}' "${reg_name}" 2>/dev/null || true)"
   if [ "${running}" != 'true' ]; then
-    docker run \
-      -d --restart=always -p "127.0.0.1:${reg_port}:5000" --name "${reg_name}" \
+    docker run  \
+      --detach  \
+      --restart always \
+      --name    "${reg_name}" \
+      --publish "${reg_interface}:${reg_port}:5000" \
       registry:2
   fi
 


### PR DESCRIPTION
In this PR: 

- The default k8s chaincode builder is upgraded from version 0.6.0 to 0.7.2 

- The `TEST_NETWORK_LOCAL_REGISTRY_INTERFACE` setting can be used to optionally bind the local docker insecure registry to an arbitrary NIC.  By default the registry is bound to the loopback interface 127.0.0.1 

- Switches from `*.vcap.me` to `*.localho.st` for the local host DNS wildcard domain.  (vcap.me is a remnant of an antiquated VMWare product.  Both domain names will match a wildcard to 127.0.0.1 in public DNS.) 