### PR TITLE
Update test-network-k8s to Fabric v2.5

### DIFF
--- a/test-network-k8s/network
+++ b/test-network-k8s/network
@@ -28,7 +28,7 @@ function context() {
   export ${name}="${!override_name:-${default_value}}"
 }
 
-context FABRIC_VERSION                2.4
+context FABRIC_VERSION                2.5
 context FABRIC_CA_VERSION             1.5
 
 context CLUSTER_RUNTIME               kind                  # or k3s for Rancher

--- a/test-network-k8s/network
+++ b/test-network-k8s/network
@@ -49,8 +49,8 @@ context CHANNEL_NAME                  mychannel
 context ORDERER_TIMEOUT               10s                   # see https://github.com/hyperledger/fabric/issues/3372
 context TEMP_DIR                      ${PWD}/build
 context CHAINCODE_BUILDER             ccaas                 # see https://github.com/hyperledgendary/fabric-builder-k8s/blob/main/docs/TEST_NETWORK_K8S.md
-context K8S_CHAINCODE_BUILDER_IMAGE   ghcr.io/hyperledger-labs/k8s-fabric-peer
-context K8S_CHAINCODE_BUILDER_VERSION v0.7.2
+context K8S_CHAINCODE_BUILDER_IMAGE   ghcr.io/hyperledger-labs/fabric-builder-k8s/k8s-fabric-peer
+context K8S_CHAINCODE_BUILDER_VERSION 0.11.0 # For Fabric v2.5+, 0.11.0 or later should be specified
 
 context LOG_FILE                      network.log
 context DEBUG_FILE                    network-debug.log


### PR DESCRIPTION
This PR updates test-network-k8s to use Fabric v2.5.

This PR enhances the following PR.
https://github.com/hyperledger/fabric-samples/pull/1033

# Related Issues
- https://github.com/hyperledger-labs/fabric-builder-k8s/pull/92
- https://github.com/hyperledger/fabric-samples/issues/840