### PR TITLE
Fix gradle version used in asset-transfer-basic/chaincode-java image

### DIFF
--- a/asset-transfer-basic/chaincode-java/Dockerfile
+++ b/asset-transfer-basic/chaincode-java/Dockerfile
@@ -1,5 +1,5 @@
 # the first stage 
-FROM gradle:jdk11-alpine AS GRADLE_BUILD
+FROM gradle:7-jdk11-alpine AS GRADLE_BUILD
 
 # copy the build.gradle and src code to the container
 COPY src/ src/


### PR DESCRIPTION
This patch fixes the gradle version used in asset-transfer-basic/chaincode-java build to 7.

The reason is because the gradle version in the gradle:jdk11-alpine image is updated from 7 to 8, which seems to cause the build to fail. The result of running docker build command with gradle:jdk11-alpine are as follows:

```bash
Step 4/16 : RUN gradle --no-daemon build shadowJar -x checkstyleMain -x checkstyleTest
 ---> Running in d245170e621f

Welcome to Gradle 8.0.1!

Here are the highlights of this release:
 - Improvements to the Kotlin DSL
 - Fine-grained parallelism from the first build with configuration cache
 - Configurable Gradle user home cache cleanup

For more details see https://docs.gradle.org/8.0.1/release-notes.html

To honour the JVM settings for this build a single-use Daemon process will be forked. See https://docs.gradle.org/8.0.1/userguide/gradle_daemon.html#sec:disabling_the_daemon.
Daemon will be stopped at the end of the build 

FAILURE: Build failed with an exception.

* Where:
Build file '/home/gradle/build.gradle' line: 7

* What went wrong:
An exception occurred applying plugin request [id: 'application']
> Failed to apply plugin class 'com.github.jengelman.gradle.plugins.shadow.ShadowJavaPlugin'.
   > You can't map a property that does not exist: propertyName=classifier

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 15s
The command '/bin/sh -c gradle --no-daemon build shadowJar -x checkstyleMain -x checkstyleTest' returned a non-zero code: 1

```

Related issues:
#940