### PR TITLE
Fix to configtx.yaml to enable it to work as intended with the test network and channel tutorials

### DIFF
--- a/test-network/configtx/configtx.yaml
+++ b/test-network/configtx/configtx.yaml
@@ -257,7 +257,7 @@ Channel: &ChannelDefaults
 #
 ################################################################################
 Profiles:
-  ChannelUsingRaft:
+  TwoOrgsApplicationGenesis:
     <<: *ChannelDefaults
     Orderer:
       <<: *OrdererDefaults


### PR DESCRIPTION
It seems the profile name was incorrectly changed to from "TwoOrgsApplicationGenesis" as the fabric tutorial requires to "ChannelUsingRafts".  This latter profile name creates an error when setting up channels using the test network and tutorials.  This update changes the profile name back to "TwoOrgsApplicationGenesis" as is required for the test network tutorials for which this file was created. 