### PR TITLE
Fix test-network chaincode-as-a-service deployment

### DIFF
--- a/test-network/scripts/deployCCAAS.sh
+++ b/test-network/scripts/deployCCAAS.sh
@@ -177,6 +177,8 @@ installChaincode 1
 infoln "Install chaincode on peer0.org2..."
 installChaincode 2
 
+resolveSequence
+
 ## query whether the chaincode is installed
 queryInstalled 1
 


### PR DESCRIPTION
Resolves a regression introduced in e73bb717db47185a8ccd1b701503b369cd2a73e1.

Previous change defaulted to "auto" as the sequence number but omitted the call to generate the correct sequence number for the "auto" value. This resulted in "auto" being used as the sequence number, which is an error since an integer is required.