### PR TITLE
Refactor Go files, remove/replace deprecated functions

### DIFF
--- a/asset-transfer-basic/application-go/assetTransfer.go
+++ b/asset-transfer-basic/application-go/assetTransfer.go
@@ -8,7 +8,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -129,14 +128,14 @@ func populateWallet(wallet *gateway.Wallet) error {
 
 	certPath := filepath.Join(credPath, "signcerts", "cert.pem")
 	// read the certificate pem
-	cert, err := ioutil.ReadFile(filepath.Clean(certPath))
+	cert, err := os.ReadFile(filepath.Clean(certPath))
 	if err != nil {
 		return err
 	}
 
 	keyDir := filepath.Join(credPath, "keystore")
 	// there's a single file in this dir containing the private key
-	files, err := ioutil.ReadDir(keyDir)
+	files, err := os.ReadDir(keyDir)
 	if err != nil {
 		return err
 	}
@@ -144,7 +143,7 @@ func populateWallet(wallet *gateway.Wallet) error {
 		return fmt.Errorf("keystore folder should have contain one file")
 	}
 	keyPath := filepath.Join(keyDir, files[0].Name())
-	key, err := ioutil.ReadFile(filepath.Clean(keyPath))
+	key, err := os.ReadFile(filepath.Clean(keyPath))
 	if err != nil {
 		return err
 	}

--- a/asset-transfer-basic/chaincode-external/assetTransfer.go
+++ b/asset-transfer-basic/chaincode-external/assetTransfer.go
@@ -7,7 +7,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"strconv"
@@ -121,7 +120,7 @@ func (s *SmartContract) UpdateAsset(ctx contractapi.TransactionContextInterface,
 		return fmt.Errorf("the asset %s does not exist", id)
 	}
 
-	// overwritting original asset with new asset
+	// overwriting original asset with new asset
 	asset := Asset{
 		ID:             id,
 		Color:          color,
@@ -138,7 +137,7 @@ func (s *SmartContract) UpdateAsset(ctx contractapi.TransactionContextInterface,
 	return ctx.GetStub().PutState(id, assetJSON)
 }
 
-// DeleteAsset deletes an given asset from the world state.
+// DeleteAsset deletes a given asset from the world state.
 func (s *SmartContract) DeleteAsset(ctx contractapi.TransactionContextInterface, id string) error {
 	exists, err := s.AssetExists(ctx, id)
 	if err != nil {
@@ -254,18 +253,18 @@ func getTLSProperties() shim.TLSProperties {
 	var err error
 
 	if !tlsDisabled {
-		keyBytes, err = ioutil.ReadFile(key)
+		keyBytes, err = os.ReadFile(key)
 		if err != nil {
 			log.Panicf("error while reading the crypto file: %s", err)
 		}
-		certBytes, err = ioutil.ReadFile(cert)
+		certBytes, err = os.ReadFile(cert)
 		if err != nil {
 			log.Panicf("error while reading the crypto file: %s", err)
 		}
 	}
 	// Did not request for the peer cert verification
 	if clientCACert != "" {
-		clientCACertBytes, err = ioutil.ReadFile(clientCACert)
+		clientCACertBytes, err = os.ReadFile(clientCACert)
 		if err != nil {
 			log.Panicf("error while reading the crypto file: %s", err)
 		}

--- a/asset-transfer-events/application-gateway-go/connect.go
+++ b/asset-transfer-events/application-gateway-go/connect.go
@@ -9,7 +9,7 @@ package main
 import (
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path"
 
 	"github.com/hyperledger/fabric-gateway/pkg/identity"
@@ -62,7 +62,7 @@ func newIdentity() *identity.X509Identity {
 }
 
 func loadCertificate(filename string) (*x509.Certificate, error) {
-	certificatePEM, err := ioutil.ReadFile(filename)
+	certificatePEM, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read certificate file: %w", err)
 	}
@@ -71,11 +71,11 @@ func loadCertificate(filename string) (*x509.Certificate, error) {
 
 // newSign creates a function that generates a digital signature from a message digest using a private key.
 func newSign() identity.Sign {
-	files, err := ioutil.ReadDir(keyPath)
+	files, err := os.ReadDir(keyPath)
 	if err != nil {
 		panic(fmt.Errorf("failed to read private key directory: %w", err))
 	}
-	privateKeyPEM, err := ioutil.ReadFile(path.Join(keyPath, files[0].Name()))
+	privateKeyPEM, err := os.ReadFile(path.Join(keyPath, files[0].Name()))
 
 	if err != nil {
 		panic(fmt.Errorf("failed to read private key file: %w", err))

--- a/fabcar/go/fabcar.go
+++ b/fabcar/go/fabcar.go
@@ -9,7 +9,6 @@ package main
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -111,14 +110,14 @@ func populateWallet(wallet *gateway.Wallet) error {
 
 	certPath := filepath.Join(credPath, "signcerts", "cert.pem")
 	// read the certificate pem
-	cert, err := ioutil.ReadFile(filepath.Clean(certPath))
+	cert, err := os.ReadFile(filepath.Clean(certPath))
 	if err != nil {
 		return err
 	}
 
 	keyDir := filepath.Join(credPath, "keystore")
 	// there's a single file in this dir containing the private key
-	files, err := ioutil.ReadDir(keyDir)
+	files, err := os.ReadDir(keyDir)
 	if err != nil {
 		return err
 	}
@@ -126,7 +125,7 @@ func populateWallet(wallet *gateway.Wallet) error {
 		return errors.New("keystore folder should have contain one file")
 	}
 	keyPath := filepath.Join(keyDir, files[0].Name())
-	key, err := ioutil.ReadFile(filepath.Clean(keyPath))
+	key, err := os.ReadFile(filepath.Clean(keyPath))
 	if err != nil {
 		return err
 	}

--- a/hardware-security-module/application-go/hsm-sample.go
+++ b/hardware-security-module/application-go/hsm-sample.go
@@ -21,7 +21,6 @@ import (
 
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"time"
 
 	"github.com/hyperledger/fabric-gateway/pkg/client"
@@ -53,7 +52,7 @@ func main() {
 	}
 	defer hsmSignerFactory.Dispose()
 
-	certificatePEM, err := ioutil.ReadFile(certPath)
+	certificatePEM, err := os.ReadFile(certPath)
 	if err != nil {
 		panic(err)
 	}
@@ -150,7 +149,7 @@ func newHSMSign(h *identity.HSMSignerFactory, certPEM []byte) (identity.Sign, id
 }
 
 func loadCertificate(filename string) (*x509.Certificate, error) {
-	certificatePEM, err := ioutil.ReadFile(filename) //#nosec G304
+	certificatePEM, err := os.ReadFile(filename) //#nosec G304
 	if err != nil {
 		return nil, err
 	}

--- a/high-throughput/application-go/functions/util.go
+++ b/high-throughput/application-go/functions/util.go
@@ -8,7 +8,7 @@ package functions
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/hyperledger/fabric-sdk-go/pkg/gateway"
@@ -29,14 +29,14 @@ func populateWallet(wallet *gateway.Wallet) error {
 
 	certPath := filepath.Join(credPath, "signcerts", "cert.pem")
 	// read the certificate pem
-	cert, err := ioutil.ReadFile(filepath.Clean(certPath))
+	cert, err := os.ReadFile(filepath.Clean(certPath))
 	if err != nil {
 		return err
 	}
 
 	keyDir := filepath.Join(credPath, "keystore")
 	// there's a single file in this dir containing the private key
-	files, err := ioutil.ReadDir(keyDir)
+	files, err := os.ReadDir(keyDir)
 	if err != nil {
 		return err
 	}
@@ -44,7 +44,7 @@ func populateWallet(wallet *gateway.Wallet) error {
 		return fmt.Errorf("keystore folder should have contain one file")
 	}
 	keyPath := filepath.Join(keyDir, files[0].Name())
-	key, err := ioutil.ReadFile(filepath.Clean(keyPath))
+	key, err := os.ReadFile(filepath.Clean(keyPath))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
1. Replace deprecated ioutil functions: ioutil is deprecated as of Go 1.16. The same functionality is now provided by package io or package os, and those implementations should be preferred in new code.
2. Fix variable names that collide with imported package name: "gateway" and "status" in [asset-transfer-basic/application-gateway-go/assetTransfer.go](https://github.com/hyperledger/fabric-samples/compare/main...tommytim0515:fabric-samples:fix_deprecated_ioutil?expand=1#diff-d4ed6defeea358911610bc1ea479c70f9f2a4707fc5c33cfad2a98f113b6692a) collide with names of the packages imported.
4. Fix typos.

Signed-off-by: Tommy TIAN <xtianae@connect.ust.hk>