### PR TITLE
Parse transaction creator to Identity in off_chain_data samples

### DIFF
--- a/off_chain_data/application-java/app/src/main/java/parser/ParsedTransaction.java
+++ b/off_chain_data/application-java/app/src/main/java/parser/ParsedTransaction.java
@@ -7,8 +7,10 @@
 package parser;
 
 import com.google.protobuf.InvalidProtocolBufferException;
+import org.hyperledger.fabric.client.identity.Identity;
 import org.hyperledger.fabric.protos.common.ChannelHeader;
 import org.hyperledger.fabric.protos.common.Payload;
+import org.hyperledger.fabric.protos.msp.SerializedIdentity;
 import org.hyperledger.fabric.protos.peer.TxValidationCode;
 
 import java.util.ArrayList;
@@ -30,8 +32,20 @@ final class ParsedTransaction implements Transaction {
     }
 
     @Override
-    public byte[] getCreator() throws InvalidProtocolBufferException {
-        return payload.getSignatureHeader().getCreator().toByteArray();
+    public Identity getCreator() throws InvalidProtocolBufferException {
+        var creator = SerializedIdentity.parseFrom(payload.getSignatureHeader().getCreator());
+
+        return new Identity() {
+            @Override
+            public String getMspId() {
+                return creator.getMspid();
+            }
+
+            @Override
+            public byte[] getCredentials() {
+                return creator.getIdBytes().toByteArray();
+            }
+        };
     }
 
     @Override

--- a/off_chain_data/application-java/app/src/main/java/parser/Transaction.java
+++ b/off_chain_data/application-java/app/src/main/java/parser/Transaction.java
@@ -7,6 +7,7 @@
 package parser;
 
 import com.google.protobuf.InvalidProtocolBufferException;
+import org.hyperledger.fabric.client.identity.Identity;
 import org.hyperledger.fabric.protos.common.ChannelHeader;
 import org.hyperledger.fabric.protos.common.Payload;
 import org.hyperledger.fabric.protos.peer.TxValidationCode;
@@ -15,7 +16,7 @@ import java.util.List;
 
 public interface Transaction {
     ChannelHeader getChannelHeader() throws InvalidProtocolBufferException;
-    byte[] getCreator() throws InvalidProtocolBufferException;
+    Identity getCreator() throws InvalidProtocolBufferException;
     TxValidationCode getValidationCode();
     boolean isValid();
     List<NamespaceReadWriteSet> getNamespaceReadWriteSets() throws InvalidProtocolBufferException;

--- a/off_chain_data/application-typescript/src/blockParser.ts
+++ b/off_chain_data/application-typescript/src/blockParser.ts
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { common, ledger, peer } from '@hyperledger/fabric-protos';
+import { Identity } from '@hyperledger/fabric-gateway';
+import { common, ledger, msp, peer } from '@hyperledger/fabric-protos';
 import { assertDefined, cache } from './utils';
 
 export interface Block {
@@ -15,7 +16,7 @@ export interface Block {
 
 export interface Transaction {
     getChannelHeader(): common.ChannelHeader;
-    getCreator(): Uint8Array;
+    getCreator(): Identity;
     getValidationCode(): number;
     isValid(): boolean;
     getNamespaceReadWriteSets(): NamespaceReadWriteSet[];
@@ -106,7 +107,14 @@ function newTransaction(payload: Payload): Transaction {
 
     return {
         getChannelHeader: () => payload.getChannelHeader(),
-        getCreator: () => payload.getSignatureHeader().getCreator_asU8(),
+        getCreator: () => {
+            const creatorBytes = payload.getSignatureHeader().getCreator_asU8();
+            const creator = msp.SerializedIdentity.deserializeBinary(creatorBytes);
+            return {
+                mspId: creator.getMspid(),
+                credentials: creator.getIdBytes_asU8(),
+            };
+        },
         getNamespaceReadWriteSets: () => transaction.getReadWriteSets()
             .flatMap(readWriteSet => readWriteSet.getNamespaceReadWriteSets()),
         getValidationCode: () => payload.getTransactionValidationCode(),


### PR DESCRIPTION
Parsing out of the creator / signer information to provide direct access to their X.509 certificate supports this end-user StackOverflow question:

https://stackoverflow.com/questions/74718400/get-clients-signature-from-the-hyperledger-fabric-block-and-verify-it