### PR TITLE
fix(test-network): ignore the error output when killing CCAAS containers

### DIFF
--- a/test-network/network.sh
+++ b/test-network/network.sh
@@ -38,6 +38,7 @@ function clearContainers() {
   infoln "Removing remaining containers"
   ${CONTAINER_CLI} rm -f $(${CONTAINER_CLI} ps -aq --filter label=service=hyperledger-fabric) 2>/dev/null || true
   ${CONTAINER_CLI} rm -f $(${CONTAINER_CLI} ps -aq --filter name='dev-peer*') 2>/dev/null || true
+  ${CONTAINER_CLI} kill "$(${CONTAINER_CLI} ps -q --filter name=ccaas)" 2>/dev/null || true
 }
 
 # Delete any images that were generated as a part of this setup
@@ -345,8 +346,6 @@ function networkDown() {
     clearContainers
     #Cleanup images
     removeUnwantedImages
-    #
-    ${CONTAINER_CLI} kill $(${CONTAINER_CLI} ps -q --filter name=ccaas) || true
     # remove orderer block and other channel configuration transactions and certs
     ${CONTAINER_CLI} run --rm -v "$(pwd):/data" busybox sh -c 'cd /data && rm -rf system-genesis-block/*.block organizations/peerOrganizations organizations/ordererOrganizations'
     ## remove fabric ca artifacts


### PR DESCRIPTION
Hi there,

I noticed that when shutting down a test network using `./network.sh down`, the `networkDown()` function will kill the chaincode-as-a-service containers by querying for all containers with name `ccaas`. However, if you did not deploy your chaincode as a service, this `docker kill` command will give an ugly error message as the following:

```
Removing remaining containers
Removing generated chaincode docker images
"docker kill" requires at least 1 argument.
See 'docker kill --help'.

Usage:  docker kill [OPTIONS] CONTAINER [CONTAINER...]

Kill one or more running containers
```

Also, I believe this command is a bit misplaced as it is more logical to have it in `clearContainers()` function. Therefore, I moved the line to the latter function and discarded its stderr (aligned with other clearing container commands).

Thanks
