### PR TITLE
add condition during delete self recipient key

### DIFF
--- a/token-erc-1155/chaincode-go/chaincode/contract.go
+++ b/token-erc-1155/chaincode-go/chaincode/contract.go
@@ -1001,8 +1001,8 @@ func removeBalance(ctx contractapi.TransactionContextInterface, sender string, i
 				}
 			}
 
-		} else {
-			// Delete self recipient key
+		} else if selfRecipientKeyNeedsToBeRemoved {
+			// Delete self recipient key if required
 			err = ctx.GetStub().DelState(selfRecipientKey)
 			if err != nil {
 				return fmt.Errorf("failed to delete the state of %v: %v", selfRecipientKey, err)


### PR DESCRIPTION
There is an issue during transfer token to the current implementation.
If a sender tries to sent all of his/her token to a receiver then the issue happen.

Conditions :
Sender need to send all of his/her token to the receiver 
Sender should not have any self Recipient Key for that token.

Error during endorsement : 
{
  status: 500,
  message: 'failed to delete the state of : DEL_STATE failed: transaction ID: dd10c301c30e4849c0d236ee778710e97a5576955726c87d1f16ed17ffc9cce0: invalid key. Empty string is not supported as a key by couchdb',
  payload: <Buffer >
}