### PR TITLE
GHA: Use ubuntu-20.04 for local forks

### DIFF
--- a/.github/actions/fsat-setup/action.yaml
+++ b/.github/actions/fsat-setup/action.yaml
@@ -12,10 +12,10 @@ inputs:
     default: v0.25.3
   fabric-version:
     description: Version of Hyperledger Fabric
-    default: '2.5.4'
+    default: '2.5.7'
   ca-version:
     description: Version of Hyperledger Fabric CA
-    default: '1.5.7'
+    default: '1.5.10'
 
 runs:
   using: "composite"

--- a/.github/actions/test-network-setup/action.yaml
+++ b/.github/actions/test-network-setup/action.yaml
@@ -3,7 +3,7 @@ description: Set up the Test Network Runtime
 inputs:
   go-version:
     description: Version of go
-    default: '1.20'
+    default: '1.21'
   node-version:
     description: Version of node
     default: 18.x
@@ -12,10 +12,10 @@ inputs:
     default: 11.x
   fabric-version:
     description: Version of Hyperledger Fabric
-    default: 2.5.4
+    default: 2.5.7
   ca-version:
     description: Version of Hyperledger Fabric CA
-    default: 1.5.7
+    default: 1.5.10
 
 runs:
   using: "composite"

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -16,13 +16,13 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VER: '1.20'
+  GO_VER: '1.21'
   NODE_VER: 18.x
   JAVA_VER: 11.x
 
 jobs:
   go:
-    runs-on: fabric-ubuntu-20.04
+    runs-on: ${{ github.repository == 'hyperledger/fabric-samples' && 'fabric-ubuntu-20.04' || 'ubuntu-20.04' }}
     steps:
       - uses: actions/setup-go@v5
         with:
@@ -32,7 +32,7 @@ jobs:
       - run: ci/scripts/lint-go.sh
 
   typescript:
-    runs-on: fabric-ubuntu-20.04
+    runs-on: ${{ github.repository == 'hyperledger/fabric-samples' && 'fabric-ubuntu-20.04' || 'ubuntu-20.04' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -41,7 +41,7 @@ jobs:
       - run: ci/scripts/lint-typescript.sh
 
   javascript:
-    runs-on: fabric-ubuntu-20.04
+    runs-on: ${{ github.repository == 'hyperledger/fabric-samples' && 'fabric-ubuntu-20.04' || 'ubuntu-20.04' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -50,7 +50,7 @@ jobs:
       - run: ci/scripts/lint-javascript.sh
 
   java:
-    runs-on: fabric-ubuntu-20.04
+    runs-on: ${{ github.repository == 'hyperledger/fabric-samples' && 'fabric-ubuntu-20.04' || 'ubuntu-20.04' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
@@ -60,7 +60,7 @@ jobs:
       - run: ci/scripts/lint-java.sh
 
   shell:
-    runs-on: fabric-ubuntu-20.04
+    runs-on: ${{ github.repository == 'hyperledger/fabric-samples' && 'fabric-ubuntu-20.04' || 'ubuntu-20.04' }}
     steps:
       - uses: actions/checkout@v4
       - run: ci/scripts/lint-shell.sh

--- a/.github/workflows/rest-sample.yaml
+++ b/.github/workflows/rest-sample.yaml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   test-sample:
-    runs-on: fabric-ubuntu-20.04
+    runs-on: ${{ github.repository == 'hyperledger/fabric-samples' && 'fabric-ubuntu-20.04' || 'ubuntu-20.04' }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/test-fsat.yaml
+++ b/.github/workflows/test-fsat.yaml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   ansible:
-    runs-on: fabric-ubuntu-20.04
+    runs-on: ${{ github.repository == 'hyperledger/fabric-samples' && 'fabric-ubuntu-20.04' || 'ubuntu-20.04' }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up Full Stack Runtime
@@ -23,7 +23,7 @@ jobs:
         working-directory: full-stack-asset-transfer-guide
 
   appdev:
-    runs-on: fabric-ubuntu-20.04
+    runs-on: ${{ github.repository == 'hyperledger/fabric-samples' && 'fabric-ubuntu-20.04' || 'ubuntu-20.04' }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up Full Stack Runtime
@@ -32,7 +32,7 @@ jobs:
         working-directory: full-stack-asset-transfer-guide
 
   chaincode:
-    runs-on: fabric-ubuntu-20.04
+    runs-on: ${{ github.repository == 'hyperledger/fabric-samples' && 'fabric-ubuntu-20.04' || 'ubuntu-20.04' }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up Full Stack Runtime
@@ -41,7 +41,7 @@ jobs:
         working-directory: full-stack-asset-transfer-guide
 
   cloud:
-    runs-on: fabric-ubuntu-20.04
+    runs-on: ${{ github.repository == 'hyperledger/fabric-samples' && 'fabric-ubuntu-20.04' || 'ubuntu-20.04' }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up Full Stack Runtime
@@ -50,7 +50,7 @@ jobs:
         working-directory: full-stack-asset-transfer-guide
 
   console:
-    runs-on: fabric-ubuntu-20.04
+    runs-on: ${{ github.repository == 'hyperledger/fabric-samples' && 'fabric-ubuntu-20.04' || 'ubuntu-20.04' }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up Full Stack Runtime

--- a/.github/workflows/test-network-basic.yaml
+++ b/.github/workflows/test-network-basic.yaml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   basic:
-    runs-on: fabric-ubuntu-20.04
+    runs-on: ${{ github.repository == 'hyperledger/fabric-samples' && 'fabric-ubuntu-20.04' || 'ubuntu-20.04' }}
     strategy:
       matrix:
         chaincode-language:

--- a/.github/workflows/test-network-events.yaml
+++ b/.github/workflows/test-network-events.yaml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   events:
-    runs-on: fabric-ubuntu-20.04
+    runs-on: ${{ github.repository == 'hyperledger/fabric-samples' && 'fabric-ubuntu-20.04' || 'ubuntu-20.04' }}
     strategy:
       matrix:
         chaincode-language:

--- a/.github/workflows/test-network-gateway.yaml
+++ b/.github/workflows/test-network-gateway.yaml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   gateway:
-    runs-on: fabric-ubuntu-20.04
+    runs-on: ${{ github.repository == 'hyperledger/fabric-samples' && 'fabric-ubuntu-20.04' || 'ubuntu-20.04' }}
     strategy:
       matrix:
         chaincode-language:

--- a/.github/workflows/test-network-hsm.yaml
+++ b/.github/workflows/test-network-hsm.yaml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   hsm:
-    runs-on: fabric-ubuntu-20.04
+    runs-on: ${{ github.repository == 'hyperledger/fabric-samples' && 'fabric-ubuntu-20.04' || 'ubuntu-20.04' }}
     strategy:
       matrix:
         chaincode-language:

--- a/.github/workflows/test-network-k8s.yaml
+++ b/.github/workflows/test-network-k8s.yaml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   ccaas-java:
-    runs-on: fabric-ubuntu-20.04
+    runs-on: ${{ github.repository == 'hyperledger/fabric-samples' && 'fabric-ubuntu-20.04' || 'ubuntu-20.04' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -29,7 +29,7 @@ jobs:
           CHAINCODE_LANGUAGE: java
 
   ccaas-external:
-    runs-on: fabric-ubuntu-20.04
+    runs-on: ${{ github.repository == 'hyperledger/fabric-samples' && 'fabric-ubuntu-20.04' || 'ubuntu-20.04' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -41,7 +41,7 @@ jobs:
           CHAINCODE_LANGUAGE: external
 
   k8s-builder:
-    runs-on: fabric-ubuntu-20.04
+    runs-on: ${{ github.repository == 'hyperledger/fabric-samples' && 'fabric-ubuntu-20.04' || 'ubuntu-20.04' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -54,7 +54,7 @@ jobs:
           CHAINCODE_BUILDER: k8s
 
   multi-namespace:
-    runs-on: fabric-ubuntu-20.04
+    runs-on: ${{ github.repository == 'hyperledger/fabric-samples' && 'fabric-ubuntu-20.04' || 'ubuntu-20.04' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test-network-ledger.yaml
+++ b/.github/workflows/test-network-ledger.yaml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   basic:
-    runs-on: fabric-ubuntu-20.04
+    runs-on: ${{ github.repository == 'hyperledger/fabric-samples' && 'fabric-ubuntu-20.04' || 'ubuntu-20.04' }}
     strategy:
       matrix:
         chaincode-language:

--- a/.github/workflows/test-network-off-chain.yaml
+++ b/.github/workflows/test-network-off-chain.yaml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   off-chain:
-    runs-on: fabric-ubuntu-20.04
+    runs-on: ${{ github.repository == 'hyperledger/fabric-samples' && 'fabric-ubuntu-20.04' || 'ubuntu-20.04' }}
     strategy:
       matrix:
         chaincode-language:

--- a/.github/workflows/test-network-private.yaml
+++ b/.github/workflows/test-network-private.yaml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   private:
-    runs-on: fabric-ubuntu-20.04
+    runs-on: ${{ github.repository == 'hyperledger/fabric-samples' && 'fabric-ubuntu-20.04' || 'ubuntu-20.04' }}
     strategy:
       matrix:
         chaincode-language:

--- a/.github/workflows/test-network-sbe.yaml
+++ b/.github/workflows/test-network-sbe.yaml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   SBE:
-    runs-on: fabric-ubuntu-20.04
+    runs-on: ${{ github.repository == 'hyperledger/fabric-samples' && 'fabric-ubuntu-20.04' || 'ubuntu-20.04' }}
     strategy:
       matrix:
         chaincode-language:

--- a/.github/workflows/test-network-secured.yaml
+++ b/.github/workflows/test-network-secured.yaml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   secured:
-    runs-on: fabric-ubuntu-20.04
+    runs-on: ${{ github.repository == 'hyperledger/fabric-samples' && 'fabric-ubuntu-20.04' || 'ubuntu-20.04' }}
     strategy:
       matrix:
         chaincode-language:


### PR DESCRIPTION
GHA: Use ubuntu-20.04 for local forks
since local forks don't have access to fabric-ubuntu-20.04.