### PR TITLE
test-network envVar.sh script improvement

### DIFF
--- a/test-network/scripts/envVar.sh
+++ b/test-network/scripts/envVar.sh
@@ -50,7 +50,7 @@ setGlobals() {
     errorln "ORG Unknown"
   fi
 
-  if [ "$VERBOSE" == "true" ]; then
+  if [ "$VERBOSE" = "true" ]; then
     env | grep CORE
   fi
 }


### PR DESCRIPTION
Change shell script to use single equals.

In my shell environment single bracket with double equals did not work. It caused failure when running the chaincode-external tutorial README.

It looks like for maximum portability, it is best to use single bracket with single equals.