### PR TITLE
Switch microfab to hyperledger-labs version

### DIFF
--- a/full-stack-asset-transfer-guide/justfile
+++ b/full-stack-asset-transfer-guide/justfile
@@ -175,7 +175,7 @@ microfab: microfab-down
     echo
     echo "Stating microfab...."
 
-    docker run --name microfab -p 8080:8080 --add-host host.docker.internal:host-gateway --rm -d -e MICROFAB_CONFIG="${MICROFAB_CONFIG}"  ibmcom/ibp-microfab:0.0.16
+    docker run --name microfab -p 8080:8080 --add-host host.docker.internal:host-gateway --rm -d -e MICROFAB_CONFIG="${MICROFAB_CONFIG}" ghcr.io/hyperledger-labs/microfab:sha-a762636db01748819667324014cbc034d88a8cee
     sleep 5
 
     curl -s http://console.127-0-0-1.nip.io:8080/ak/api/v1/components | weft microfab -w $CFG/_wallets -p $CFG/_gateways -m $CFG/_msp -f


### PR DESCRIPTION
full-stack-asset-transfer points to an old image
that no longer exists.
Point to the hyperledger-labs microfab image instead.