### PR TITLE
Only run GHA on PRs targeting the mainline

### DIFF
--- a/.github/workflows/enable-gha.yaml
+++ b/.github/workflows/enable-gha.yaml
@@ -1,11 +1,9 @@
 name: Enable GitHub Actions
-run-name: ${{ github.actor }} is activating GitHub Actions on the main branch 🚀
+run-name: ${{ github.actor }} is activating GitHub Actions on a PR to the main branch 🚀
 
 on:
-  push:
-    branches: ["**"]
   pull_request:
-    branches: ["**"]
+    branches: ["main"]
   workflow_dispatch:
     
 jobs:


### PR DESCRIPTION
This PR reduces the frequency of running "hello-GHA" pipelines to target only mainline PRs. 

Signed-off-by: Josh Kneubuhl <jkneubuh@us.ibm.com>