### PR TITLE
Fix docs and scripts for asset-transfer-basic as an external service

### DIFF
--- a/asset-transfer-basic/chaincode-external/README.md
+++ b/asset-transfer-basic/chaincode-external/README.md
@@ -22,7 +22,7 @@ To set the path within the peer container, you will need to modify the docker co
 
 ```
         - ../..:/opt/gopath/src/github.com/hyperledger/fabric-samples
-        - ../../config/core.yaml:/etc/hyperledger/fabric/core.yaml
+        - ../../config/core.yaml:/etc/hyperledger/peercfg/core.yaml
 ```
 
 This update will mount the `core.yaml` that you modified into the peer container and override the configuration file within the peer image. The update also mounts the fabric-sample builder so that it can be found at the location that you specified in `core.yaml`. You also have the option of commenting out the line `- /var/run/docker.sock:/host/var/run/docker.sock`, since we no longer need to access the docker daemon from inside the peer container to launch the chaincode.

--- a/asset-transfer-basic/chaincode-external/sampleBuilder/bin/build
+++ b/asset-transfer-basic/chaincode-external/sampleBuilder/bin/build
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -euo pipefail
 

--- a/asset-transfer-basic/chaincode-external/sampleBuilder/bin/detect
+++ b/asset-transfer-basic/chaincode-external/sampleBuilder/bin/detect
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -euo pipefail
 

--- a/asset-transfer-basic/chaincode-external/sampleBuilder/bin/release
+++ b/asset-transfer-basic/chaincode-external/sampleBuilder/bin/release
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -euo pipefail
 


### PR DESCRIPTION

#### Type of change

- Bug fix
- Documentation update

#### Description

This PR fixes docs and scripts for asset-transfer-basic as an external service.

The path to the configuration file that the peer container in the test-network references seems to have changed. So we need to update the path in the procedures.

As discussed in the following mailing list exchange, starting with Fabric v2.5, so we need to change the scripts (detect, build, release, run) to start with #!/bin/bash instead of #!/bin/sh.
https://lists.hyperledger.org/g/fabric/topic/104464487

#### Related issues

Resolves #1137