### PR TITLE
Fix certPath in assetTransfer.go

### DIFF
--- a/asset-transfer-basic/application-gateway-go/assetTransfer.go
+++ b/asset-transfer-basic/application-gateway-go/assetTransfer.go
@@ -28,7 +28,7 @@ import (
 const (
 	mspID        = "Org1MSP"
 	cryptoPath   = "../../test-network/organizations/peerOrganizations/org1.example.com"
-	certPath     = cryptoPath + "/users/User1@org1.example.com/msp/signcerts/cert.pem"
+	certPath     = cryptoPath + "/users/User1@org1.example.com/msp/signcerts/User1@org1.example.com-cert.pem"
 	keyPath      = cryptoPath + "/users/User1@org1.example.com/msp/keystore/"
 	tlsCertPath  = cryptoPath + "/peers/peer0.org1.example.com/tls/ca.crt"
 	peerEndpoint = "localhost:7051"


### PR DESCRIPTION
Following the latest tutorial, the current version of network.sh does not generate `cert.pem` as filename under `msp/signcerts` but instead created `User1@org1.example.com-cert.pem`. I have edited the application file to reflect such difference.