### PR TITLE
change "docker-compose" to docker compose

### DIFF
--- a/test-network/network.sh
+++ b/test-network/network.sh
@@ -29,7 +29,7 @@ trap "popd > /dev/null" EXIT
 . scripts/utils.sh
 
 : ${CONTAINER_CLI:="docker"}
-: ${CONTAINER_CLI_COMPOSE:="${CONTAINER_CLI}-compose"}
+: ${CONTAINER_CLI_COMPOSE:="${CONTAINER_CLI} compose"}
 infoln "Using ${CONTAINER_CLI} and ${CONTAINER_CLI_COMPOSE}"
 
 # Obtain CONTAINER_IDS and remove them


### PR DESCRIPTION
"docker-compose" is being deprecated and so it should be replaced instead with "docker compose" as per this link: https://stackoverflow.com/questions/66514436/difference-between-docker-compose-and-docker-compose

In network.sh, it threw an error for me saying docker-compose was not found. So it would be better if "docker-compose" was replaced with "docker compose". In fact, the network.sh worked smoothly after I made this change.

Prerequisites: Install docker-compose-plugin along with docker as follows:
``sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin``
as per docker docs