### PR TITLE
Fix java contract paperkey parameter in commercial paper example

### DIFF
--- a/commercial-paper/organization/digibank/contract-java/src/main/java/org/example/CommercialPaperContract.java
+++ b/commercial-paper/organization/digibank/contract-java/src/main/java/org/example/CommercialPaperContract.java
@@ -107,7 +107,7 @@ public class CommercialPaperContract implements ContractInterface {
             String newOwner, int price, String purchaseDateTime) {
 
         // Retrieve the current paper using key fields provided
-        String paperKey = State.makeKey(new String[] { paperNumber });
+        String paperKey = State.makeKey(new String[] { issuer, paperNumber });
         CommercialPaper paper = ctx.paperList.getPaper(paperKey);
 
         // Validate current owner
@@ -146,7 +146,7 @@ public class CommercialPaperContract implements ContractInterface {
     public CommercialPaper redeem(CommercialPaperContext ctx, String issuer, String paperNumber, String redeemingOwner,
             String redeemDateTime) {
 
-        String paperKey = CommercialPaper.makeKey(new String[] { paperNumber });
+        String paperKey = CommercialPaper.makeKey(new String[] { issuer, paperNumber });
 
         CommercialPaper paper = ctx.paperList.getPaper(paperKey);
 

--- a/commercial-paper/organization/magnetocorp/contract-java/src/main/java/org/example/CommercialPaperContract.java
+++ b/commercial-paper/organization/magnetocorp/contract-java/src/main/java/org/example/CommercialPaperContract.java
@@ -107,7 +107,7 @@ public class CommercialPaperContract implements ContractInterface {
             String newOwner, int price, String purchaseDateTime) {
 
         // Retrieve the current paper using key fields provided
-        String paperKey = State.makeKey(new String[] { paperNumber });
+        String paperKey = State.makeKey(new String[] { issuer, paperNumber });
         CommercialPaper paper = ctx.paperList.getPaper(paperKey);
 
         // Validate current owner
@@ -146,7 +146,7 @@ public class CommercialPaperContract implements ContractInterface {
     public CommercialPaper redeem(CommercialPaperContext ctx, String issuer, String paperNumber, String redeemingOwner,
             String redeemDateTime) {
 
-        String paperKey = CommercialPaper.makeKey(new String[] { paperNumber });
+        String paperKey = CommercialPaper.makeKey(new String[] {issuer, paperNumber });
 
         CommercialPaper paper = ctx.paperList.getPaper(paperKey);
 


### PR DESCRIPTION
In Java contract of "commercial paper" example, the "paperkey" is not equivalent of "paperNumber" parameter only, but  it's a combination of "issuer" and "paperNumber" params.
this is already done for Js https://github.com/hyperledger/fabric-samples/blob/main/commercial-paper/organization/magnetocorp/contract/lib/papercontract.js#L104