### PR TITLE
Fix build failure in full-stack-asset-transfer

### DIFF
--- a/.github/actions/fsat-setup/action.yaml
+++ b/.github/actions/fsat-setup/action.yaml
@@ -3,19 +3,19 @@ description: Set up the Full Stack Asset Transfer Guide Dependencies
 inputs:
   node-version:
     description: Version of node
-    default: 16.x
+    default: 18.x
   just-version:
     description: Just Version
-    default: 1.2.0
+    default: '1.13.0'
   k9s-version:
     description: k9s Version
     default: v0.25.3
   fabric-version:
     description: Version of Hyperledger Fabric
-    default: 2.5.0-alpha3
+    default: '2.5.0'
   ca-version:
     description: Version of Hyperledger Fabric CA
-    default: 1.5.6-beta3
+    default: '1.5.6'
 
 runs:
   using: "composite"
@@ -35,9 +35,9 @@ runs:
         sudo chmod 755 /usr/local/bin/k9s
 
     - name: Install just
-      shell: bash
-      run: |
-        curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --tag ${{ inputs.just-version }} --to /usr/local/bin
+      uses: extractions/setup-just@v1
+      with:
+        just-version: ${{ inputs.just-version }}
 
     - name: Install weft
       shell: bash

--- a/.github/actions/test-network-setup/action.yaml
+++ b/.github/actions/test-network-setup/action.yaml
@@ -6,7 +6,7 @@ inputs:
     default: 1.19.6
   node-version:
     description: Version of node
-    default: 16.x
+    default: 18.x
   java-version:
     description: Version of JDK
     default: 11.x

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -17,7 +17,7 @@ concurrency:
 
 env:
   GO_VER: 1.19.6
-  NODE_VER: 16.x
+  NODE_VER: 18.x
   JAVA_VER: 11.x
 
 jobs:

--- a/.github/workflows/rest-sample.yaml
+++ b/.github/workflows/rest-sample.yaml
@@ -5,7 +5,7 @@ name: REST Sample 🐧
 run-name: ${{ github.actor }} is testing the REST Sample 🐧
 
 env:
-  NODE_VER: 16.x
+  NODE_VER: 18.x
 
 on:
   workflow_dispatch:

--- a/full-stack-asset-transfer-guide/applications/trader-typescript/package.json
+++ b/full-stack-asset-transfer-guide/applications/trader-typescript/package.json
@@ -5,7 +5,7 @@
     "main": "dist/index.js",
     "typings": "dist/index.d.ts",
     "engines": {
-        "node": ">=16.13.0"
+        "node": ">=18.12.0"
     },
     "scripts": {
         "build": "tsc",
@@ -22,11 +22,11 @@
         "@hyperledger/fabric-gateway": "^1.1.0"
     },
     "devDependencies": {
-        "@tsconfig/node16": "^1.0.3",
-        "@types/node": "^16.11.46",
+        "@tsconfig/node18": "^2.0.0",
+        "@types/node": "^18.16.1",
         "@typescript-eslint/eslint-plugin": "^5.22.0",
         "@typescript-eslint/parser": "^5.22.0",
         "eslint": "^8.14.0",
-        "typescript": "~4.7.4"
+        "typescript": "~5.0.4"
     }
 }

--- a/full-stack-asset-transfer-guide/applications/trader-typescript/tsconfig.json
+++ b/full-stack-asset-transfer-guide/applications/trader-typescript/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json.schemastore.org/tsconfig",
-    "extends": "@tsconfig/node16/tsconfig.json",
+    "extends": "@tsconfig/node18/tsconfig.json",
     "compilerOptions": {
         "declaration": true,
         "declarationMap": true,

--- a/full-stack-asset-transfer-guide/contracts/asset-transfer-typescript/Dockerfile
+++ b/full-stack-asset-transfer-guide/contracts/asset-transfer-typescript/Dockerfile
@@ -1,7 +1,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-FROM node:16.14 AS builder
+FROM node:18.16 AS builder
 
 WORKDIR /usr/src/app
 
@@ -12,7 +12,7 @@ RUN npm install
 RUN npm run build && npm shrinkwrap
 
 
-FROM node:16.14 as prod-builder
+FROM node:18.16 as prod-builder
 WORKDIR /usr/src/app
 COPY --chown=node:node --from=builder /usr/src/app/dist ./dist
 COPY --chown=node:node --from=builder /usr/src/app/package.json ./
@@ -21,7 +21,7 @@ RUN npm ci --omit=dev && npm cache clean --force
 
 # ------------------------------------------------------------------------------
 # Builds the Chaincode as a Service docker version
-FROM node:16.14 AS ccaas
+FROM node:18.16 AS ccaas
 WORKDIR /usr/src/app
 
 ARG TARGETARCH
@@ -47,7 +47,7 @@ ENTRYPOINT [ "/tini", "--", "/usr/src/app/docker-entrypoint.sh" ]
 
 # ------------------------------------------------------------------------------
 # Builds the chaincode for the k8s builder
-FROM node:16.14 AS k8s
+FROM node:18.16 AS k8s
 WORKDIR /usr/src/app
 
 ARG TARGETARCH

--- a/full-stack-asset-transfer-guide/contracts/asset-transfer-typescript/package.json
+++ b/full-stack-asset-transfer-guide/contracts/asset-transfer-typescript/package.json
@@ -5,7 +5,7 @@
     "main": "dist/index.js",
     "typings": "dist/index.d.ts",
     "engines": {
-        "node": ">=16"
+        "node": ">=18.12.0"
     },
     "scripts": {
         "lint": "eslint ./src --ext .ts",
@@ -26,18 +26,18 @@
     "author": "Hyperledger",
     "license": "Apache-2.0",
     "dependencies": {
-        "fabric-contract-api": "~2.5.2",
-        "fabric-shim": "~2.5.2",
+        "fabric-contract-api": "~2.5.3",
+        "fabric-shim": "~2.5.3",
         "json-stringify-deterministic": "^1.0.7",
         "sort-keys-recursive": "^2.1.7"
     },
     "devDependencies": {
-        "@tsconfig/node16": "^1.0.3",
-        "@types/node": "^16.11.46",
+        "@tsconfig/node18": "^2.0.0",
+        "@types/node": "^18.16.1",
         "@typescript-eslint/eslint-plugin": "^5.30.7",
         "@typescript-eslint/parser": "^5.30.7",
         "eslint": "^8.20.0",
-        "typescript": "~4.7.4"
+        "typescript": "~5.0.4"
     },
     "nyc": {
         "extension": [

--- a/full-stack-asset-transfer-guide/contracts/asset-transfer-typescript/tsconfig.json
+++ b/full-stack-asset-transfer-guide/contracts/asset-transfer-typescript/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json.schemastore.org/tsconfig",
-    "extends": "@tsconfig/node16/tsconfig.json",
+    "extends": "@tsconfig/node18/tsconfig.json",
     "compilerOptions": {
         "experimentalDecorators": true,
         "emitDecoratorMetadata": true,

--- a/full-stack-asset-transfer-guide/tests/10-appdev-e2e.sh
+++ b/full-stack-asset-transfer-guide/tests/10-appdev-e2e.sh
@@ -11,15 +11,12 @@ export FABRIC_CFG_PATH="${WORKSHOP_PATH}/config"
 
 "${WORKSHOP_PATH}/check.sh"
 
-CHAINDODE_PID=
+CHAINCODE_PID=
 
 function exitHook() {
 
   # shut down the npm run
   [ -n "${CHAINCODE_PID}" ] && kill "${CHAINCODE_PID}"
-
-  # and node children spawned by npm.  This could be improved by scraping out the pid for the target node command.
-  [ -n "${CHAINCODE_PID}" ] && killall node
 
   # Shut down microfab
   docker kill microfab &> /dev/null


### PR DESCRIPTION
A typo in the 10-appdev-e2e.sh script caused the shell to exit with an error status, failing the build.

Also:
- Update sample application and smart contract to Node 18, using the latest fabric-contact-api release.
- Use release versions of Fabric v2.5 and update tool versions in workflow set up.
- Use GitHub Action to install just instead of curl of install script.