### PR TITLE
Move Kube Test Network tests from Azure -> GHA

### DIFF
--- a/.github/workflows/test-network-k8s.yaml
+++ b/.github/workflows/test-network-k8s.yaml
@@ -1,0 +1,66 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+name: Kubernetes Test Network
+run-name: ${{ github.actor }} is testing the Kubernetes Test Network
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  ccaas-java:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Test the network
+        working-directory: test-network-k8s
+        run: ../ci/scripts/run-k8s-test-network-basic.sh
+        env:
+          CLIENT_LANGUAGE: typescript
+          CHAINCODE_LANGUAGE: java
+
+  ccaas-external:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Test the network
+        working-directory: test-network-k8s
+        run: ../ci/scripts/run-k8s-test-network-basic.sh
+        env:
+          CLIENT_LANGUAGE: typescript
+          CHAINCODE_LANGUAGE: external
+
+  k8s-builder:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Test the network
+        working-directory: test-network-k8s
+        run: ../ci/scripts/run-k8s-test-network-basic.sh
+        env:
+          CHAINCODE_NAME: basic
+          CHAINCODE_LANGUAGE: java
+          CHAINCODE_BUILDER: k8s
+
+  multi-namespace:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Test the network
+        working-directory: test-network-k8s
+        run: ../ci/scripts/run-k8s-test-network-basic.sh
+        env:
+          ORG0_NS: org0-namespace
+          ORG1_NS: org1-namespace
+          ORG2_NS: org2-namespace
+          CHAINCODE_NAME: basic
+          CHAINCODE_LANGUAGE: java
+          CHAINCODE_BUILDER: k8s

--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -31,36 +31,6 @@ jobs:
     steps:
       - template: templates/asset-transfer-basic/azure-pipelines-rest.yml
 
-  - job: KubeTestNetworkBasic
-    displayName: Kube Test Network
-    pool:
-      vmImage: ubuntu-20.04
-    strategy:
-      matrix:
-        CCaaS-Java:
-          CLIENT_LANGUAGE: typescript
-          CHAINCODE_LANGUAGE: java
-        CCaaS-Golang:
-          CLIENT_LANGUAGE: typescript
-          CHAINCODE_LANGUAGE: external
-        K8s-Builder-Java:
-          CHAINCODE_NAME: basic
-          CHAINCODE_LANGUAGE: java
-          CHAINCODE_BUILDER: k8s
-        Multi-Namespace:
-          ORG0_NS: org0-namespace
-          ORG1_NS: org1-namespace
-          ORG2_NS: org2-namespace
-          CHAINCODE_NAME: basic
-          CHAINCODE_LANGUAGE: java
-          CHAINCODE_BUILDER: k8s
-
-    steps:
-      - template: templates/install-k8s-deps.yml
-      - script: ../ci/scripts/run-k8s-test-network-basic.sh
-        workingDirectory: test-network-k8s
-        displayName: Run Kubernetes Test Network Basic Asset Transfer
-
   - job: TestNetworkLedger
     displayName: Test Network
     pool:


### PR DESCRIPTION
This PR ports the Kubernetes Test Network tests from Azure to GHA.

Signed-off-by: Josh Kneubuhl <jkneubuh@us.ibm.com>