### PR TITLE
Update the full-stack sample to use arm64 operator images

### DIFF
--- a/full-stack-asset-transfer-guide/infrastructure/sample-network/config/manager/fabric-operator-manager.yaml
+++ b/full-stack-asset-transfer-guide/infrastructure/sample-network/config/manager/fabric-operator-manager.yaml
@@ -20,16 +20,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: fabric-operator
-  labels:
-    release: "operator"
-    helm.sh/chart: "hlf"
-    app.kubernetes.io/name: "hlf"
-    app.kubernetes.io/instance: "hlf"
-    app.kubernetes.io/managed-by: "fabric-operator"
 spec:
   replicas: 1
-  strategy:
-    type: "Recreate"
   selector:
     matchLabels:
       name: fabric-operator
@@ -37,70 +29,28 @@ spec:
     metadata:
       labels:
         name: fabric-operator
-        release: "operator"
-        helm.sh/chart: "hlf"
-        app.kubernetes.io/name: "hlf"
-        app.kubernetes.io/instance: "hlf"
-        app.kubernetes.io/managed-by: "fabric-operator"
-      annotations:
-        productName: "Hyperledger Fabric Operator"
-        productID: ""
-        productVersion: "1.0.0"
-        productChargedContainers: ""
-        productMetric: "VIRTUAL_PROCESSOR_CORE"
     spec:
       serviceAccountName: fabric-operator
-      # hostIPC: false
-      # hostNetwork: false
-      # hostPID: false
-      # affinity:
-      #   nodeAffinity:
-      #     requiredDuringSchedulingIgnoredDuringExecution:
-      #       nodeSelectorTerms:
-      #         - matchExpressions:
-      #             - key: kubernetes.io/arch
-      #               operator: In
-      #               values:
-      #                 - amd64
-      # securityContext:
-      #   runAsNonRoot: true
-      #   runAsUser: 1001
-      #   fsGroup: 2000
-
-      imagePullSecrets:
-        - name: image-pull-secret
-
+#      imagePullSecrets:
+#        - name: image-pull-secret
       containers:
         - name: fabric-operator
           image: ${FABRIC_OPERATOR_IMAGE}
           imagePullPolicy: ${IMAGE_PULL_POLICY}
-
           command:
             - ibp-operator
-          # securityContext:
-          #   privileged: false
-          #   allowPrivilegeEscalation: false
-          #   readOnlyRootFilesystem: false
-          #   runAsNonRoot: false
-          #   runAsUser: 1001
-          #   capabilities:
-          #     drop:
-          #       - ALL
-          #     add:
-          #       - CHOWN
-          #       - FOWNER
-          livenessProbe:
-            tcpSocket:
-              port: 8383
-            initialDelaySeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 5
-          readinessProbe:
-            tcpSocket:
-              port: 8383
-            initialDelaySeconds: 10
-            timeoutSeconds: 5
-            periodSeconds: 5
+#          livenessProbe:
+#            tcpSocket:
+#              port: 8383
+#            initialDelaySeconds: 10
+#            timeoutSeconds: 5
+#            failureThreshold: 5
+#          readinessProbe:
+#            tcpSocket:
+#              port: 8383
+#            initialDelaySeconds: 10
+#            timeoutSeconds: 5
+#            periodSeconds: 5
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -114,10 +64,3 @@ spec:
               value: "fabric-operator"
             - name: CLUSTERTYPE
               value: K8S
-          resources:
-            requests:
-              cpu: 10m
-              memory: 10Mi
-            limits:
-              cpu: 100m
-              memory: 200Mi

--- a/full-stack-asset-transfer-guide/infrastructure/sample-network/network
+++ b/full-stack-asset-transfer-guide/infrastructure/sample-network/network
@@ -78,13 +78,13 @@ context CA_IMAGE_LABEL            ${FABRIC_CA_VERSION}
 #context PEER_IMAGE                ${FABRIC_CONTAINER_REGISTRY}/fabric-peer
 #context PEER_IMAGE_LABEL          ${FABRIC_VERSION}
 context PEER_IMAGE                ghcr.io/hyperledger-labs/k8s-fabric-peer
-context PEER_IMAGE_LABEL          v0.7.2    # FROM fabric-peer 2.4
+context PEER_IMAGE_LABEL          v0.8.0
 context ORDERER_IMAGE             ${FABRIC_CONTAINER_REGISTRY}/fabric-orderer
 context ORDERER_IMAGE_LABEL       ${FABRIC_VERSION}
 context TOOLS_IMAGE               ${FABRIC_CONTAINER_REGISTRY}/fabric-tools
 context TOOLS_IMAGE_LABEL         ${FABRIC_VERSION}
 context OPERATOR_IMAGE            ghcr.io/hyperledger-labs/fabric-operator
-context OPERATOR_IMAGE_LABEL      latest-amd64
+context OPERATOR_IMAGE_LABEL      1.0.4
 context INIT_IMAGE                registry.access.redhat.com/ubi8/ubi-minimal
 context INIT_IMAGE_LABEL          latest
 context GRPCWEB_IMAGE             ghcr.io/hyperledger-labs/grpc-web


### PR DESCRIPTION
Updates the full stack sample to launch the operator with the multi-arch / arm64 image for the M1. 

Signed-off-by: Josh Kneubuhl <jkneubuh@us.ibm.com>