### PR TITLE
test-network error message if jq not installed

### DIFF
--- a/test-network/scripts/configUpdate.sh
+++ b/test-network/scripts/configUpdate.sh
@@ -33,13 +33,15 @@ fetchChannelConfig() {
   set -x
   configtxlator proto_decode --input ${TEST_NETWORK_HOME}/channel-artifacts/config_block.pb --type common.Block --output ${TEST_NETWORK_HOME}/channel-artifacts/config_block.json
   jq .data.data[0].payload.data.config ${TEST_NETWORK_HOME}/channel-artifacts/config_block.json >"${OUTPUT}"
+  res=$?
   { set +x; } 2>/dev/null
+  verifyResult $res "Failed to parse channel configuration, make sure you have jq installed"
 }
 
 # createConfigUpdate <channel_id> <original_config.json> <modified_config.json> <output.pb>
 # Takes an original and modified config, and produces the config update tx
 # which transitions between the two
-# NOTE: this requires configtxlator for execution.
+# NOTE: this requires jq and configtxlator for execution.
 createConfigUpdate() {
   CHANNEL=$1
   ORIGINAL=$2

--- a/test-network/scripts/setAnchorPeer.sh
+++ b/test-network/scripts/setAnchorPeer.sh
@@ -38,7 +38,10 @@ createAnchorPeerUpdate() {
   set -x
   # Modify the configuration to append the anchor peer 
   jq '.channel_group.groups.Application.groups.'${CORE_PEER_LOCALMSPID}'.values += {"AnchorPeers":{"mod_policy": "Admins","value":{"anchor_peers": [{"host": "'$HOST'","port": '$PORT'}]},"version": "0"}}' ${TEST_NETWORK_HOME}/channel-artifacts/${CORE_PEER_LOCALMSPID}config.json > ${TEST_NETWORK_HOME}/channel-artifacts/${CORE_PEER_LOCALMSPID}modified_config.json
+  res=$?
   { set +x; } 2>/dev/null
+  verifyResult $res "Channel configuration update for anchor peer failed, make sure you have jq installed"
+  
 
   # Compute a config update, based on the differences between 
   # {orgmsp}config.json and {orgmsp}modified_config.json, write


### PR DESCRIPTION
With removal of fabric-tools image, test-network
now depends on jq being installed locally.

This commit logs an error message if jq commands
fail due to jq not being installed locally.