### PR TITLE
Update nano test network

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,6 @@
 .#*
 # Vim file artifacts
 .*.sw*
-# installed platform-specific binaries
-bin
-/config
 .DS_Store
 .project
 # omit Go vendor directories
@@ -19,8 +16,14 @@ node_modules/
 # Ignore Gradle build output directory
 build
 package-lock.json
-external-chaincode/
 
 # Eclipse
 .classpath
 .settings
+
+# installed Fabric binaries etc.
+bin/
+builders/
+config/
+external-chaincode/
+install-fabric.sh

--- a/ci/scripts/shellcheck.sh
+++ b/ci/scripts/shellcheck.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 set -euo pipefail
 
-scversion="v0.8.0" # or "stable", or "latest"
-wget -qO- "https://github.com/koalaman/shellcheck/releases/download/${scversion?}/shellcheck-${scversion?}.linux.x86_64.tar.xz" | tar -xJv "shellcheck-${scversion}/shellcheck"
-"./shellcheck-${scversion}/shellcheck" --version
+shellcheck --version
 
-"./shellcheck-${scversion}/shellcheck" ./test-network-nano-bash/*.sh
+cd ./test-network-nano-bash && shellcheck *.sh

--- a/test-network-nano-bash/.gitignore
+++ b/test-network-nano-bash/.gitignore
@@ -1,4 +1,5 @@
 channel-artifacts/
 crypto-config/
 data/
+logs/
 *.gz

--- a/test-network-nano-bash/README.md
+++ b/test-network-nano-bash/README.md
@@ -16,23 +16,31 @@ As the name `nano` implies, the scripts provide the smallest minimal setup possi
 # Prereqs
 
 - Follow the Fabric documentation for the [Prereqs](https://hyperledger-fabric.readthedocs.io/en/latest/prereqs.html)
-- Follow the Fabric documentation for [downloading the Fabric samples and binaries](https://hyperledger-fabric.readthedocs.io/en/latest/install.html). You can skip the docker image downloads by using `curl -sSL https://bit.ly/2ysbOFE | bash -s -- -d`
+- Follow the Fabric documentation for [downloading the Fabric samples and binaries](https://hyperledger-fabric.readthedocs.io/en/latest/install.html). You can skip the docker image downloads by using `./install-fabric.sh binary samples`
 
 ## To run the chaincode as a service
-- You need to have the `ccaas_builder` binaries. If you do not have them in `fabric-samples/bin` you can build them from the Fabric source with the command `make ccaasbuilder`, you will then find the builder in `fabric/release/darwin-amd64/bin` or equivalent for your system. Just move the whole hierarchy starting there to `fabric-samples/bin` with something like: `mv release/darwin-amd64/bin/ccaas_builder ../fabric-samples/bin`
-- You need to edit the `fabric-samples/config/core.yaml` file to point to that builder. The path specified in the default config file is only valid within the peer container which you won't be using. Modify the `externalBuilders` field in the `core.yaml` file to add the local external builder so that the configuration looks something like the following:
-```
+You need to configure the peer to use the `ccaas` external builder downloaded with the binaries above.
+The path specified in the default config file is only valid within the peer container which you won't be using.
+Edit the `fabric-samples/config/core.yaml` file and modify the `externalBuilders` field to point to the correct path.
+The configuration should look something like the following:
+
+```yaml
 externalBuilders:
-       - name: ccaas_builder
-         path: /opt/hyperledger/ccaas_builder
-         propagateEnvironment:
-           - CHAINCODE_AS_A_SERVICE_BUILDER_CONFIG
-       - name: external-sample-builder
-	     path: ../bin/ccaas_builder
+  - name: ccaas_builder
+    path: /Users/nanofab/fabric-samples/builders/ccaas
+    propagateEnvironment:
+      - CHAINCODE_AS_A_SERVICE_BUILDER_CONFIG
 ```
-The path must be absolute or relative to where the peer will run so that it can find the builder when installing the chaincode.
+
+If you have [yq](https://mikefarah.gitbook.io/yq/) installed, run the following command in the `fabric-samples` directory to update the configuration:
+
+```shell
+yq -i 'del(.chaincode.externalBuilders) | .chaincode.externalBuilders[0].name = "ccaas_builder" | .chaincode.externalBuilders[0].path = env(PWD) + "/builders/ccaas" | .chaincode.externalBuilders[0].propagateEnvironment[0] = "CHAINCODE_AS_A_SERVICE_BUILDER_CONFIG"' config/core.yaml
+```
 
 # Instructions for starting network
+
+## Running each component separately
 
 Open terminal windows for 3 ordering nodes, 4 peer nodes, and 4 peer admins as seen in the following terminal setup. The first two peers and peer admins belong to Org1, the latter two peer and peer admins belong to Org2.
 Note, you can start with two ordering nodes and a single Org1 peer node and single Org1 peer admin terminal if you would like to keep things even more minimal (two ordering nodes are required to achieve consensus (2 of 3), while a single peer from Org1 can be utilized since the endorsement policy is set as any single organization).
@@ -47,12 +55,28 @@ If you have trouble running bash scripts in your environment, you can just as ea
 - In the three orderer terminals, run `./orderer1.sh`, `./orderer2.sh`, `./orderer3.sh` respectively
 - In the four peer terminals, run `./peer1.sh`, `./peer2.sh`, `./peer3.sh`, `./peer4.sh` respectively
 - Note that each orderer and peer write their data (including their ledgers) to their own subdirectory under the `data` directory
-- In the four peer admin terminals, run `source peer1admin.sh`, `source peer2admin.sh`, `source peer3admin.sh`, `source peer4admin.sh` respectively
+- In the four peer admin terminals, run `source peer1admin.sh && ./create_channel.sh`, `source peer2admin.sh && ./join_channel.sh`, `source peer3admin.sh && ./join_channel.sh`, `source peer4admin.sh && ./join_channel.sh` respectively
 
-Note the syntax of running the scripts. The peer admin scripts run with the `source` command in order to source the script files in the respective shells. This is important so that the exported environment variables can be utilized by any subsequent user commands.
+Note the syntax of running the scripts. The peer admin scripts set the admin environment variables and must be run with the `source` command in order that the exported environment variables can be utilized by any subsequent user commands.
 
-The `peer1admin.sh` script sets the peer1 admin environment variables, creates the application channel `mychannel`, updates the channel configuration for the org1 gossip anchor peer, and joins peer1 to `mychannel`.
-The remaining peer admin scripts join their respective peers to `mychannel`.
+The `create_channel.sh` script creates the application channel `mychannel`, updates the channel configuration for the gossip anchor peer, and joins the peer to `mychannel`.
+The `join_channel.sh` script joins a peer to `mychannel`.
+
+## Starting the network with one command
+
+Using the individual scripts above gives you more control of the process of starting a Fabric network and demonstrates how all the required components fit together, however the same network can also be started using a single script for convenience.
+
+```shell
+./network.sh start
+```
+
+After the network has started, use seperate terminals to run peer commands.
+You will need to configure the peer environment for each new terminal.
+For example to run against peer1, use:
+
+```shell
+source peer1admin.sh
+```
 
 # Instructions for deploying and running the basic asset transfer sample chaincode
 
@@ -65,7 +89,7 @@ To deploy and invoke the chaincode, utilize the peer1 admin terminal that you ha
 
 Package and install the chaincode on peer1:
 
-```
+```shell
 peer lifecycle chaincode package basic.tar.gz --path ../asset-transfer-basic/chaincode-go --lang golang --label basic_1
 
 peer lifecycle chaincode install basic.tar.gz
@@ -73,16 +97,15 @@ peer lifecycle chaincode install basic.tar.gz
 
 The chaincode install may take a minute since the `fabric-ccenv` chaincode builder docker image will be downloaded if not already available on your machine. Copy the returned chaincode package ID into an environment variable for use in subsequent commands (your ID may be different):
 
-```
+```shell
 export CHAINCODE_ID=basic_1:faaa38f2fc913c8344986a7d1617d21f6c97bc8d85ee0a489c90020cd57af4a5
 ```
-
 
 ## 2. Running the chaincode as a service
 
 Package and install the external chaincode on peer1 with the following simple commands:
 
-```
+```shell
 cd chaincode-external
 
 tar cfz code.tar.gz connection.json
@@ -95,50 +118,55 @@ peer lifecycle chaincode install chaincode-external/external-chaincode.tgz
 
 Copy the returned chaincode package ID into an environment variable for use in subsequent commands (your ID may be different):
 
-```
-export CHAINCODE_ID=basic_1.0:f3e2ca5115bba71aa2fd16e35722b420cb29c42594f0fdd6814daedbc2130b80
+```shell
+export CHAINCODE_ID=$(peer lifecycle chaincode calculatepackageid chaincode-external/external-chaincode.tgz) && echo $CHAINCODE_ID
 ```
 
 In another terminal, navigate to `fabric-samples/asset-transfer-basic/chaincode-typescript` and build the chaincode:
 
-```
+```shell
 npm install
+npm run build
 ```
 
 Set the chaincode package ID again (this is a different terminal):
 
-```
-export CHAINCODE_ID=basic_1.0:f3e2ca5115bba71aa2fd16e35722b420cb29c42594f0fdd6814daedbc2130b80
+```shell
+export CHAINCODE_ID=$(peer lifecycle chaincode calculatepackageid ../../test-network-nano-bash/chaincode-external/external-chaincode.tgz) && echo $CHAINCODE_ID
 ```
 
 Set the chaincode server address:
 
-```
+```shell
 export CHAINCODE_SERVER_ADDRESS=127.0.0.1:9999
 ```
 
 And start the chaincode service:
 
-```
-npm run start:server-notls
+```shell
+npm run start:server-nontls
 ```
 
 ## Activate the chaincode
 
 Using the peer1 admin, approve and commit the chaincode (only a single approver is required based on the lifecycle endorsement policy of any organization):
 
-```
+```shell
 peer lifecycle chaincode approveformyorg -o 127.0.0.1:6050 --channelID mychannel --name basic --version 1 --package-id $CHAINCODE_ID --sequence 1 --tls --cafile ${PWD}/crypto-config/ordererOrganizations/example.com/orderers/orderer.example.com/tls/ca.crt
 
 peer lifecycle chaincode commit -o 127.0.0.1:6050 --channelID mychannel --name basic --version 1 --sequence 1 --tls --cafile "${PWD}"/crypto-config/ordererOrganizations/example.com/orderers/orderer.example.com/tls/ca.crt
 ```
+
+**Note:** after following the instructions above, the chaincode will only be installed on peer1 and will only be available in the peer1admin shell.
+Rerun the `peer lifecycle chaincode install` command in other peer admin shells to install it on the corresponding peer.
+You will also need to rerun the `peer lifecycle chaincode approveformyorg` command to use the chaincode on peers in another organisation, e.g. using the peer3admin shell.
 
 ## Interact with the chaincode
 
 Invoke the chaincode to create an asset (only a single endorser is required based on the default endorsement policy of any organization).
 Then query the asset, update it, and query again to see the resulting asset changes on the ledger. Note that you need to wait a bit for invoke transactions to complete.
 
-```
+```shell
 peer chaincode invoke -o 127.0.0.1:6050 -C mychannel -n basic -c '{"Args":["CreateAsset","1","blue","35","tom","1000"]}' --tls --cafile "${PWD}"/crypto-config/ordererOrganizations/example.com/orderers/orderer.example.com/tls/ca.crt
 
 peer chaincode query -C mychannel -n basic -c '{"Args":["ReadAsset","1"]}'
@@ -150,4 +178,8 @@ peer chaincode query -C mychannel -n basic -c '{"Args":["ReadAsset","1"]}'
 
 Congratulations, you have deployed a minimal Fabric network! Inspect the scripts if you would like to see the minimal set of commands that were required to deploy the network.
 
-Utilize `Ctrl-C` in the orderer and peer terminal windows to kill the orderer and peer processes. You can run the scripts again to restart the components with their existing data, or run `./generate_artifacts` again to clean up the existing artifacts and data if you would like to restart with a clean environment.
+# Stopping the network
+
+If you started the Fabric componentes individually, utilize `Ctrl-C` in the orderer and peer terminal windows to kill the orderer and peer processes. You can run the scripts again to restart the components with their existing data, or run `./generate_artifacts` again to clean up the existing artifacts and data if you would like to restart with a clean environment.
+
+If you used the `network.sh` script, utilize `Ctrl-C` to kill the orderer and peer processes. You can restart the network with the existing data, or run `./network.sh clean` to remove old data before restarting.

--- a/test-network-nano-bash/create_channel.sh
+++ b/test-network-nano-bash/create_channel.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env sh
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+set -eu
+
+# create channel and add anchor peer
+peer channel create -c mychannel -o 127.0.0.1:6050 -f "${PWD}"/channel-artifacts/mychannel.tx --outputBlock "${PWD}"/channel-artifacts/mychannel.block  --tls --cafile "${PWD}"/crypto-config/ordererOrganizations/example.com/orderers/orderer.example.com/tls/ca.crt
+peer channel update -o 127.0.0.1:6050 -c mychannel -f "${PWD}"/channel-artifacts/Org1MSPanchors.tx --tls --cafile "${PWD}"/crypto-config/ordererOrganizations/example.com/orderers/orderer.example.com/tls/ca.crt
+
+# join peer to channel
+peer channel join -b "${PWD}"/channel-artifacts/mychannel.block

--- a/test-network-nano-bash/generate_artifacts.sh
+++ b/test-network-nano-bash/generate_artifacts.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env sh
+#
+# SPDX-License-Identifier: Apache-2.0
+#
 set -eu
 
 # remove existing artifacts, or proceed on if the directories don't exist

--- a/test-network-nano-bash/join_channel.sh
+++ b/test-network-nano-bash/join_channel.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+set -eu
+
+# join peer to channel
+peer channel join -b "${PWD}"/channel-artifacts/mychannel.block

--- a/test-network-nano-bash/network.sh
+++ b/test-network-nano-bash/network.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env sh
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+set -eu
+
+# Print the usage message
+printHelp() {
+  USAGE="${1:-}"
+  if [ "$USAGE" = "start" ]; then
+    echo "Usage: "
+    echo "  network.sh start [Flags]"
+    echo
+    echo "  Starts the test network"
+    echo
+    echo "    Flags:"
+    echo "    -d <delay> - CLI delays for a certain number of seconds (defaults to 3)"
+    echo "    -h - Print this message"
+  elif [ "$USAGE" = "clean" ]; then
+    echo "Usage: "
+    echo "  network.sh clean [Flags]"
+    echo
+    echo "  Cleans the test network configuration and data files"
+    echo
+    echo "    Flags:"
+    echo "    -h - Print this message"
+  else
+    echo "Usage: "
+    echo "  network.sh <Mode> [Flags]"
+    echo "    Modes:"
+    echo "      start - Starts the test network"
+    echo "      clean - Cleans the test network configuration and data files"
+    echo
+    echo "    Flags:"
+    echo "    -h - Print this message"
+    echo
+    echo " Examples:"
+    echo "   network.sh start"
+  fi
+}
+
+networkStop() {
+  echo "Stopping Fabric network..."
+  trap " " 0 1 2 3 15 && kill -- -$$
+  wait
+  echo "Fabric network stopped."
+}
+
+networkStart() {
+  : "${CLI_DELAY:=5}"
+
+  # shellcheck disable=SC2064
+  trap networkStop 0 1 2 3 15
+
+  if [ -d "${PWD}"/channel-artifacts ] && [ -d "${PWD}"/crypto-config ]; then
+    echo "Using existing artifacts..."
+    CREATE_CHANNEL=false
+  else
+    echo "Generating artifacts..."
+    ./generate_artifacts.sh
+    CREATE_CHANNEL=true
+  fi
+
+  echo "Creating logs directory..."
+  mkdir -p "${PWD}"/logs
+
+  echo "Starting orderers..."
+  ./orderer1.sh > ./logs/orderer1.log 2>&1 &
+  ./orderer2.sh > ./logs/orderer2.log 2>&1 &
+  ./orderer3.sh > ./logs/orderer3.log 2>&1 &
+
+  echo "Waiting ${CLI_DELAY}s..."
+  sleep ${CLI_DELAY}
+
+  echo "Starting peers..."
+  ./peer1.sh > ./logs/peer1.log 2>&1 &
+  ./peer2.sh > ./logs/peer2.log 2>&1 &
+  ./peer3.sh > ./logs/peer3.log 2>&1 &
+  ./peer4.sh > ./logs/peer4.log 2>&1 &
+
+  echo "Waiting ${CLI_DELAY}s..."
+  sleep ${CLI_DELAY}
+
+  if [ "${CREATE_CHANNEL}" = "true" ]; then
+    echo "Creating channel (peer1)..."
+    . ./peer1admin.sh && ./create_channel.sh
+
+    echo "Joining channel (peer2)..."
+    . ./peer2admin.sh && ./join_channel.sh
+
+    echo "Joining channel (peer3)..."
+    . ./peer3admin.sh && ./join_channel.sh
+
+    echo "Joining channel (peer4)..."
+    . ./peer4admin.sh && ./join_channel.sh
+  fi
+
+  echo "Fabric network running. Use Ctrl-C to stop."
+
+  wait
+}
+
+networkClean() {
+  echo "Removing directories: channel-artifacts crypto-config data logs"
+  rm -r "${PWD}"/channel-artifacts || true
+  rm -r "${PWD}"/crypto-config || true
+  rm -r "${PWD}"/data || true
+  rm -r "${PWD}"/logs || true
+}
+
+# Parse commandline args
+
+## Parse mode
+if [ $# -lt 1 ] ; then
+  printHelp
+  exit 0
+else
+  MODE=$1
+  shift
+fi
+
+# parse flags
+while [ $# -ge 1 ] ; do
+  key="$1"
+  case $key in
+  -d )
+    CLI_DELAY="$2"
+    shift
+    ;;
+  -h )
+    printHelp "$MODE"
+    exit 0
+    ;;
+  * )
+    echo "Unknown flag: $key"
+    printHelp
+    exit 1
+    ;;
+  esac
+  shift
+done
+
+if [ "$MODE" = "start" ]; then
+  networkStart
+elif [ "$MODE" = "clean" ]; then
+  networkClean
+else
+  printHelp
+  exit 1
+fi

--- a/test-network-nano-bash/orderer1.sh
+++ b/test-network-nano-bash/orderer1.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env sh
+#
+# SPDX-License-Identifier: Apache-2.0
+#
 set -eu
 
 # look for binaries in local dev environment /build/bin directory and then in local samples /bin directory

--- a/test-network-nano-bash/orderer2.sh
+++ b/test-network-nano-bash/orderer2.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env sh
+#
+# SPDX-License-Identifier: Apache-2.0
+#
 set -eu
 
 # look for binaries in local dev environment /build/bin directory and then in local samples /bin directory

--- a/test-network-nano-bash/orderer3.sh
+++ b/test-network-nano-bash/orderer3.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env sh
+#
+# SPDX-License-Identifier: Apache-2.0
+#
 set -eu
 
 # look for binaries in local dev environment /build/bin directory and then in local samples /bin directory

--- a/test-network-nano-bash/peer1.sh
+++ b/test-network-nano-bash/peer1.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env sh
+#
+# SPDX-License-Identifier: Apache-2.0
+#
 set -eu
 
 if [ "$(uname)" = "Linux" ] ; then

--- a/test-network-nano-bash/peer1admin.sh
+++ b/test-network-nano-bash/peer1admin.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env sh
+#
+# SPDX-License-Identifier: Apache-2.0
+#
 
 # look for binaries in local dev environment /build/bin directory and then in local samples /bin directory
 export PATH="${PWD}"/../../fabric/build/bin:"${PWD}"/../bin:"$PATH"
@@ -10,10 +13,3 @@ export CORE_PEER_TLS_ROOTCERT_FILE="${PWD}"/crypto-config/peerOrganizations/org1
 export CORE_PEER_ADDRESS=127.0.0.1:7051
 export CORE_PEER_LOCALMSPID=Org1MSP
 export CORE_PEER_MSPCONFIGPATH="${PWD}"/crypto-config/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp
-
-# peer1 admin will be responsible for creating channel and adding anchor peer
-peer channel create -c mychannel -o 127.0.0.1:6050 -f "${PWD}"/channel-artifacts/mychannel.tx --outputBlock "${PWD}"/channel-artifacts/mychannel.block  --tls --cafile "${PWD}"/crypto-config/ordererOrganizations/example.com/orderers/orderer.example.com/tls/ca.crt
-peer channel update -o 127.0.0.1:6050 -c mychannel -f "${PWD}"/channel-artifacts/Org1MSPanchors.tx --tls --cafile "${PWD}"/crypto-config/ordererOrganizations/example.com/orderers/orderer.example.com/tls/ca.crt
-
-# join peer to channel
-peer channel join -b "${PWD}"/channel-artifacts/mychannel.block

--- a/test-network-nano-bash/peer2.sh
+++ b/test-network-nano-bash/peer2.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env sh
+#
+# SPDX-License-Identifier: Apache-2.0
+#
 set -eu
 
 if [ "$(uname)" = "Linux" ] ; then

--- a/test-network-nano-bash/peer2admin.sh
+++ b/test-network-nano-bash/peer2admin.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env sh
+#
+# SPDX-License-Identifier: Apache-2.0
+#
 
 # look for binaries in local dev environment /build/bin directory and then in local samples /bin directory
 export PATH="${PWD}"/../../fabric/build/bin:"${PWD}"/../bin:"$PATH"
@@ -10,6 +13,3 @@ export CORE_PEER_TLS_ROOTCERT_FILE="${PWD}"/crypto-config/peerOrganizations/org1
 export CORE_PEER_ADDRESS=127.0.0.1:7053
 export CORE_PEER_LOCALMSPID=Org1MSP
 export CORE_PEER_MSPCONFIGPATH="${PWD}"/crypto-config/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp
-
-# join peer to channel
-peer channel join -b "${PWD}"/channel-artifacts/mychannel.block

--- a/test-network-nano-bash/peer3.sh
+++ b/test-network-nano-bash/peer3.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env sh
+#
+# SPDX-License-Identifier: Apache-2.0
+#
 set -eu
 
 if [ "$(uname)" = "Linux" ] ; then

--- a/test-network-nano-bash/peer3admin.sh
+++ b/test-network-nano-bash/peer3admin.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env sh
+#
+# SPDX-License-Identifier: Apache-2.0
+#
 
 # look for binaries in local dev environment /build/bin directory and then in local samples /bin directory
 export PATH="${PWD}"/../../fabric/build/bin:"${PWD}"/../bin:"$PATH"
@@ -10,6 +13,3 @@ export CORE_PEER_TLS_ROOTCERT_FILE="${PWD}"/crypto-config/peerOrganizations/org2
 export CORE_PEER_ADDRESS=127.0.0.1:7055
 export CORE_PEER_LOCALMSPID=Org2MSP
 export CORE_PEER_MSPCONFIGPATH="${PWD}"/crypto-config/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp
-
-# join peer to channel
-peer channel join -b "${PWD}"/channel-artifacts/mychannel.block

--- a/test-network-nano-bash/peer4.sh
+++ b/test-network-nano-bash/peer4.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env sh
+#
+# SPDX-License-Identifier: Apache-2.0
+#
 set -eu
 
 if [ "$(uname)" = "Linux" ] ; then

--- a/test-network-nano-bash/peer4admin.sh
+++ b/test-network-nano-bash/peer4admin.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env sh
+#
+# SPDX-License-Identifier: Apache-2.0
+#
 
 # look for binaries in local dev environment /build/bin directory and then in local samples /bin directory
 export PATH="${PWD}"/../../fabric/build/bin:"${PWD}"/../bin:"$PATH"
@@ -10,6 +13,3 @@ export CORE_PEER_TLS_ROOTCERT_FILE="${PWD}"/crypto-config/peerOrganizations/org2
 export CORE_PEER_ADDRESS=127.0.0.1:7057
 export CORE_PEER_LOCALMSPID=Org2MSP
 export CORE_PEER_MSPCONFIGPATH="${PWD}"/crypto-config/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp
-
-# join peer to channel
-peer channel join -b "${PWD}"/channel-artifacts/mychannel.block


### PR DESCRIPTION
Fix minor bugs, and add network.sh script to simplify standing up the network

Note: the updated peerNadmin.sh scripts no longer create or join a channel and now only configure the environment for the relevant peer

Signed-off-by: James Taylor <jamest@uk.ibm.com>