### PR TITLE
Add test-network org3 affiliation

### DIFF
--- a/test-network/addOrg3/fabric-ca/org3/fabric-ca-server-config.yaml
+++ b/test-network/addOrg3/fabric-ca/org3/fabric-ca-server-config.yaml
@@ -242,6 +242,8 @@ affiliations:
       - department2
    org2:
       - department1
+   org3:
+      - department1
 
 #############################################################################
 #  Signing section


### PR DESCRIPTION
The org3 affiliation is needed when registering users for org3.

Resolves https://github.com/hyperledger/fabric/issues/4155