### PR TITLE
FSAT: Extend sleep time to stabilize integration test

### DIFF
--- a/full-stack-asset-transfer-guide/infrastructure/kind_with_nginx.sh
+++ b/full-stack-asset-transfer-guide/infrastructure/kind_with_nginx.sh
@@ -98,7 +98,7 @@ EOF
 function start_nginx() {
   kubectl apply -k https://github.com/hyperledger-labs/fabric-operator.git/config/ingress/kind
 
-  sleep 10
+  sleep 20
 
   kubectl wait --namespace ingress-nginx \
       --for=condition=ready pod \


### PR DESCRIPTION
This patch extends the sleep time to wait for starting nginx by following the description on [full-stack-asset-transfer-guide/justfile](https://github.com/hyperledger/fabric-samples/blob/ae9e7e8df8e2932e235a89b79c31dc54c47a3cf6/full-stack-asset-transfer-guide/justfile#L79) to stabilize the intergration test.