### PR TITLE
separate namespace for each organization

### DIFF
--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -147,6 +147,13 @@ jobs:
           CHAINCODE_NAME: basic
           CHAINCODE_LANGUAGE: java
           CHAINCODE_BUILDER: k8s
+        Multi-Namespace:
+          ORG0_NS: org0-namespace
+          ORG1_NS: org1-namespace
+          ORG2_NS: org2-namespace
+          CHAINCODE_NAME: basic
+          CHAINCODE_LANGUAGE: java
+          CHAINCODE_BUILDER: k8s
 
     steps:
       - template: templates/install-k8s-deps.yml

--- a/test-network-k8s/config/org0/configtx-template.yaml
+++ b/test-network-k8s/config/org0/configtx-template.yaml
@@ -25,7 +25,7 @@ Organizations:
     ID: OrdererMSP
 
     # MSPDir is the filesystem path which contains the MSP configuration
-    MSPDir: ../../build/channel-msp/ordererOrganizations/org0/msp
+    MSPDir: ./channel-msp/ordererOrganizations/org0/msp
 
     # Policies defines the set of policies at this level of the config tree
     # For organization policies, their canonical path is usually
@@ -42,9 +42,9 @@ Organizations:
         Rule: "OR('OrdererMSP.admin')"
 
     OrdererEndpoints:
-      - org0-orderer1:6050
-      - org0-orderer2:6050
-      - org0-orderer3:6050
+      - org0-orderer1.${ORG0_NS}.svc.cluster.local:6050
+      - org0-orderer2.${ORG0_NS}.svc.cluster.local:6050
+      - org0-orderer3.${ORG0_NS}.svc.cluster.local:6050
 
   - &Org1
     # DefaultOrg defines the organization which is used in the sampleconfig
@@ -54,7 +54,7 @@ Organizations:
     # ID to load the MSP definition as
     ID: Org1MSP
 
-    MSPDir: ../../build/channel-msp/peerOrganizations/org1/msp
+    MSPDir: ./channel-msp/peerOrganizations/org1/msp
 
     # Policies defines the set of policies at this level of the config tree
     # For organization policies, their canonical path is usually
@@ -78,7 +78,7 @@ Organizations:
       # AnchorPeers defines the location of peers which can be used
       # for cross org gossip communication.  Note, this value is only
       # encoded in the genesis block in the Application section context
-      - Host: org1-peer1
+      - Host: org1-peer1.${ORG1_NS}.svc.cluster.local
         Port: 7051
 
   - &Org2
@@ -89,7 +89,7 @@ Organizations:
     # ID to load the MSP definition as
     ID: Org2MSP
 
-    MSPDir: ../../build/channel-msp/peerOrganizations/org2/msp
+    MSPDir: ./channel-msp/peerOrganizations/org2/msp
 
     # Policies defines the set of policies at this level of the config tree
     # For organization policies, their canonical path is usually
@@ -112,7 +112,7 @@ Organizations:
       # AnchorPeers defines the location of peers which can be used
       # for cross org gossip communication.  Note, this value is only
       # encoded in the genesis block in the Application section context
-      - Host: org2-peer1
+      - Host: org2-peer1.${ORG2_NS}.svc.cluster.local
         Port: 7051
 
 ################################################################################
@@ -224,16 +224,16 @@ Orderer: &OrdererDefaults
     Consenters:
       - Host: org0-orderer1
         Port: 6050
-        ClientTLSCert: ../../build/channel-msp/ordererOrganizations/org0/orderers/org0-orderer1/tls/signcerts/tls-cert.pem
-        ServerTLSCert: ../../build/channel-msp/ordererOrganizations/org0/orderers/org0-orderer1/tls/signcerts/tls-cert.pem
+        ClientTLSCert: ./channel-msp/ordererOrganizations/org0/orderers/org0-orderer1/tls/signcerts/tls-cert.pem
+        ServerTLSCert: ./channel-msp/ordererOrganizations/org0/orderers/org0-orderer1/tls/signcerts/tls-cert.pem
       - Host: org0-orderer2
         Port: 6050
-        ClientTLSCert: ../../build/channel-msp/ordererOrganizations/org0/orderers/org0-orderer2/tls/signcerts/tls-cert.pem
-        ServerTLSCert: ../../build/channel-msp/ordererOrganizations/org0/orderers/org0-orderer2/tls/signcerts/tls-cert.pem
+        ClientTLSCert: ./channel-msp/ordererOrganizations/org0/orderers/org0-orderer2/tls/signcerts/tls-cert.pem
+        ServerTLSCert: ./channel-msp/ordererOrganizations/org0/orderers/org0-orderer2/tls/signcerts/tls-cert.pem
       - Host: org0-orderer3
         Port: 6050
-        ClientTLSCert: ../../build/channel-msp/ordererOrganizations/org0/orderers/org0-orderer3/tls/signcerts/tls-cert.pem
-        ServerTLSCert: ../../build/channel-msp/ordererOrganizations/org0/orderers/org0-orderer3/tls/signcerts/tls-cert.pem
+        ClientTLSCert: ./channel-msp/ordererOrganizations/org0/orderers/org0-orderer3/tls/signcerts/tls-cert.pem
+        ServerTLSCert: ./channel-msp/ordererOrganizations/org0/orderers/org0-orderer3/tls/signcerts/tls-cert.pem
 
 
     # Options to be specified for all the etcd/raft nodes. The values here

--- a/test-network-k8s/kube/fabric-builder-rolebinding.yaml
+++ b/test-network-k8s/kube/fabric-builder-rolebinding.yaml
@@ -13,6 +13,6 @@ roleRef:
   kind: Role
   name: fabric-builder-role
 subjects:
-  - namespace: ${NS}
+  - namespace: ${ORG1_NS}
     kind: ServiceAccount
     name: default

--- a/test-network-k8s/kube/fabric-rest-sample.yaml
+++ b/test-network-k8s/kube/fabric-rest-sample.yaml
@@ -11,7 +11,7 @@ metadata:
 data:
   HLF_CONNECTION_PROFILE_ORG1: |
     {
-        "name": "${NS}-org1",
+        "name": "Org1",
         "version": "1.0.0",
         "client": {
             "organization": "Org1",
@@ -36,14 +36,14 @@ data:
         },
         "peers": {
             "org1-peers": {
-                "url": "grpcs://org1-peer-gateway-svc:7051",
+                "url": "grpcs://org1-peer1.${ORG1_NS}.svc.cluster.local:7051",
                 "tlsCACerts": {
                     "pem": "-----BEGIN CERTIFICATE-----\\nMIICvzCCAmWgAwIBAgIULJGws7jbEY6ruSgDuvi9L7VphvIwCgYIKoZIzj0EAwIw\\naDELMAkGA1UEBhMCVVMxFzAVBgNVBAgTDk5vcnRoIENhcm9saW5hMRQwEgYDVQQK\\nEwtIeXBlcmxlZGdlcjEPMA0GA1UECxMGRmFicmljMRkwFwYDVQQDExBmYWJyaWMt\\nY2Etc2VydmVyMB4XDTIxMDkyMDE2MDkwMFoXDTIyMDkyMDE2MTQwMFowYDELMAkG\\nA1UEBhMCVVMxFzAVBgNVBAgTDk5vcnRoIENhcm9saW5hMRQwEgYDVQQKEwtIeXBl\\ncmxlZGdlcjENMAsGA1UECxMEcGVlcjETMBEGA1UEAxMKb3JnMS1wZWVyMTBZMBMG\\nByqGSM49AgEGCCqGSM49AwEHA0IABL9e3GZBf1MeoObGxwSHkcgDEjMo+/13Qc4u\\nfSG2MKrveHBIEA4MRkHNqd+sTjoz0/1B15y2n+RiPo8uJvlyC/CjgfQwgfEwDgYD\\nVR0PAQH/BAQDAgOoMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAMBgNV\\nHRMBAf8EAjAAMB0GA1UdDgQWBBSeytspiXlEzMAsnF9/wxqc9fydETAfBgNVHSME\\nGDAWgBQwru1VH0OwH3dxfPdD8w74ZIlLRzAVBgNVHREEDjAMggpvcmcxLXBlZXIx\\nMFsGCCoDBAUGBwgBBE97ImF0dHJzIjp7ImhmLkFmZmlsaWF0aW9uIjoiIiwiaGYu\\nRW5yb2xsbWVudElEIjoib3JnMS1wZWVyMSIsImhmLlR5cGUiOiJwZWVyIn19MAoG\\nCCqGSM49BAMCA0gAMEUCIQDJEjPxceCfXU5B/emrHE4JbEzrZKxLVViBWCNMsHiR\\nFgIgY+8jsvr3rlBPkpRhl8CtT2DgaP7iWvovtMYsPKhLAqk=\\n-----END CERTIFICATE-----\\n"
                   },
                 "grpcOptions": {
                     "grpc-wait-for-ready-timeout": 100000,
-                    "ssl-target-name-override": "org1-peer-gateway-svc",
-                    "hostnameOverride": "org1-peer-gateway-svc"
+                    "ssl-target-name-override": "org1-peer1.${ORG1_NS}.svc.cluster.local",
+                    "hostnameOverride": "org1-peer1.${ORG1_NS}.svc.cluster.local"
                 }
             }
         },
@@ -87,7 +87,7 @@ data:
     -----END PRIVATE KEY-----
   HLF_CONNECTION_PROFILE_ORG2: |
     {
-        "name": "${NS}-org2",
+        "name": "Org2",
         "version": "1.0.0",
         "client": {
             "organization": "Org2",
@@ -112,13 +112,13 @@ data:
         },
         "peers": {
             "org2-peers": {
-                "url": "grpcs://org2-peer-gateway-svc:7051",
+                "url": "org2-peer1.${ORG2_NS}.svc.cluster.local:7051",
                 "tlsCACerts": {
                     "pem": "-----BEGIN CERTIFICATE-----\\nMIICKDCCAc6gAwIBAgIUJJ4wGOSCfw8XOOIx29o67wBpFB4wCgYIKoZIzj0EAwIw\\naDELMAkGA1UEBhMCVVMxFzAVBgNVBAgTDk5vcnRoIENhcm9saW5hMRQwEgYDVQQK\\nEwtIeXBlcmxlZGdlcjEPMA0GA1UECxMGRmFicmljMRkwFwYDVQQDExBmYWJyaWMt\\nY2Etc2VydmVyMB4XDTIxMDkyMDExNDEwMFoXDTM2MDkxNjExNDEwMFowaDELMAkG\\nA1UEBhMCVVMxFzAVBgNVBAgTDk5vcnRoIENhcm9saW5hMRQwEgYDVQQKEwtIeXBl\\ncmxlZGdlcjEPMA0GA1UECxMGRmFicmljMRkwFwYDVQQDExBmYWJyaWMtY2Etc2Vy\\ndmVyMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEyzGJLZX6pe59QAIBacjfzU4I\\nHezBYLyEu4ySpFx4xwxNLE4BWqLhB1VaOuenSQATM8pmSAy7i1830oM9elKWK6NW\\nMFQwDgYDVR0PAQH/BAQDAgEGMBIGA1UdEwEB/wQIMAYBAf8CAQEwHQYDVR0OBBYE\\nFEoAAhmjq/3M8CFPc7N8SL53erL5MA8GA1UdEQQIMAaHBH8AAAEwCgYIKoZIzj0E\\nAwIDSAAwRQIhAJQ5PJOT4Gg8oiBU2KthMPkZqOLeu3Li4S3yBpLFgbsgAiB960P2\\nXPMu3HLoNXrktYOL9JzWlGyYRSPAnkap5Bsj0w==\\n-----END CERTIFICATE-----\\n"
                 },
                 "grpcOptions": {
-                    "ssl-target-name-override": "org2-peer-gateway-svc",
-                    "hostnameOverride": "org2-peer-gateway-svc"
+                    "ssl-target-name-override": "org2-peer1.${ORG2_NS}.svc.cluster.local",
+                    "hostnameOverride": "org2-peer1.${ORG2_NS}.svc.cluster.local"
                 }
             }
         },

--- a/test-network-k8s/kube/fabric-rest-sample.yaml
+++ b/test-network-k8s/kube/fabric-rest-sample.yaml
@@ -36,14 +36,14 @@ data:
         },
         "peers": {
             "org1-peers": {
-                "url": "grpcs://org1-peer1.${ORG1_NS}.svc.cluster.local:7051",
+                "url": "grpcs://org1-peer-gateway-svc:7051",
                 "tlsCACerts": {
                     "pem": "-----BEGIN CERTIFICATE-----\\nMIICvzCCAmWgAwIBAgIULJGws7jbEY6ruSgDuvi9L7VphvIwCgYIKoZIzj0EAwIw\\naDELMAkGA1UEBhMCVVMxFzAVBgNVBAgTDk5vcnRoIENhcm9saW5hMRQwEgYDVQQK\\nEwtIeXBlcmxlZGdlcjEPMA0GA1UECxMGRmFicmljMRkwFwYDVQQDExBmYWJyaWMt\\nY2Etc2VydmVyMB4XDTIxMDkyMDE2MDkwMFoXDTIyMDkyMDE2MTQwMFowYDELMAkG\\nA1UEBhMCVVMxFzAVBgNVBAgTDk5vcnRoIENhcm9saW5hMRQwEgYDVQQKEwtIeXBl\\ncmxlZGdlcjENMAsGA1UECxMEcGVlcjETMBEGA1UEAxMKb3JnMS1wZWVyMTBZMBMG\\nByqGSM49AgEGCCqGSM49AwEHA0IABL9e3GZBf1MeoObGxwSHkcgDEjMo+/13Qc4u\\nfSG2MKrveHBIEA4MRkHNqd+sTjoz0/1B15y2n+RiPo8uJvlyC/CjgfQwgfEwDgYD\\nVR0PAQH/BAQDAgOoMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAMBgNV\\nHRMBAf8EAjAAMB0GA1UdDgQWBBSeytspiXlEzMAsnF9/wxqc9fydETAfBgNVHSME\\nGDAWgBQwru1VH0OwH3dxfPdD8w74ZIlLRzAVBgNVHREEDjAMggpvcmcxLXBlZXIx\\nMFsGCCoDBAUGBwgBBE97ImF0dHJzIjp7ImhmLkFmZmlsaWF0aW9uIjoiIiwiaGYu\\nRW5yb2xsbWVudElEIjoib3JnMS1wZWVyMSIsImhmLlR5cGUiOiJwZWVyIn19MAoG\\nCCqGSM49BAMCA0gAMEUCIQDJEjPxceCfXU5B/emrHE4JbEzrZKxLVViBWCNMsHiR\\nFgIgY+8jsvr3rlBPkpRhl8CtT2DgaP7iWvovtMYsPKhLAqk=\\n-----END CERTIFICATE-----\\n"
                   },
                 "grpcOptions": {
                     "grpc-wait-for-ready-timeout": 100000,
-                    "ssl-target-name-override": "org1-peer1.${ORG1_NS}.svc.cluster.local",
-                    "hostnameOverride": "org1-peer1.${ORG1_NS}.svc.cluster.local"
+                    "ssl-target-name-override": "org1-peer-gateway-svc",
+                    "hostnameOverride": "org1-peer-gateway-svc"
                 }
             }
         },
@@ -112,13 +112,13 @@ data:
         },
         "peers": {
             "org2-peers": {
-                "url": "org2-peer1.${ORG2_NS}.svc.cluster.local:7051",
+                "url": "org2-peer-gateway-svc:7051",
                 "tlsCACerts": {
                     "pem": "-----BEGIN CERTIFICATE-----\\nMIICKDCCAc6gAwIBAgIUJJ4wGOSCfw8XOOIx29o67wBpFB4wCgYIKoZIzj0EAwIw\\naDELMAkGA1UEBhMCVVMxFzAVBgNVBAgTDk5vcnRoIENhcm9saW5hMRQwEgYDVQQK\\nEwtIeXBlcmxlZGdlcjEPMA0GA1UECxMGRmFicmljMRkwFwYDVQQDExBmYWJyaWMt\\nY2Etc2VydmVyMB4XDTIxMDkyMDExNDEwMFoXDTM2MDkxNjExNDEwMFowaDELMAkG\\nA1UEBhMCVVMxFzAVBgNVBAgTDk5vcnRoIENhcm9saW5hMRQwEgYDVQQKEwtIeXBl\\ncmxlZGdlcjEPMA0GA1UECxMGRmFicmljMRkwFwYDVQQDExBmYWJyaWMtY2Etc2Vy\\ndmVyMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEyzGJLZX6pe59QAIBacjfzU4I\\nHezBYLyEu4ySpFx4xwxNLE4BWqLhB1VaOuenSQATM8pmSAy7i1830oM9elKWK6NW\\nMFQwDgYDVR0PAQH/BAQDAgEGMBIGA1UdEwEB/wQIMAYBAf8CAQEwHQYDVR0OBBYE\\nFEoAAhmjq/3M8CFPc7N8SL53erL5MA8GA1UdEQQIMAaHBH8AAAEwCgYIKoZIzj0E\\nAwIDSAAwRQIhAJQ5PJOT4Gg8oiBU2KthMPkZqOLeu3Li4S3yBpLFgbsgAiB960P2\\nXPMu3HLoNXrktYOL9JzWlGyYRSPAnkap5Bsj0w==\\n-----END CERTIFICATE-----\\n"
                 },
                 "grpcOptions": {
-                    "ssl-target-name-override": "org2-peer1.${ORG2_NS}.svc.cluster.local",
-                    "hostnameOverride": "org2-peer1.${ORG2_NS}.svc.cluster.local"
+                    "ssl-target-name-override": "org2-peer-gateway-svc",
+                    "hostnameOverride": "org2-peer-gateway-svc"
                 }
             }
         },

--- a/test-network-k8s/kube/org0/org0-ca.yaml
+++ b/test-network-k8s/kube/org0/org0-ca.yaml
@@ -16,7 +16,7 @@ spec:
   dnsNames:
     - localhost
     - org0-ca
-    - org0-ca.${NS}.svc.cluster.local
+    - org0-ca.${ORG0_NS}.svc.cluster.local
     - org0-ca.${DOMAIN}
   ipAddresses:
     - 127.0.0.1

--- a/test-network-k8s/kube/org0/org0-job-scrub-fabric-volumes.yaml
+++ b/test-network-k8s/kube/org0/org0-job-scrub-fabric-volumes.yaml
@@ -1,0 +1,32 @@
+#
+# Copyright IBM Corp. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: job-scrub-fabric-volumes
+spec:
+  backoffLimit: 0
+  completions: 1
+  template:
+    metadata:
+      name: job-scrub-fabric-volumes
+    spec:
+      restartPolicy: "Never"
+      containers:
+        - name: main
+          image: busybox:latest
+          command:
+            - sh
+            - -c
+            - "rm -rvf /mnt/fabric-*/*"
+          volumeMounts:
+            - name: fabric-org0-volume
+              mountPath: /mnt/fabric-org0
+      volumes:
+        - name: fabric-org0-volume
+          persistentVolumeClaim:
+            claimName: fabric-org0

--- a/test-network-k8s/kube/org0/org0-orderer1.yaml
+++ b/test-network-k8s/kube/org0/org0-orderer1.yaml
@@ -9,7 +9,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: org0-orderer1-tls-cert
-  namespace: ${NS}
+  namespace: ${ORG0_NS}
 spec:
   isCA: false
   privateKey:
@@ -18,7 +18,7 @@ spec:
   dnsNames:
     - localhost
     - org0-orderer1
-    - org0-orderer1.${NS}.svc.cluster.local
+    - org0-orderer1.${ORG0_NS}.svc.cluster.local
     - org0-orderer1.${DOMAIN}
     - org0-orderer1-admin.${DOMAIN}
   ipAddresses:

--- a/test-network-k8s/kube/org0/org0-orderer2.yaml
+++ b/test-network-k8s/kube/org0/org0-orderer2.yaml
@@ -9,7 +9,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: org0-orderer2-tls-cert
-  namespace: ${NS}
+  namespace: ${ORG0_NS}
 spec:
   isCA: false
   privateKey:
@@ -18,7 +18,7 @@ spec:
   dnsNames:
     - localhost
     - org0-orderer2
-    - org0-orderer2.${NS}.svc.cluster.local
+    - org0-orderer2.${ORG0_NS}.svc.cluster.local
     - org0-orderer2.${DOMAIN}
     - org0-orderer2-admin.${DOMAIN}
   ipAddresses:

--- a/test-network-k8s/kube/org0/org0-orderer3.yaml
+++ b/test-network-k8s/kube/org0/org0-orderer3.yaml
@@ -9,7 +9,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: org0-orderer3-tls-cert
-  namespace: ${NS}
+  namespace: ${ORG0_NS}
 spec:
   isCA: false
   privateKey:
@@ -18,7 +18,7 @@ spec:
   dnsNames:
     - localhost
     - org0-orderer3
-    - org0-orderer3.${NS}.svc.cluster.local
+    - org0-orderer3.${ORG0_NS}.svc.cluster.local
     - org0-orderer3.${DOMAIN}
     - org0-orderer3-admin.${DOMAIN}
   ipAddresses:

--- a/test-network-k8s/kube/org1/org1-ca.yaml
+++ b/test-network-k8s/kube/org1/org1-ca.yaml
@@ -16,7 +16,7 @@ spec:
   dnsNames:
     - localhost
     - org1-ca
-    - org1-ca.${NS}.svc.cluster.local
+    - org1-ca.${ORG1_NS}.svc.cluster.local
     - org1-ca.${DOMAIN}
   ipAddresses:
     - 127.0.0.1

--- a/test-network-k8s/kube/org1/org1-job-scrub-fabric-volumes.yaml
+++ b/test-network-k8s/kube/org1/org1-job-scrub-fabric-volumes.yaml
@@ -24,20 +24,9 @@ spec:
             - -c
             - "rm -rvf /mnt/fabric-*/*"
           volumeMounts:
-            - name: fabric-org0-volume
-              mountPath: /mnt/fabric-org0
             - name: fabric-org1-volume
               mountPath: /mnt/fabric-org1
-            - name: fabric-org2-volume
-              mountPath: /mnt/fabric-org2
       volumes:
-        - name: fabric-org0-volume
-          persistentVolumeClaim:
-            claimName: fabric-org0
         - name: fabric-org1-volume
           persistentVolumeClaim:
             claimName: fabric-org1
-        - name: fabric-org2-volume
-          persistentVolumeClaim:
-            claimName: fabric-org2
-

--- a/test-network-k8s/kube/org1/org1-peer1.yaml
+++ b/test-network-k8s/kube/org1/org1-peer1.yaml
@@ -8,7 +8,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: org1-peer1-tls-cert
-  namespace: ${NS}
+  namespace: ${ORG1_NS}
 spec:
   isCA: false
   privateKey:
@@ -17,7 +17,7 @@ spec:
   dnsNames:
     - localhost
     - org1-peer1
-    - org1-peer1.${NS}.svc.cluster.local
+    - org1-peer1.${ORG1_NS}.svc.cluster.local
     - org1-peer1.${DOMAIN}
     - org1-peer-gateway-svc
     - org1-peer-gateway-svc.${DOMAIN}
@@ -46,7 +46,7 @@ data:
   CORE_PEER_CHAINCODELISTENADDRESS: 0.0.0.0:7052
   # bootstrap peer is the other peer in the same org
   CORE_PEER_GOSSIP_BOOTSTRAP: org1-peer2:7051
-  CORE_PEER_GOSSIP_EXTERNALENDPOINT: org1-peer1:7051
+  CORE_PEER_GOSSIP_EXTERNALENDPOINT: org1-peer1.${ORG1_NS}.svc.cluster.local:7051
   CORE_PEER_LOCALMSPID: Org1MSP
   CORE_PEER_MSPCONFIGPATH: /var/hyperledger/fabric/organizations/peerOrganizations/org1.example.com/peers/org1-peer1.org1.example.com/msp
   CORE_OPERATIONS_LISTENADDRESS: 0.0.0.0:9443

--- a/test-network-k8s/kube/org1/org1-peer2.yaml
+++ b/test-network-k8s/kube/org1/org1-peer2.yaml
@@ -8,7 +8,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: org1-peer2-tls-cert
-  namespace: ${NS}
+  namespace: ${ORG1_NS}
 spec:
   isCA: false
   privateKey:
@@ -18,7 +18,7 @@ spec:
     - localhost
     - org1-peer2
     - org1-peer-gateway-svc
-    - org1-peer2.${NS}.svc.cluster.local
+    - org1-peer2.${ORG1_NS}.svc.cluster.local
     - org1-peer2.${DOMAIN}
   ipAddresses:
     - 127.0.0.1
@@ -46,7 +46,7 @@ data:
   CORE_PEER_CHAINCODELISTENADDRESS: 0.0.0.0:7052
   # bootstrap peer is the other peer in the same org
   CORE_PEER_GOSSIP_BOOTSTRAP: org1-peer1:7051
-  CORE_PEER_GOSSIP_EXTERNALENDPOINT: org1-peer2:7051
+  CORE_PEER_GOSSIP_EXTERNALENDPOINT: org1-peer2.${ORG1_NS}.svc.cluster.local:7051
   CORE_PEER_LOCALMSPID: Org1MSP
   CORE_PEER_MSPCONFIGPATH: /var/hyperledger/fabric/organizations/peerOrganizations/org1.example.com/peers/org1-peer2.org1.example.com/msp
   CORE_OPERATIONS_LISTENADDRESS: 0.0.0.0:9443

--- a/test-network-k8s/kube/org2/org2-ca.yaml
+++ b/test-network-k8s/kube/org2/org2-ca.yaml
@@ -16,7 +16,7 @@ spec:
   dnsNames:
     - localhost
     - org2-ca
-    - org2-ca.${NS}.svc.cluster.local
+    - org2-ca.${ORG2_NS}.svc.cluster.local
     - org2-ca.${DOMAIN}
   ipAddresses:
     - 127.0.0.1

--- a/test-network-k8s/kube/org2/org2-job-scrub-fabric-volumes.yaml
+++ b/test-network-k8s/kube/org2/org2-job-scrub-fabric-volumes.yaml
@@ -1,0 +1,33 @@
+#
+# Copyright IBM Corp. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: job-scrub-fabric-volumes
+spec:
+  backoffLimit: 0
+  completions: 1
+  template:
+    metadata:
+      name: job-scrub-fabric-volumes
+    spec:
+      restartPolicy: "Never"
+      containers:
+        - name: main
+          image: busybox:latest
+          command:
+            - sh
+            - -c
+            - "rm -rvf /mnt/fabric-*/*"
+          volumeMounts:
+            - name: fabric-org2-volume
+              mountPath: /mnt/fabric-org2
+      volumes:
+        - name: fabric-org2-volume
+          persistentVolumeClaim:
+            claimName: fabric-org2
+

--- a/test-network-k8s/kube/org2/org2-peer1.yaml
+++ b/test-network-k8s/kube/org2/org2-peer1.yaml
@@ -8,7 +8,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: org2-peer1-tls-cert
-  namespace: ${NS}
+  namespace: ${ORG2_NS}
 spec:
   isCA: false
   privateKey:
@@ -17,7 +17,7 @@ spec:
   dnsNames:
     - localhost
     - org2-peer1
-    - org2-peer1.${NS}.svc.cluster.local
+    - org2-peer1.${ORG2_NS}.svc.cluster.local
     - org2-peer1.${DOMAIN}
     - org2-peer-gateway-svc
     - org2-peer-gateway-svc.${DOMAIN}
@@ -46,7 +46,7 @@ data:
   CORE_PEER_CHAINCODELISTENADDRESS: 0.0.0.0:7052
   # bootstrap peer is the other peer in the same org
   CORE_PEER_GOSSIP_BOOTSTRAP: org2-peer2:7051
-  CORE_PEER_GOSSIP_EXTERNALENDPOINT: org2-peer1:7051
+  CORE_PEER_GOSSIP_EXTERNALENDPOINT: org2-peer1.${ORG2_NS}.svc.cluster.local:7051
   CORE_PEER_LOCALMSPID: Org2MSP
   CORE_PEER_MSPCONFIGPATH: /var/hyperledger/fabric/organizations/peerOrganizations/org2.example.com/peers/org2-peer1.org2.example.com/msp
   CORE_OPERATIONS_LISTENADDRESS: 0.0.0.0:9443

--- a/test-network-k8s/kube/org2/org2-peer2.yaml
+++ b/test-network-k8s/kube/org2/org2-peer2.yaml
@@ -8,7 +8,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: org2-peer2-tls-cert
-  namespace: ${NS}
+  namespace: ${ORG2_NS}
 spec:
   isCA: false
   privateKey:
@@ -18,7 +18,7 @@ spec:
     - localhost
     - org2-peer2
     - org2-peer-gateway-svc
-    - org2-peer2.${NS}.svc.cluster.local
+    - org2-peer2.${ORG2_NS}.svc.cluster.local
     - org2-peer2.${DOMAIN}
   ipAddresses:
     - 127.0.0.1
@@ -45,7 +45,7 @@ data:
   CORE_PEER_CHAINCODELISTENADDRESS: 0.0.0.0:7052
   # bootstrap peer is the other peer in the same org
   CORE_PEER_GOSSIP_BOOTSTRAP: org2-peer1:7051
-  CORE_PEER_GOSSIP_EXTERNALENDPOINT: org2-peer2:7051
+  CORE_PEER_GOSSIP_EXTERNALENDPOINT: org2-peer2.${ORG2_NS}.svc.cluster.local:7051
   CORE_PEER_LOCALMSPID: Org2MSP
   CORE_PEER_MSPCONFIGPATH: /var/hyperledger/fabric/organizations/peerOrganizations/org2.example.com/peers/org2-peer2.org2.example.com/msp
   CORE_OPERATIONS_LISTENADDRESS: 0.0.0.0:9443

--- a/test-network-k8s/network
+++ b/test-network-k8s/network
@@ -41,9 +41,9 @@ context NETWORK_NAME                  test-network
 context CLUSTER_NAME                  kind
 context KUBE_NAMESPACE                ${NETWORK_NAME}
 context NS                            ${KUBE_NAMESPACE}
-context ORG0_NS                       org0-namespace
-context ORG1_NS                       org1-namespace
-context ORG2_NS                       org2-namespace
+context ORG0_NS                       ${NS}
+context ORG1_NS                       ${NS}
+context ORG2_NS                       ${NS}
 context DOMAIN                        localho.st
 context CHANNEL_NAME                  mychannel
 context ORDERER_TIMEOUT               10s                   # see https://github.com/hyperledger/fabric/issues/3372

--- a/test-network-k8s/network
+++ b/test-network-k8s/network
@@ -41,6 +41,9 @@ context NETWORK_NAME                  test-network
 context CLUSTER_NAME                  kind
 context KUBE_NAMESPACE                ${NETWORK_NAME}
 context NS                            ${KUBE_NAMESPACE}
+context ORG0_NS                       org0-namespace
+context ORG1_NS                       org1-namespace
+context ORG2_NS                       org2-namespace
 context DOMAIN                        localho.st
 context CHANNEL_NAME                  mychannel
 context ORDERER_TIMEOUT               10s                   # see https://github.com/hyperledger/fabric/issues/3372

--- a/test-network-k8s/scripts/ccp-template.json
+++ b/test-network-k8s/scripts/ccp-template.json
@@ -24,13 +24,13 @@
     },
     "peers": {
         "org${ORG}-peers": {
-            "url": "grpcs://org${ORG}-peer-gateway-svc:7051",
+            "url": "grpcs://org${ORG}-peer1.${NS}.svc.cluster.local:7051",
             "tlsCACerts": {
                 "pem": "${PEERPEM}"
             },
             "grpcOptions": {
-                "ssl-target-name-override": "org${ORG}-peer-gateway-svc",
-                "hostnameOverride": "org${ORG}-peer-gateway-svc"
+                "ssl-target-name-override": "org${ORG}-peer1.${NS}.svc.cluster.local",
+                "hostnameOverride": "org${ORG}-peer1.${NS}.svc.cluster.local"
             }
         }
     },

--- a/test-network-k8s/scripts/chaincode.sh
+++ b/test-network-k8s/scripts/chaincode.sh
@@ -299,9 +299,9 @@ function launch_chaincode_service() {
     | sed 's,{{CHAINCODE_ID}},'${cc_id}',g' \
     | sed 's,{{CHAINCODE_IMAGE}},'${cc_image}',g' \
     | sed 's,{{PEER_NAME}},'${peer}',g' \
-    | exec kubectl -n $NS apply -f -
+    | exec kubectl -n $ORG1_NS apply -f -
 
-  kubectl -n $NS rollout status deploy/${org}${peer}-ccaas-${cc_name}
+  kubectl -n $ORG1_NS rollout status deploy/${org}${peer}-ccaas-${cc_name}
 
   pop_fn
 }

--- a/test-network-k8s/scripts/fabric_CAs.sh
+++ b/test-network-k8s/scripts/fabric_CAs.sh
@@ -8,13 +8,13 @@
 function launch_ECert_CAs() {
   push_fn "Launching Fabric CAs"
 
-  apply_template kube/org0/org0-ca.yaml
-  apply_template kube/org1/org1-ca.yaml
-  apply_template kube/org2/org2-ca.yaml
+  apply_template kube/org0/org0-ca.yaml $ORG0_NS
+  apply_template kube/org1/org1-ca.yaml $ORG1_NS
+  apply_template kube/org2/org2-ca.yaml $ORG2_NS
 
-  kubectl -n $NS rollout status deploy/org0-ca
-  kubectl -n $NS rollout status deploy/org1-ca
-  kubectl -n $NS rollout status deploy/org2-ca
+  kubectl -n $ORG0_NS rollout status deploy/org0-ca
+  kubectl -n $ORG1_NS rollout status deploy/org1-ca
+  kubectl -n $ORG2_NS rollout status deploy/org2-ca
 
   # todo: this papers over a nasty bug whereby the CAs are ready, but sporadically refuse connections after a down / up
   sleep 5
@@ -28,23 +28,28 @@ function init_tls_cert_issuers() {
 
   # Create a self-signing certificate issuer / root TLS certificate for the blockchain.
   # TODO : Bring-Your-Own-Key - allow the network bootstrap to read an optional ECDSA key pair for the TLS trust root CA.
-  kubectl -n $NS apply -f kube/root-tls-cert-issuer.yaml
-  kubectl -n $NS wait --timeout=30s --for=condition=Ready issuer/root-tls-cert-issuer
+  kubectl -n $ORG0_NS apply -f kube/root-tls-cert-issuer.yaml
+  kubectl -n $ORG0_NS wait --timeout=30s --for=condition=Ready issuer/root-tls-cert-issuer
+  kubectl -n $ORG1_NS apply -f kube/root-tls-cert-issuer.yaml
+  kubectl -n $ORG1_NS wait --timeout=30s --for=condition=Ready issuer/root-tls-cert-issuer
+  kubectl -n $ORG2_NS apply -f kube/root-tls-cert-issuer.yaml
+  kubectl -n $ORG2_NS wait --timeout=30s --for=condition=Ready issuer/root-tls-cert-issuer
 
   # Use the self-signing issuer to generate three Issuers, one for each org.
-  kubectl -n $NS apply -f kube/org0/org0-tls-cert-issuer.yaml
-  kubectl -n $NS apply -f kube/org1/org1-tls-cert-issuer.yaml
-  kubectl -n $NS apply -f kube/org2/org2-tls-cert-issuer.yaml
+  kubectl -n $ORG0_NS apply -f kube/org0/org0-tls-cert-issuer.yaml
+  kubectl -n $ORG1_NS apply -f kube/org1/org1-tls-cert-issuer.yaml
+  kubectl -n $ORG2_NS apply -f kube/org2/org2-tls-cert-issuer.yaml
 
-  kubectl -n $NS wait --timeout=30s --for=condition=Ready issuer/org0-tls-cert-issuer
-  kubectl -n $NS wait --timeout=30s --for=condition=Ready issuer/org1-tls-cert-issuer
-  kubectl -n $NS wait --timeout=30s --for=condition=Ready issuer/org2-tls-cert-issuer
+  kubectl -n $ORG0_NS wait --timeout=30s --for=condition=Ready issuer/org0-tls-cert-issuer
+  kubectl -n $ORG1_NS wait --timeout=30s --for=condition=Ready issuer/org1-tls-cert-issuer
+  kubectl -n $ORG2_NS wait --timeout=30s --for=condition=Ready issuer/org2-tls-cert-issuer
 
   pop_fn
 }
 
 function enroll_bootstrap_ECert_CA_user() {
   local org=$1
+  local ns=$2
 
   # Determine the CA information and TLS certificate
   CA_NAME=${org}-ca
@@ -53,7 +58,7 @@ function enroll_bootstrap_ECert_CA_user() {
 
   # Read the CA's TLS certificate from the cert-manager CA secret
   echo "retrieving ${CA_NAME} TLS root cert"
-  kubectl -n $NS get secret ${CA_NAME}-tls-cert -o json \
+  kubectl -n $ns get secret ${CA_NAME}-tls-cert -o json \
     | jq -r .data.\"ca.crt\" \
     | base64 -d \
     > ${CA_DIR}/tlsca-cert.pem
@@ -68,9 +73,9 @@ function enroll_bootstrap_ECert_CA_user() {
 function enroll_bootstrap_ECert_CA_users() {
   push_fn "Enrolling bootstrap ECert CA users"
 
-  enroll_bootstrap_ECert_CA_user org0
-  enroll_bootstrap_ECert_CA_user org1
-  enroll_bootstrap_ECert_CA_user org2
+  enroll_bootstrap_ECert_CA_user org0 $ORG0_NS
+  enroll_bootstrap_ECert_CA_user org1 $ORG1_NS
+  enroll_bootstrap_ECert_CA_user org2 $ORG2_NS
 
   pop_fn
 }

--- a/test-network-k8s/scripts/fabric_config.sh
+++ b/test-network-k8s/scripts/fabric_config.sh
@@ -6,15 +6,17 @@
 #
 
 function init_namespace() {
-  push_fn "Creating namespace \"$NS\""
-  for ns in $ORG0_NS $ORG1_NS $ORG2_NS; do
+  local namespaces=$(echo "$ORG0_NS $ORG1_NS $ORG2_NS" | xargs -n1 | sort -u)
+  for ns in $namespaces; do
+    push_fn "Creating namespace \"$ns\""
     kubectl create namespace $ns || true
+    pop_fn
   done
-  pop_fn
 }
 
 function delete_namespace() {
-  for ns in $ORG0_NS $ORG1_NS $ORG2_NS; do
+  local namespaces=$(echo "$ORG0_NS $ORG1_NS $ORG2_NS" | xargs -n1 | sort -u)
+  for ns in $namespaces; do
     push_fn "Deleting namespace \"$ns\""
     kubectl delete namespace $ns || true
     pop_fn
@@ -61,8 +63,8 @@ function load_org_config() {
 function apply_k8s_builder_roles() {
   push_fn "Applying k8s chaincode builder roles"
 
-  apply_template kube/fabric-builder-role.yaml
-  apply_template kube/fabric-builder-rolebinding.yaml
+  apply_template kube/fabric-builder-role.yaml $ORG1_NS
+  apply_template kube/fabric-builder-rolebinding.yaml $ORG1_NS
 
   pop_fn
 }
@@ -70,8 +72,8 @@ function apply_k8s_builder_roles() {
 function apply_k8s_builders() {
   push_fn "Installing k8s chaincode builders"
 
-  apply_template kube/org1/org1-install-k8s-builder.yaml
-  apply_template kube/org2/org2-install-k8s-builder.yaml
+  apply_template kube/org1/org1-install-k8s-builder.yaml $ORG1_NS
+  apply_template kube/org2/org2-install-k8s-builder.yaml $ORG1_NS
 
   pop_fn
 }

--- a/test-network-k8s/scripts/fabric_config.sh
+++ b/test-network-k8s/scripts/fabric_config.sh
@@ -7,18 +7,18 @@
 
 function init_namespace() {
   push_fn "Creating namespace \"$NS\""
-
-  kubectl create namespace $NS || true
-
+  for ns in $ORG0_NS $ORG1_NS $ORG2_NS; do
+    kubectl create namespace $ns || true
+  done
   pop_fn
 }
 
 function delete_namespace() {
-  push_fn "Deleting namespace \"$NS\""
-
-  kubectl delete namespace $NS || true
-
-  pop_fn
+  for ns in $ORG0_NS $ORG1_NS $ORG2_NS; do
+    push_fn "Deleting namespace \"$ns\""
+    kubectl delete namespace $ns || true
+    pop_fn
+  done
 }
 
 function init_storage_volumes() {
@@ -37,9 +37,9 @@ function init_storage_volumes() {
     exit 1
   fi
 
-  cat kube/pvc-fabric-org0.yaml | envsubst | kubectl -n $NS create -f - || true
-  cat kube/pvc-fabric-org1.yaml | envsubst | kubectl -n $NS create -f - || true
-  cat kube/pvc-fabric-org2.yaml | envsubst | kubectl -n $NS create -f - || true
+  cat kube/pvc-fabric-org0.yaml | envsubst | kubectl -n $ORG0_NS create -f - || true
+  cat kube/pvc-fabric-org1.yaml | envsubst | kubectl -n $ORG1_NS create -f - || true
+  cat kube/pvc-fabric-org2.yaml | envsubst | kubectl -n $ORG2_NS create -f - || true
 
   pop_fn
 }
@@ -47,13 +47,13 @@ function init_storage_volumes() {
 function load_org_config() {
   push_fn "Creating fabric config maps"
 
-  kubectl -n $NS delete configmap org0-config || true
-  kubectl -n $NS delete configmap org1-config || true
-  kubectl -n $NS delete configmap org2-config || true
+  kubectl -n $ORG0_NS delete configmap org0-config || true
+  kubectl -n $ORG1_NS delete configmap org1-config || true
+  kubectl -n $ORG2_NS delete configmap org2-config || true
 
-  kubectl -n $NS create configmap org0-config --from-file=config/org0
-  kubectl -n $NS create configmap org1-config --from-file=config/org1
-  kubectl -n $NS create configmap org2-config --from-file=config/org2
+  kubectl -n $ORG0_NS create configmap org0-config --from-file=config/org0
+  kubectl -n $ORG1_NS create configmap org1-config --from-file=config/org1
+  kubectl -n $ORG2_NS create configmap org2-config --from-file=config/org2
 
   pop_fn
 }

--- a/test-network-k8s/scripts/utils.sh
+++ b/test-network-k8s/scripts/utils.sh
@@ -84,7 +84,7 @@ function apply_template() {
   echo "Applying template $1:"
   cat $1 | envsubst
 
-  cat $1 | envsubst | kubectl -n $NS apply -f -
+  cat $1 | envsubst | kubectl -n $2 apply -f -
 }
 
 # Set the calling context to refer the peer binary to the correct org / peer instance


### PR DESCRIPTION
Currently all the organizations are in a single namespace. Changes are done in multiple files to create three namespaces and to separate organizations across namespaces.
- ORG0_NS, ORG1_NS, ORG3_NS are defined in network script
- $NS in the scripts are replaced with corresponding namespace

All till chaincode invoke/query is working. I'm yet to test the api server. kind was used for n/w setup, will test on Rancher also.

fixes https://github.com/hyperledger/fabric-samples/issues/644.

Signed-off-by: Basil K Y <techiebasil@gmail.com>