### PR TITLE
Activate GHA on fabric-samples

### DIFF
--- a/.github/workflows/enable-gha.yaml
+++ b/.github/workflows/enable-gha.yaml
@@ -1,0 +1,26 @@
+name: Enable GitHub Actions
+run-name: ${{ github.actor }} is activating GitHub Actions on the main branch 🚀
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: ["**"]
+  workflow_dispatch:
+    
+jobs:
+  Explore-GitHub-Actions:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
+      - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"
+      - run: echo "🔎 The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
+      - name: Check out repository code
+        uses: actions/checkout@v3
+      - run: echo "💡 The ${{ github.repository }} repository has been cloned to the runner."
+      - run: echo "🖥️ The workflow is now ready to test your code on the runner."
+      - name: List files in the repository
+        run: |
+          ls ${{ github.workspace }}
+      - run: echo "🍏 This job's status is ${{ job.status }}."
+


### PR DESCRIPTION
This PR launches a no-op / hello-world action to enable GitHub Actions on the samples repository.

Until this workflow is triggered (once) on the repo, GHA will refuse to run on PRs targeting main.

Signed-off-by: Josh Kneubuhl <jkneubuh@us.ibm.com>