### PR TITLE
cfssl to generating certificates

### DIFF
--- a/test-network/organizations/cfssl/admin-csr-template.json
+++ b/test-network/organizations/cfssl/admin-csr-template.json
@@ -1,0 +1,22 @@
+{
+    "CN": "{USER}",
+    "key": {
+        "algo": "ecdsa",
+        "size": 256
+    },
+    "names": [
+        {
+            "C": "IN",
+            "ST": "Delhi",
+            "L": "Aero city",
+            "O": "cfssl",
+            "OU": "admin"
+        }
+    ],
+    "hosts": [
+        "{USER}",
+        "localhost",
+        "127.0.0.1",
+        "0.0.0.0"
+    ]
+}

--- a/test-network/organizations/cfssl/ca-orderer.json
+++ b/test-network/organizations/cfssl/ca-orderer.json
@@ -1,0 +1,21 @@
+{
+    "CN": "cfssl-orderer-ca",
+    "key": {
+        "algo": "ecdsa",
+        "size": 256
+    },
+    "names": [
+        {
+            "C": "IN",
+            "ST": "Delhi",
+            "L": "Aero city",
+            "O": "cfssl",
+            "OU": "client"
+        }
+    ],
+    "hosts": [
+        "localhost",
+        "127.0.0.1",
+        "0.0.0.0"
+    ]
+}

--- a/test-network/organizations/cfssl/ca-peer.json
+++ b/test-network/organizations/cfssl/ca-peer.json
@@ -1,0 +1,21 @@
+{
+    "CN": "cfssl-peer-ca",
+    "key": {
+        "algo": "ecdsa",
+        "size": 256
+    },
+    "names": [
+        {
+            "C": "IN",
+            "ST": "Delhi",
+            "L": "Aero city",
+            "O": "cfssl",
+            "OU": "Fabric"
+        }
+    ],
+    "hosts": [
+        "localhost",
+        "127.0.0.1",
+        "0.0.0.0"
+    ]
+}

--- a/test-network/organizations/cfssl/cert-signing-config.json
+++ b/test-network/organizations/cfssl/cert-signing-config.json
@@ -1,0 +1,27 @@
+{
+    "signing": {
+        "default": {
+            "expiry": "175200h"
+        },
+        "profiles": {
+            "sign": {
+                "usages": [
+                    "signing",
+                    "key encipherment",
+                    "cert sign",
+                    "digital signature"
+                ],
+                "expiry": "175200h"
+            },
+            "tls": {
+                "usages": [
+                    "signing",
+                    "key encipherment",
+                    "server auth",
+                    "client auth"
+                ],
+                "expiry": "175200h"
+            }
+        }
+    }
+}

--- a/test-network/organizations/cfssl/client-csr-template.json
+++ b/test-network/organizations/cfssl/client-csr-template.json
@@ -1,0 +1,22 @@
+{
+    "CN": "{USER}",
+    "key": {
+        "algo": "ecdsa",
+        "size": 256
+    },
+    "names": [
+        {
+            "C": "IN",
+            "ST": "Delhi",
+            "L": "Aero city",
+            "O": "cfssl",
+            "OU": "client"
+        }
+    ],
+    "hosts": [
+        "{USER}",
+        "localhost",
+        "127.0.0.1",
+        "0.0.0.0"
+    ]
+}

--- a/test-network/organizations/cfssl/orderer-csr-template.json
+++ b/test-network/organizations/cfssl/orderer-csr-template.json
@@ -1,0 +1,22 @@
+{
+    "CN": "{USER}",
+    "key": {
+        "algo": "ecdsa",
+        "size": 256
+    },
+    "names": [
+        {
+            "C": "IN",
+            "ST": "Delhi",
+            "L": "Aero city",
+            "O": "cfssl",
+            "OU": "orderer"
+        }
+    ],
+    "hosts": [
+        "{USER}",
+        "localhost",
+        "127.0.0.1",
+        "0.0.0.0"
+    ]
+}

--- a/test-network/organizations/cfssl/peer-csr-template.json
+++ b/test-network/organizations/cfssl/peer-csr-template.json
@@ -1,0 +1,22 @@
+{
+    "CN": "{USER}",
+    "key": {
+        "algo": "ecdsa",
+        "size": 256
+    },
+    "names": [
+        {
+            "C": "IN",
+            "ST": "Delhi",
+            "L": "Aero city",
+            "O": "cfssl",
+            "OU": "peer"
+        }
+    ],
+    "hosts": [
+        "{USER}",
+        "localhost",
+        "127.0.0.1",
+        "0.0.0.0"
+    ]
+}

--- a/test-network/organizations/cfssl/registerEnroll.sh
+++ b/test-network/organizations/cfssl/registerEnroll.sh
@@ -72,7 +72,7 @@ function orderer_cert() {
         cp "$CERT_DIR/ca/ca.pem" "$CERT_DIR/tlsca/tlsca.example.com-cert.pem"
 
         cp "$CERT_DIR/ca/ca.pem" "$CERT_DIR/msp/cacerts/"
-        cp "$CERT_DIR/ca/ca.pem" "$CERT_DIR/msp/tlscacerts/"
+        cp "$CERT_DIR/ca/ca.pem" "$CERT_DIR/msp/tlscacerts/tlsca.example.com-cert.pem"
 
         echo 'NodeOUs:
     Enable: true
@@ -176,7 +176,7 @@ function generate_peer_certs() {
     cfssl gencert \
         -ca="$CERT_DIR/ca/ca.pem" \
         -ca-key="$CERT_DIR/ca/ca-key.pem" \
-        -config="$PWD/organizations/cfssl/cert-signing-config.jso"n \
+        -config="$PWD/organizations/cfssl/cert-signing-config.json" \
         -cn="$USER" \
         -hostname="$USER,localhost,127.0.0.1" \
         -profile="sign" \
@@ -243,7 +243,7 @@ function generate_orderer_certs() {
     mv "$CERT_DIR/orderers/$USER/msp/signcerts/cert-key.pem" "$CERT_DIR/orderers/$USER/msp/keystore"
 
     cp "$CERT_DIR/ca/ca.pem" "$CERT_DIR/orderers/$USER/msp/cacerts"
-    cp "$CERT_DIR/ca/ca.pem" "$CERT_DIR/orderers/$USER/msp/tlscacerts"
+    cp "$CERT_DIR/ca/ca.pem" "$CERT_DIR/orderers/$USER/msp/tlscacerts/tlsca.example.com-cert.pem"
 
     echo 'NodeOUs:
     Enable: true

--- a/test-network/organizations/cfssl/registerEnroll.sh
+++ b/test-network/organizations/cfssl/registerEnroll.sh
@@ -1,0 +1,276 @@
+#!/bin/bash
+# Copyright 2023 Aditya Joshi, All rights reserved
+
+function peer_cert() {
+
+    TYPE=$1 #peer user
+    USER=$2
+    ORG=$3
+
+    mkdir -p "organizations/peerOrganizations/$ORG.example.com/ca"
+    mkdir -p "organizations/peerOrganizations/$ORG.example.com/msp/cacerts"
+    mkdir -p "organizations/peerOrganizations/$ORG.example.com/msp/tlscacerts"
+    mkdir -p "organizations/peerOrganizations/$ORG.example.com/peers"
+    mkdir -p "organizations/peerOrganizations/$ORG.example.com/tlsca"
+
+    CERT_DIR=organizations/peerOrganizations/$ORG.example.com
+
+    if [ ! -f "$CERT_DIR/ca/ca-key.pem" ]; then
+
+        cfssl gencert -initca "${PWD}/organizations/cfssl/ca-peer.json" | cfssljson -bare "$CERT_DIR/ca/ca"
+
+        cp "$CERT_DIR/ca/ca.pem" "$CERT_DIR/tlsca/tlsca.$ORG.example.com-cert.pem"
+        cp "$CERT_DIR/ca/ca.pem" "$CERT_DIR/ca/ca.$ORG.example.com-cert.pem"
+
+        cp "$CERT_DIR/ca/ca.pem" "$CERT_DIR/msp/cacerts/"
+        cp "$CERT_DIR/ca/ca.pem" "$CERT_DIR/msp/tlscacerts/"
+
+        echo 'NodeOUs:
+    Enable: true
+    ClientOUIdentifier:
+        Certificate: cacerts/ca.pem
+        OrganizationalUnitIdentifier: client
+    PeerOUIdentifier:
+        Certificate: cacerts/ca.pem
+        OrganizationalUnitIdentifier: peer
+    AdminOUIdentifier:
+        Certificate: cacerts/ca.pem
+        OrganizationalUnitIdentifier: admin
+    OrdererOUIdentifier:
+        Certificate: cacerts/ca.pem
+        OrganizationalUnitIdentifier: orderer' >"$CERT_DIR/msp/config.yaml"
+
+    fi
+
+    if [[ $TYPE == "peer" ]]; then
+        generate_peer_certs "$CERT_DIR" "$USER"
+    fi
+    if [[ $TYPE == "admin" ]]; then
+        generate_user_certs "$CERT_DIR" "$USER" "$TYPE"
+    fi
+
+    find . -name "*.csr" -print0 | xargs -0 rm
+
+}
+
+function orderer_cert() {
+    TYPE=$1 #orderer user
+    USER=$2 #orderer.example.com
+
+    mkdir -p organizations/ordererOrganizations/example.com/ca
+    mkdir -p organizations/ordererOrganizations/example.com/msp/cacerts
+    mkdir -p organizations/ordererOrganizations/example.com/msp/tlscacerts
+    mkdir -p organizations/ordererOrganizations/example.com/orderers
+    mkdir -p organizations/ordererOrganizations/example.com/tlsca
+
+    CERT_DIR=organizations/ordererOrganizations/example.com
+
+    if [ ! -f "$CERT_DIR/ca/ca-key.pem" ]; then
+
+        cfssl gencert -initca "${PWD}/organizations/cfssl/ca-orderer.json" | cfssljson -bare "$CERT_DIR/ca/ca"
+
+        cp "$CERT_DIR/ca/ca.pem" "$CERT_DIR/tlsca/tlsca.example.com-cert.pem"
+
+        cp "$CERT_DIR/ca/ca.pem" "$CERT_DIR/msp/cacerts/"
+        cp "$CERT_DIR/ca/ca.pem" "$CERT_DIR/msp/tlscacerts/"
+
+        echo 'NodeOUs:
+    Enable: true
+    ClientOUIdentifier:
+        Certificate: cacerts/ca.pem
+        OrganizationalUnitIdentifier: client
+    PeerOUIdentifier:
+        Certificate: cacerts/ca.pem
+        OrganizationalUnitIdentifier: peer
+    AdminOUIdentifier:
+        Certificate: cacerts/ca.pem
+        OrganizationalUnitIdentifier: admin
+    OrdererOUIdentifier:
+        Certificate: cacerts/ca.pem
+        OrganizationalUnitIdentifier: orderer' >"$CERT_DIR/msp/config.yaml"
+
+    fi
+
+    if [[ $TYPE == "orderer" ]]; then
+        generate_orderer_certs $CERT_DIR "$USER"
+    fi
+
+    if [[ $TYPE == "admin" ]]; then
+        generate_user_certs "$CERT_DIR" "$USER" "$TYPE"
+    fi
+
+    find . -name "*.csr" -print0 | xargs -0 rm
+
+}
+
+function generate_user_certs() {
+
+    CERT_DIR=$1
+    USER=$2
+    TYPE=$3
+
+    mkdir -p $CERT_DIR/users/$USER/tls
+
+    for DIR in cacerts keystore signcerts tlscacerts; do
+        mkdir -p $CERT_DIR/users/$USER/msp/$DIR
+    done
+
+    sed -e "s/{USER}/$USER/g" <"$PWD/organizations/cfssl/${TYPE}-csr-template.json" >$PWD/organizations/cfssl/${TYPE}-${USER}-csr.json
+
+    cfssl gencert \
+        -ca=$CERT_DIR/ca/ca.pem \
+        -ca-key=$CERT_DIR/ca/ca-key.pem \
+        -config=$PWD/organizations/cfssl/cert-signing-config.json \
+        -cn="$USER" \
+        -hostname="$USER,localhost,127.0.0.1" \
+        -profile="sign" \
+        $PWD/organizations/cfssl/${TYPE}-${USER}-csr.json | cfssljson -bare $CERT_DIR/users/$USER/msp/signcerts/cert
+
+    mv $CERT_DIR/users/$USER/msp/signcerts/cert-key.pem $CERT_DIR/users/$USER/msp/keystore/cert-key.pem
+    cp $CERT_DIR/ca/ca.pem $CERT_DIR/users/$USER/msp/cacerts
+    cp $CERT_DIR/ca/ca.pem $CERT_DIR/users/$USER/msp/tlscacerts
+
+    echo 'NodeOUs:
+    Enable: true
+    ClientOUIdentifier:
+      Certificate: cacerts/ca.pem
+      OrganizationalUnitIdentifier: client
+    PeerOUIdentifier:
+      Certificate: cacerts/ca.pem
+      OrganizationalUnitIdentifier: peer
+    AdminOUIdentifier:
+      Certificate: cacerts/ca.pem
+      OrganizationalUnitIdentifier: admin
+    OrdererOUIdentifier:
+      Certificate: cacerts/ca.pem
+      OrganizationalUnitIdentifier: orderer' >$CERT_DIR/users/$USER/msp/config.yaml
+
+    cfssl gencert \
+        -ca=$CERT_DIR/ca/ca.pem \
+        -ca-key=$CERT_DIR/ca/ca-key.pem \
+        -config=$PWD/organizations/cfssl/cert-signing-config.json \
+        -cn="$USER" \
+        -hostname="$USER,localhost,127.0.0.1" \
+        -profile="tls" \
+        $PWD/organizations/cfssl/${TYPE}-${USER}-csr.json | cfssljson -bare $CERT_DIR/users/$USER/tls/client
+
+    cp $CERT_DIR/ca/ca.pem $CERT_DIR/users/$USER/tls/ca.crt
+    mv $CERT_DIR/users/$USER/tls/client-key.pem $CERT_DIR/users/$USER/tls/client.key
+    mv $CERT_DIR/users/$USER/tls/client.pem $CERT_DIR/users/$USER/tls/client.crt
+
+    rm $PWD/organizations/cfssl/${TYPE}-${USER}-csr.json
+
+}
+
+function generate_peer_certs() {
+    CERT_DIR=$1
+    USER=$2
+
+    for DIR in cacerts keystore signcerts tlscacerts; do
+        mkdir -p "$CERT_DIR/peers/$USER/msp/$DIR"
+    done
+
+    mkdir -p "$CERT_DIR/peers/$USER/tls"
+    sed -e "s/{USER}/$USER/g" <"$PWD/organizations/cfssl/peer-csr-template.json" >"$PWD/organizations/cfssl/peer-${USER}.json"
+
+    cfssl gencert \
+        -ca="$CERT_DIR/ca/ca.pem" \
+        -ca-key="$CERT_DIR/ca/ca-key.pem" \
+        -config="$PWD/organizations/cfssl/cert-signing-config.jso"n \
+        -cn="$USER" \
+        -hostname="$USER,localhost,127.0.0.1" \
+        -profile="sign" \
+        "$PWD/organizations/cfssl/peer-${USER}.json" | cfssljson -bare "$CERT_DIR/peers/${USER}/msp/signcerts/cert"
+
+    mv "$CERT_DIR/peers/$USER/msp/signcerts/cert-key.pem" "$CERT_DIR/peers/$USER/msp/keystore"
+
+    cp "$CERT_DIR/ca/ca.pem" "$CERT_DIR/peers/$USER/msp/cacerts"
+    cp "$CERT_DIR/ca/ca.pem" "$CERT_DIR/peers/$USER/msp/tlscacerts"
+
+    echo 'NodeOUs:
+    Enable: true
+    ClientOUIdentifier:
+        Certificate: cacerts/ca.pem
+        OrganizationalUnitIdentifier: client
+    PeerOUIdentifier:
+        Certificate: cacerts/ca.pem
+        OrganizationalUnitIdentifier: peer
+    AdminOUIdentifier:
+        Certificate: cacerts/ca.pem
+        OrganizationalUnitIdentifier: admin
+    OrdererOUIdentifier:
+        Certificate: cacerts/ca.pem
+        OrganizationalUnitIdentifier: orderer' >"$CERT_DIR/peers/$USER/msp/config.yaml"
+
+    cfssl gencert \
+        -ca="$CERT_DIR/ca/ca.pem" \
+        -ca-key="$CERT_DIR/ca/ca-key.pem" \
+        -config="$PWD/organizations/cfssl/cert-signing-config.json" \
+        -cn="$USER" \
+        -hostname="$USER,localhost,127.0.0.1" \
+        -profile="tls" \
+        "$PWD/organizations/cfssl/peer-${USER}.json" | cfssljson -bare "$CERT_DIR/peers/$USER/tls/server"
+
+    cp "$CERT_DIR/ca/ca.pem" "$CERT_DIR/peers/$USER/tls/ca.crt"
+    mv "$CERT_DIR/peers/$USER/tls/server.pem" "$CERT_DIR/peers/$USER/tls/server.crt"
+    mv "$CERT_DIR/peers/$USER/tls/server-key.pem" "$CERT_DIR/peers/$USER/tls/server.key"
+
+    rm "$PWD/organizations/cfssl/peer-${USER}.json"
+}
+
+function generate_orderer_certs() {
+
+    CERT_DIR=$1
+    USER=$2
+
+    for DIR in cacerts keystore signcerts tlscacerts; do
+        mkdir -p "organizations/ordererOrganizations/example.com/orderers/$USER/msp/$DIR"
+    done
+
+    mkdir -p "organizations/ordererOrganizations/example.com/orderers/$USER/tls"
+
+    sed -e "s/{USER}/$USER/g" <"$PWD/organizations/cfssl/orderer-csr-template.json" >"$PWD/organizations/cfssl/orderer-${USER}.json"
+
+    cfssl gencert \
+        -ca="$CERT_DIR/ca/ca.pem" \
+        -ca-key="$CERT_DIR/ca/ca-key.pem" \
+        -config="$PWD/organizations/cfssl/cert-signing-config.json" \
+        -cn="$USER" \
+        -hostname="$USER,localhost,127.0.0.1" \
+        -profile="sign" \
+        "$PWD/organizations/cfssl/orderer-${USER}.json" | cfssljson -bare "$CERT_DIR/orderers/$USER/msp/signcerts/cert"
+
+    mv "$CERT_DIR/orderers/$USER/msp/signcerts/cert-key.pem" "$CERT_DIR/orderers/$USER/msp/keystore"
+
+    cp "$CERT_DIR/ca/ca.pem" "$CERT_DIR/orderers/$USER/msp/cacerts"
+    cp "$CERT_DIR/ca/ca.pem" "$CERT_DIR/orderers/$USER/msp/tlscacerts"
+
+    echo 'NodeOUs:
+    Enable: true
+    ClientOUIdentifier:
+        Certificate: cacerts/ca.pem
+        OrganizationalUnitIdentifier: client
+    PeerOUIdentifier:
+        Certificate: cacerts/ca.pem
+        OrganizationalUnitIdentifier: peer
+    AdminOUIdentifier:
+        Certificate: cacerts/ca.pem
+        OrganizationalUnitIdentifier: admin
+    OrdererOUIdentifier:
+        Certificate: cacerts/ca.pem
+        OrganizationalUnitIdentifier: orderer' >"$CERT_DIR/orderers/$USER/msp/config.yaml"
+
+    cfssl gencert \
+        -ca="$CERT_DIR/ca/ca.pem" \
+        -ca-key="$CERT_DIR/ca/ca-key.pem" \
+        -config="$PWD/organizations/cfssl/cert-signing-config.json" \
+        -cn="$USER" \
+        -hostname="$USER,localhost,127.0.0.1" \
+        -profile="tls" \
+        "$PWD/organizations/cfssl/orderer-${USER}.json" | cfssljson -bare "$CERT_DIR/orderers/$USER/tls/server"
+
+    cp "$CERT_DIR/ca/ca.pem" "$CERT_DIR/orderers/$USER/tls/ca.crt"
+    mv "$CERT_DIR/orderers/$USER/tls/server.pem" "$CERT_DIR/orderers/$USER/tls/server.crt"
+    mv "$CERT_DIR/orderers/$USER/tls/server-key.pem" "$CERT_DIR/orderers/$USER/tls/server.key"
+    rm "$PWD/organizations/cfssl/orderer-${USER}.json"
+}

--- a/test-network/scripts/utils.sh
+++ b/test-network/scripts/utils.sh
@@ -15,6 +15,7 @@ function printHelp() {
     println
     println "    Flags:"
     println "    -ca - Use Certificate Authorities to generate network crypto material"
+    println "    -cfssl <use CFSSL> -  Use CFSSL CA to generate network crypto material"
     println "    -bft - Use Orderers with consensus type BFT (Not available in Fabric v2.x)"
     println "    -c <channel name> - Name of channel to create (defaults to \"mychannel\")"
     println "    -s <dbtype> - Peer state database to deploy: goleveldb (default) or couchdb"
@@ -111,6 +112,7 @@ function printHelp() {
     println "    Flags:"
     println "    Used with \033[0;32mnetwork.sh up\033[0m, \033[0;32mnetwork.sh createChannel\033[0m:"
     println "    -ca - Use Certificate Authorities to generate network crypto material"
+    println "    -cfssl <use CFSSL> -  Use CFSSL CA to generate network crypto material"
     println "    -bft - Use Orderers with consensus type BFT (Not available in Fabric v2.x)"
     println "    -c <channel name> - Name of channel to create (defaults to \"mychannel\")"
     println "    -s <dbtype> - Peer state database to deploy: goleveldb (default) or couchdb"


### PR DESCRIPTION
This PR adds a new example to support pluggable CA in hyperledger fabric. Current examples in the `fabric-samples` provide two implementations for cert generation i.e `cryptogen` and `fabric-ca`. 

This PR will help the developers to understand more about bring your own identity. These changesets will allow developers to generate certificates using the [cfssl tool](https://github.com/cloudflare/cfssl), which is an opensource tool by cloudflare for cert management.

Generate certs using cfssl
```
./network.sh up -cfssl
```