### PR TITLE
Fix of issue #1204

### DIFF
--- a/test-network-k8s/scripts/prereqs.sh
+++ b/test-network-k8s/scripts/prereqs.sh
@@ -47,7 +47,7 @@ function check_prereqs() {
   if [[ $? -ne 0 ]]; then
     echo "Downloading LATEST Fabric binaries and config"
     curl -sSL https://raw.githubusercontent.com/hyperledger/fabric/main/scripts/bootstrap.sh \
-      | bash -s -- -s -d
+      | bash -s -- ${FABRIC_VERSION} ${FABRIC_CA_VERSION} -s -d
 
     # remove sample config files extracted by the installation script
     rm config/configtx.yaml


### PR DESCRIPTION
Fix solution of  issue #1204 titled Test-network-k8s network script gets last version Fabric bin files instead of requested version.
When test-network-k8s is called with a specific but not the last version of Fabric hyper-ledger and the binary files are not available into ./bin folder, the script always downloaded the last version of binary files.