### PR TITLE
fixed test-network-k8s/scripts/test_network.sh missing 

### DIFF
--- a/test-network-k8s/scripts/channel.sh
+++ b/test-network-k8s/scripts/channel.sh
@@ -58,7 +58,7 @@ function register_org_admin() {
     --id.name       ${id_name} \
     --id.secret     ${id_secret} \
     --id.type       ${type} \
-    --url           https://${ca_name}.${DOMAIN} \
+    --url           https://${ca_name}.${DOMAIN}:${NGINX_HTTPS_PORT} \
     --tls.certfiles $TEMP_DIR/cas/${ca_name}/tlsca-cert.pem \
     --mspdir        $TEMP_DIR/enrollments/${org}/users/${RCAADMIN_USER}/msp \
     --id.attrs      "hf.Registrar.Roles=client,hf.Registrar.Attributes=*,hf.Revoker=true,hf.GenCRL=true,admin=true:ecert,abac.init=true:ecert"

--- a/test-network-k8s/scripts/test_network.sh
+++ b/test-network-k8s/scripts/test_network.sh
@@ -52,7 +52,7 @@ function create_node_local_MSP() {
     --id.name       ${id_name} \
     --id.secret     ${id_secret} \
     --id.type       ${node_type} \
-    --url           https://${ca_name}.${DOMAIN} \
+    --url           https://${ca_name}.${DOMAIN}:${NGINX_HTTPS_PORT} \
     --tls.certfiles $TEMP_DIR/cas/${ca_name}/tlsca-cert.pem \
     --mspdir        $TEMP_DIR/enrollments/${org}/users/${RCAADMIN_USER}/msp \
     || rc=$?        # trap error code from registration without exiting the network driver script"


### PR DESCRIPTION
Hi, 

I added ${NGINX_HTTPS_PORT} at test-network-k8s/scripts/test_network.sh and test-network-k8s/scripts/channel.sh. When I run test-network-k8s/network with setting NGINX_HTTPS_PORT=31401, I encounter bugs that fabric-ca-client still request for the port 443.

Error: POST failure of request: POST https://org0-ca.zlpt.com/register
{"id":"org0-orderer2","type":"orderer","secret":"ordererpw","affiliation":""}: Post "https://org0-ca.zlpt.com/register": dial tcp 127.0.0.1:443: connect: connection refused

Now, everything works fine.
