### PR TITLE
Update GitHub action versions

### DIFF
--- a/.github/actions/fsat-setup/action.yaml
+++ b/.github/actions/fsat-setup/action.yaml
@@ -6,7 +6,7 @@ inputs:
     default: 18.x
   just-version:
     description: Just Version
-    default: '1.13.0'
+    default: '1.24.0'
   k9s-version:
     description: k9s Version
     default: v0.25.3
@@ -35,9 +35,9 @@ runs:
         sudo chmod 755 /usr/local/bin/k9s
 
     - name: Install just
-      uses: extractions/setup-just@v1
+      uses: taiki-e/install-action@v2
       with:
-        just-version: ${{ inputs.just-version }}
+        tool: just@${{ inputs.just-version }}
 
     - name: Install weft
       shell: bash

--- a/.github/actions/test-network-setup/action.yaml
+++ b/.github/actions/test-network-setup/action.yaml
@@ -20,10 +20,9 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-go@v4
+    - uses: actions/setup-go@v5
       with:
         go-version: ${{ inputs.go-version }}
-        cache: true
         cache-dependency-path: '**/go.sum'
 
     - uses: actions/setup-node@v4
@@ -32,7 +31,7 @@ runs:
         cache: 'npm'
         cache-dependency-path: '**/package-lock.json'
 
-    - uses: actions/setup-java@v3
+    - uses: actions/setup-java@v4
       with:
         distribution: temurin
         java-version: ${{ inputs.java-version }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -24,7 +24,7 @@ jobs:
   go:
     runs-on: fabric-ubuntu-20.04
     steps:
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VER }}
       - uses: actions/checkout@v4
@@ -53,7 +53,7 @@ jobs:
     runs-on: fabric-ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: ${{ env.JAVA_VER }}


### PR DESCRIPTION
Avoid using deprecated action versions based on Node versions prior to Node 18.