### PR TITLE
AssetTransfer Private - Incorrect Endorsement Policy

### DIFF
--- a/asset-transfer-private-data/chaincode-go/collections_config.json
+++ b/asset-transfer-private-data/chaincode-go/collections_config.json
@@ -6,7 +6,10 @@
    "maxPeerCount": 1,
    "blockToLive":1000000,
    "memberOnlyRead": true,
-   "memberOnlyWrite": true
+   "memberOnlyWrite": true,
+   "endorsementPolicy": {
+    "signaturePolicy":"OR('Org1MSP.member','Org2MSP.member')"
+  }   
 },
  {
    "name": "Org1MSPPrivateCollection",

--- a/asset-transfer-private-data/chaincode-java/collections_config.json
+++ b/asset-transfer-private-data/chaincode-java/collections_config.json
@@ -6,7 +6,10 @@
    "maxPeerCount": 1,
    "blockToLive":1000000,
    "memberOnlyRead": true,
-   "memberOnlyWrite": true
+   "memberOnlyWrite": true,
+   "endorsementPolicy": {
+   	"signaturePolicy":"OR('Org1MSP.member','Org2MSP.member')"
+   }
 },
  {
    "name": "Org1MSPPrivateCollection",

--- a/ci/scripts/run-test-network-private.sh
+++ b/ci/scripts/run-test-network-private.sh
@@ -15,7 +15,7 @@ function createNetwork() {
   print "Creating network"
   ./network.sh up createChannel -ca -s couchdb
   print "Deploying ${CHAINCODE_NAME} chaincode"
-  ./network.sh deployCC -ccn "${CHAINCODE_NAME}" -ccp "${CHAINCODE_PATH}/chaincode-${CHAINCODE_LANGUAGE}" -ccv 1 -ccs 1 -ccl "${CHAINCODE_LANGUAGE}" -ccep "OR('Org1MSP.peer','Org2MSP.peer')" -cccg ../asset-transfer-private-data/chaincode-go/collections_config.json
+  ./network.sh deployCC -ccn "${CHAINCODE_NAME}" -ccp "${CHAINCODE_PATH}/chaincode-${CHAINCODE_LANGUAGE}" -ccv 1 -ccs 1 -ccl "${CHAINCODE_LANGUAGE}" -cccg ../asset-transfer-private-data/chaincode-go/collections_config.json
 }
 
 function stopNetwork() {


### PR DESCRIPTION
For the asset transfer example (https://hyperledger-fabric.readthedocs.io/en/release-2.5/private_data_tutorial.html#pd-use-case)  there are three private data collections, one per org and one shared between the orgs.

The shared collection didn't have an endorsement policy so inherited the chaincodes; this was specifically set away from the default to be OR(Org1MSP,Org2MSP).   The documentation says this is to ensure that either organization can create an asset. Whilst this is strictly correct, it is misleading - it doesn't need to be a chaincode wide policy, but specifically to the shared collection. 

Therefore it is better to leave the chaincode policy at its default and move the specific policy down to the collection. 
With the context of this example as coded, this is exactly functionally the same - but gives a more accurate impression. 

