### PR TITLE
add support for docker compose v2 (fix #730)

### DIFF
--- a/test-network/addOrg3/addOrg3.sh
+++ b/test-network/addOrg3/addOrg3.sh
@@ -18,7 +18,11 @@ export VERBOSE=false
 . ../scripts/utils.sh
 
 : ${CONTAINER_CLI:="docker"}
-: ${CONTAINER_CLI_COMPOSE:="${CONTAINER_CLI}-compose"}
+if command -v docker-compose > /dev/null 2>&1; then
+    : ${CONTAINER_CLI_COMPOSE:="${CONTAINER_CLI}-compose"}
+else
+    : ${CONTAINER_CLI_COMPOSE:="${CONTAINER_CLI} compose"}
+fi
 infoln "Using ${CONTAINER_CLI} and ${CONTAINER_CLI_COMPOSE}"
 
 

--- a/test-network/network.sh
+++ b/test-network/network.sh
@@ -29,7 +29,11 @@ trap "popd > /dev/null" EXIT
 . scripts/utils.sh
 
 : ${CONTAINER_CLI:="docker"}
-: ${CONTAINER_CLI_COMPOSE:="${CONTAINER_CLI}-compose"}
+if command -v docker-compose > /dev/null 2>&1; then
+    : ${CONTAINER_CLI_COMPOSE:="${CONTAINER_CLI}-compose"}
+else
+    : ${CONTAINER_CLI_COMPOSE:="${CONTAINER_CLI} compose"}
+fi
 infoln "Using ${CONTAINER_CLI} and ${CONTAINER_CLI_COMPOSE}"
 
 # Obtain CONTAINER_IDS and remove them

--- a/test-network/scripts/createChannel.sh
+++ b/test-network/scripts/createChannel.sh
@@ -17,7 +17,11 @@ BFT="$5"
 : ${BFT:=0}
 
 : ${CONTAINER_CLI:="docker"}
-: ${CONTAINER_CLI_COMPOSE:="${CONTAINER_CLI}-compose"}
+if command -v docker-compose > /dev/null 2>&1; then
+    : ${CONTAINER_CLI_COMPOSE:="${CONTAINER_CLI}-compose"}
+else
+    : ${CONTAINER_CLI_COMPOSE:="${CONTAINER_CLI} compose"}
+fi
 infoln "Using ${CONTAINER_CLI} and ${CONTAINER_CLI_COMPOSE}"
 
 if [ ! -d "channel-artifacts" ]; then

--- a/test-network/scripts/deployCCAAS.sh
+++ b/test-network/scripts/deployCCAAS.sh
@@ -24,7 +24,11 @@ VERBOSE=${12:-"false"}
 CCAAS_SERVER_PORT=9999
 
 : ${CONTAINER_CLI:="docker"}
-: ${CONTAINER_CLI_COMPOSE:="${CONTAINER_CLI}-compose"}
+if command -v docker-compose > /dev/null 2>&1; then
+    : ${CONTAINER_CLI_COMPOSE:="${CONTAINER_CLI}-compose"}
+else
+    : ${CONTAINER_CLI_COMPOSE:="${CONTAINER_CLI} compose"}
+fi
 infoln "Using ${CONTAINER_CLI} and ${CONTAINER_CLI_COMPOSE}"
 
 println "executing with the following"


### PR DESCRIPTION
Linux servers with docker engine installed through [docker document](https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository) could not run `network.sh` successfully due to docker compose version compatibility. The default docker engine doesn't support `docker-compose` command.

As the [docker document](https://docs.docker.com/compose/migrate/#what-does-this-mean-for-my-projects-that-use-compose-v1) suggest, `docker compose` is preferred to use in docker compose V2.

This PR adds support for docker compose V2 version. It uses `docker compose` command if it finds `docker-compose` command fails to execute.