### PR TITLE
Refactor test-network post-decoupling fabric-tools image

### DIFF
--- a/test-network/.gitignore
+++ b/test-network/.gitignore
@@ -3,6 +3,7 @@
 /ledgers
 /ledgers-backup
 /channel-artifacts/*.json
+/channel-artifacts/*.pb
 /org3-artifacts/crypto-config/*
 organizations/fabric-ca/ordererOrg/*
 organizations/fabric-ca/org1/*

--- a/test-network/addOrg3/addOrg3.sh
+++ b/test-network/addOrg3/addOrg3.sh
@@ -12,7 +12,7 @@
 # prepending $PWD/../bin to PATH to ensure we are picking up the correct binaries
 # this may be commented out to resolve installed version of tools if desired
 export PATH=${PWD}/../../bin:${PWD}:$PATH
-export FABRIC_CFG_PATH=${PWD}
+export FABRIC_CFG_PATH=${PWD}/../../config
 export VERBOSE=false
 
 . ../scripts/utils.sh
@@ -161,7 +161,7 @@ function addOrg3 () {
   # Create the configuration transaction needed to add
   # Org3 to the network
   infoln "Generating and submitting config tx to add Org3"
-  cp ${PWD}/../../config/core.yaml ${PWD}
+  export FABRIC_CFG_PATH=${PWD}/../../config
   . ../scripts/org3-scripts/updateChannelConfig.sh $CHANNEL_NAME $CLI_DELAY $CLI_TIMEOUT $VERBOSE
   if [ $? -ne 0 ]; then
     fatalln "ERROR !!!! Unable to create config tx"

--- a/test-network/scripts/envVar.sh
+++ b/test-network/scripts/envVar.sh
@@ -8,19 +8,20 @@
 # This is a collection of bash functions used by different scripts
 
 # imports
-# test network home var targets to test network folder
-# the reason we use a var here is considering with org3 specific folder
-# when invoking this for org3 as test-network/scripts/org3-scripts
-# the value is changed from default as $PWD(test-network)
-# to .. as relative path to make the import works
-test_network_home=${test_network_home:-${PWD}}
-. ${test_network_home}/scripts/utils.sh
+# test network home var targets to test-network folder
+# the reason we use a var here is to accommodate scenarios
+# where execution occurs from folders outside of default as $PWD, such as the test-network/addOrg3 folder.
+# For setting environment variables, simple relative paths like ".." could lead to unintended references
+# due to how they interact with FABRIC_CFG_PATH. It's advised to specify paths more explicitly,
+# such as using "../${PWD}", to ensure that Fabric's environment variables are pointing to the correct paths.
+TEST_NETWORK_HOME=${TEST_NETWORK_HOME:-${PWD}}
+. ${TEST_NETWORK_HOME}/scripts/utils.sh
 
 export CORE_PEER_TLS_ENABLED=true
-export ORDERER_CA=${test_network_home}/organizations/ordererOrganizations/example.com/tlsca/tlsca.example.com-cert.pem
-export PEER0_ORG1_CA=${test_network_home}/organizations/peerOrganizations/org1.example.com/tlsca/tlsca.org1.example.com-cert.pem
-export PEER0_ORG2_CA=${test_network_home}/organizations/peerOrganizations/org2.example.com/tlsca/tlsca.org2.example.com-cert.pem
-export PEER0_ORG3_CA=${test_network_home}/organizations/peerOrganizations/org3.example.com/tlsca/tlsca.org3.example.com-cert.pem
+export ORDERER_CA=${TEST_NETWORK_HOME}/organizations/ordererOrganizations/example.com/tlsca/tlsca.example.com-cert.pem
+export PEER0_ORG1_CA=${TEST_NETWORK_HOME}/organizations/peerOrganizations/org1.example.com/tlsca/tlsca.org1.example.com-cert.pem
+export PEER0_ORG2_CA=${TEST_NETWORK_HOME}/organizations/peerOrganizations/org2.example.com/tlsca/tlsca.org2.example.com-cert.pem
+export PEER0_ORG3_CA=${TEST_NETWORK_HOME}/organizations/peerOrganizations/org3.example.com/tlsca/tlsca.org3.example.com-cert.pem
 
 # Set environment variables for the peer org
 setGlobals() {
@@ -34,17 +35,17 @@ setGlobals() {
   if [ $USING_ORG -eq 1 ]; then
     export CORE_PEER_LOCALMSPID="Org1MSP"
     export CORE_PEER_TLS_ROOTCERT_FILE=$PEER0_ORG1_CA
-    export CORE_PEER_MSPCONFIGPATH=${test_network_home}/organizations/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp
+    export CORE_PEER_MSPCONFIGPATH=${TEST_NETWORK_HOME}/organizations/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp
     export CORE_PEER_ADDRESS=localhost:7051
   elif [ $USING_ORG -eq 2 ]; then
     export CORE_PEER_LOCALMSPID="Org2MSP"
     export CORE_PEER_TLS_ROOTCERT_FILE=$PEER0_ORG2_CA
-    export CORE_PEER_MSPCONFIGPATH=${test_network_home}/organizations/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp
+    export CORE_PEER_MSPCONFIGPATH=${TEST_NETWORK_HOME}/organizations/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp
     export CORE_PEER_ADDRESS=localhost:9051
   elif [ $USING_ORG -eq 3 ]; then
     export CORE_PEER_LOCALMSPID="Org3MSP"
     export CORE_PEER_TLS_ROOTCERT_FILE=$PEER0_ORG3_CA
-    export CORE_PEER_MSPCONFIGPATH=${test_network_home}/organizations/peerOrganizations/org3.example.com/users/Admin@org3.example.com/msp
+    export CORE_PEER_MSPCONFIGPATH=${TEST_NETWORK_HOME}/organizations/peerOrganizations/org3.example.com/users/Admin@org3.example.com/msp
     export CORE_PEER_ADDRESS=localhost:11051
   else
     errorln "ORG Unknown"
@@ -52,27 +53,6 @@ setGlobals() {
 
   if [ "$VERBOSE" = "true" ]; then
     env | grep CORE
-  fi
-}
-
-# Set environment variables for use in the CLI container
-setGlobalsCLI() {
-  setGlobals $1
-
-  local USING_ORG=""
-  if [ -z "$OVERRIDE_ORG" ]; then
-    USING_ORG=$1
-  else
-    USING_ORG="${OVERRIDE_ORG}"
-  fi
-  if [ $USING_ORG -eq 1 ]; then
-    export CORE_PEER_ADDRESS=peer0.org1.example.com:7051
-  elif [ $USING_ORG -eq 2 ]; then
-    export CORE_PEER_ADDRESS=peer0.org2.example.com:9051
-  elif [ $USING_ORG -eq 3 ]; then
-    export CORE_PEER_ADDRESS=peer0.org3.example.com:11051
-  else
-    errorln "ORG Unknown"
   fi
 }
 

--- a/test-network/scripts/org3-scripts/joinChannel.sh
+++ b/test-network/scripts/org3-scripts/joinChannel.sh
@@ -5,11 +5,10 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-# This script is designed to be run in the cli container as the
-# second step of the EYFN tutorial. It joins the org3 peers to the
-# channel previously setup in the BYFN tutorial and install the
-# chaincode as version 2.0 on peer0.org3.
-#
+# This script is designed to be run by addOrg3.sh as the
+# second step of the Adding an Org to a Channel tutorial.
+# It joins the org3 peers to the channel previously setup in
+# the test network tutorial.
 
 CHANNEL_NAME="$1"
 DELAY="$2"
@@ -23,13 +22,13 @@ COUNTER=1
 MAX_RETRY=5
 
 # import environment variables
-# test network home var targets to test network folder
+# test network home var targets to test-network folder
 # the reason we use a var here is considering with org3 specific folder
 # when invoking this for org3 as test-network/scripts/org3-scripts
-# the value is changed from default as $PWD(test-network)
-# to .. as relative path to make the import works
-export test_network_home=..
-. ${test_network_home}/scripts/envVar.sh
+# the value is changed from default as $PWD (test-network)
+# to ${PWD}/.. to make the import works
+export TEST_NETWORK_HOME="${PWD}/.."
+. ${TEST_NETWORK_HOME}/scripts/envVar.sh
 
 # joinChannel ORG
 joinChannel() {
@@ -53,11 +52,11 @@ joinChannel() {
 
 setAnchorPeer() {
   ORG=$1
-  ${test_network_home}/scripts/setAnchorPeer.sh $ORG $CHANNEL_NAME
+  ${TEST_NETWORK_HOME}/scripts/setAnchorPeer.sh $ORG $CHANNEL_NAME
 }
 
-setGlobalsCLI 3
-BLOCKFILE="${CHANNEL_NAME}.block"
+setGlobals 3
+BLOCKFILE="${TEST_NETWORK_HOME}/channel-artifacts/${CHANNEL_NAME}.block"
 
 echo "Fetching channel config block from orderer..."
 set -x

--- a/test-network/scripts/org3-scripts/updateChannelConfig.sh
+++ b/test-network/scripts/org3-scripts/updateChannelConfig.sh
@@ -5,10 +5,10 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-# This script is designed to be run in the cli container as the
-# first step of the EYFN tutorial.  It creates and submits a
-# configuration transaction to add org3 to the test network
-#
+# This script is designed to be run by addOrg3.sh as the
+# first step of the Adding an Org to a Channel tutorial.
+# It creates and submits a configuration transaction to
+# add org3 to the test network
 
 CHANNEL_NAME="$1"
 DELAY="$2"
@@ -23,34 +23,34 @@ MAX_RETRY=5
 
 
 # imports
-# test network home var targets to test network folder
+# test network home var targets to test-network folder
 # the reason we use a var here is considering with org3 specific folder
 # when invoking this for org3 as test-network/scripts/org3-scripts
-# the value is changed from default as $PWD(test-network)
-# to .. as relative path to make the import works
-export test_network_home=..
-. ${test_network_home}/scripts/configUpdate.sh 
+# the value is changed from default as $PWD (test-network)
+# to ${PWD}/.. to make the import works
+export TEST_NETWORK_HOME="${PWD}/.."
+. ${TEST_NETWORK_HOME}/scripts/configUpdate.sh 
 
 infoln "Creating config transaction to add org3 to network"
 
 # Fetch the config for the channel, writing it to config.json
-fetchChannelConfig 1 ${CHANNEL_NAME} config.json
+fetchChannelConfig 1 ${CHANNEL_NAME} ${TEST_NETWORK_HOME}/channel-artifacts/config.json
 
 # Modify the configuration to append the new org
 set -x
-jq -s '.[0] * {"channel_group":{"groups":{"Application":{"groups": {"Org3MSP":.[1]}}}}}' config.json ${test_network_home}/organizations/peerOrganizations/org3.example.com/org3.json > modified_config.json
+jq -s '.[0] * {"channel_group":{"groups":{"Application":{"groups": {"Org3MSP":.[1]}}}}}' ${TEST_NETWORK_HOME}/channel-artifacts/config.json ${TEST_NETWORK_HOME}/organizations/peerOrganizations/org3.example.com/org3.json > ${TEST_NETWORK_HOME}/channel-artifacts/modified_config.json
 { set +x; } 2>/dev/null
 
 # Compute a config update, based on the differences between config.json and modified_config.json, write it as a transaction to org3_update_in_envelope.pb
-createConfigUpdate ${CHANNEL_NAME} config.json modified_config.json org3_update_in_envelope.pb
+createConfigUpdate ${CHANNEL_NAME} ${TEST_NETWORK_HOME}/channel-artifacts/config.json ${TEST_NETWORK_HOME}/channel-artifacts/modified_config.json ${TEST_NETWORK_HOME}/channel-artifacts/org3_update_in_envelope.pb
 
 infoln "Signing config transaction"
-signConfigtxAsPeerOrg 1 org3_update_in_envelope.pb
+signConfigtxAsPeerOrg 1 ${TEST_NETWORK_HOME}/channel-artifacts/org3_update_in_envelope.pb
 
 infoln "Submitting transaction from a different peer (peer0.org2) which also signs it"
 setGlobals 2
 set -x
-peer channel update -f org3_update_in_envelope.pb -c ${CHANNEL_NAME} -o localhost:7050 --ordererTLSHostnameOverride orderer.example.com --tls --cafile "$ORDERER_CA"
+peer channel update -f ${TEST_NETWORK_HOME}/channel-artifacts/org3_update_in_envelope.pb -c ${CHANNEL_NAME} -o localhost:7050 --ordererTLSHostnameOverride orderer.example.com --tls --cafile "$ORDERER_CA"
 { set +x; } 2>/dev/null
 
 successln "Config transaction to add org3 to network submitted"

--- a/test-network/scripts/setAnchorPeer.sh
+++ b/test-network/scripts/setAnchorPeer.sh
@@ -11,14 +11,14 @@
 # when invoking this for org3 as test-network/scripts/org3-scripts
 # the value is changed from default as $PWD(test-network)
 # to .. as relative path to make the import works
-test_network_home=${test_network_home:-${PWD}}
-. ${test_network_home}/scripts/configUpdate.sh
+TEST_NETWORK_HOME=${TEST_NETWORK_HOME:-${PWD}}
+. ${TEST_NETWORK_HOME}/scripts/configUpdate.sh
 
 
-# NOTE: this must be run in a CLI container since it requires jq and configtxlator 
+# NOTE: This requires jq and configtxlator for execution.
 createAnchorPeerUpdate() {
   infoln "Fetching channel config for channel $CHANNEL_NAME"
-  fetchChannelConfig $ORG $CHANNEL_NAME ${CORE_PEER_LOCALMSPID}config.json
+  fetchChannelConfig $ORG $CHANNEL_NAME ${TEST_NETWORK_HOME}/channel-artifacts/${CORE_PEER_LOCALMSPID}config.json
 
   infoln "Generating anchor peer update transaction for Org${ORG} on channel $CHANNEL_NAME"
 
@@ -37,17 +37,17 @@ createAnchorPeerUpdate() {
 
   set -x
   # Modify the configuration to append the anchor peer 
-  jq '.channel_group.groups.Application.groups.'${CORE_PEER_LOCALMSPID}'.values += {"AnchorPeers":{"mod_policy": "Admins","value":{"anchor_peers": [{"host": "'$HOST'","port": '$PORT'}]},"version": "0"}}' ${CORE_PEER_LOCALMSPID}config.json > ${CORE_PEER_LOCALMSPID}modified_config.json
+  jq '.channel_group.groups.Application.groups.'${CORE_PEER_LOCALMSPID}'.values += {"AnchorPeers":{"mod_policy": "Admins","value":{"anchor_peers": [{"host": "'$HOST'","port": '$PORT'}]},"version": "0"}}' ${TEST_NETWORK_HOME}/channel-artifacts/${CORE_PEER_LOCALMSPID}config.json > ${TEST_NETWORK_HOME}/channel-artifacts/${CORE_PEER_LOCALMSPID}modified_config.json
   { set +x; } 2>/dev/null
 
   # Compute a config update, based on the differences between 
   # {orgmsp}config.json and {orgmsp}modified_config.json, write
   # it as a transaction to {orgmsp}anchors.tx
-  createConfigUpdate ${CHANNEL_NAME} ${CORE_PEER_LOCALMSPID}config.json ${CORE_PEER_LOCALMSPID}modified_config.json ${CORE_PEER_LOCALMSPID}anchors.tx
+  createConfigUpdate ${CHANNEL_NAME} ${TEST_NETWORK_HOME}/channel-artifacts/${CORE_PEER_LOCALMSPID}config.json ${TEST_NETWORK_HOME}/channel-artifacts/${CORE_PEER_LOCALMSPID}modified_config.json ${TEST_NETWORK_HOME}/channel-artifacts/${CORE_PEER_LOCALMSPID}anchors.tx
 }
 
 updateAnchorPeer() {
-  peer channel update -o localhost:7050 --ordererTLSHostnameOverride orderer.example.com -c $CHANNEL_NAME -f ${CORE_PEER_LOCALMSPID}anchors.tx --tls --cafile "$ORDERER_CA" >&log.txt
+  peer channel update -o localhost:7050 --ordererTLSHostnameOverride orderer.example.com -c $CHANNEL_NAME -f ${TEST_NETWORK_HOME}/channel-artifacts/${CORE_PEER_LOCALMSPID}anchors.tx --tls --cafile "$ORDERER_CA" >&log.txt
   res=$?
   cat log.txt
   verifyResult $res "Anchor peer update failed"
@@ -57,7 +57,7 @@ updateAnchorPeer() {
 ORG=$1
 CHANNEL_NAME=$2
 
-setGlobalsCLI $ORG
+setGlobals $ORG
 
 createAnchorPeerUpdate 
 


### PR DESCRIPTION
This patch aims to refactor the test-network in several aspects, the initial PR (#1186) for the decoupling of the fabric-tools image from fabric-samples.

For context, please refer to the discussions on that PR.

- Rename 'test_network_home' env var to 'TEST_NETWORK_HOME'
- Dedicate the intermediate artifacts related to configtx to channel-artifacts
- Refer to core.yaml in fabric-samples/config, similar to org1 and 2, instead of adding a new core file
- Remove unnecessary functions and comments for CLI container
- Other minor modifications

Related Issues:
- https://github.com/hyperledger/fabric-samples/pull/1186