### PR TITLE
Update test dependencies for Java chaincode

### DIFF
--- a/asset-transfer-basic/chaincode-java/build.gradle
+++ b/asset-transfer-basic/chaincode-java/build.gradle
@@ -17,10 +17,9 @@ dependencies {
     implementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.5.+'
     implementation 'org.json:json:+'
     implementation 'com.owlike:genson:1.5'
-    testImplementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.5.+'
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.4.2'
-    testImplementation 'org.assertj:assertj-core:3.11.1'
-    testImplementation 'org.mockito:mockito-core:2.+'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
+    testImplementation 'org.assertj:assertj-core:3.25.3'
+    testImplementation 'org.mockito:mockito-core:5.12.0'
 }
 
 repositories {

--- a/asset-transfer-basic/chaincode-java/src/test/java/org/hyperledger/fabric/samples/assettransfer/AssetTransferTest.java
+++ b/asset-transfer-basic/chaincode-java/src/test/java/org/hyperledger/fabric/samples/assettransfer/AssetTransferTest.java
@@ -8,7 +8,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.ThrowableAssert.catchThrowable;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
@@ -26,7 +26,7 @@ import org.mockito.InOrder;
 
 public final class AssetTransferTest {
 
-    private final class MockKeyValue implements KeyValue {
+    private static final class MockKeyValue implements KeyValue {
 
         private final String key;
         private final String value;
@@ -54,7 +54,7 @@ public final class AssetTransferTest {
 
     }
 
-    private final class MockAssetResultsIterator implements QueryResultsIterator<KeyValue> {
+    private static final class MockAssetResultsIterator implements QueryResultsIterator<KeyValue> {
 
         private final List<KeyValue> assetList;
 
@@ -102,7 +102,7 @@ public final class AssetTransferTest {
                 .hasMessage("Undefined contract method called");
         assertThat(((ChaincodeException) thrown).getPayload()).isEqualTo(null);
 
-        verifyZeroInteractions(ctx);
+        verifyNoInteractions(ctx);
     }
 
     @Nested

--- a/asset-transfer-private-data/chaincode-java/build.gradle
+++ b/asset-transfer-private-data/chaincode-java/build.gradle
@@ -17,10 +17,9 @@ dependencies {
     implementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.5.+'
     implementation 'org.json:json:+'
 
-    testImplementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.5.+'
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.4.2'
-    testImplementation 'org.assertj:assertj-core:3.11.1'
-    testImplementation 'org.mockito:mockito-core:2.+'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
+    testImplementation 'org.assertj:assertj-core:3.25.3'
+    testImplementation 'org.mockito:mockito-core:5.12.0'
 }
 
 repositories {

--- a/asset-transfer-private-data/chaincode-java/src/test/java/org/hyperledger/fabric/samples/privatedata/AssetTransferTest.java
+++ b/asset-transfer-private-data/chaincode-java/src/test/java/org/hyperledger/fabric/samples/privatedata/AssetTransferTest.java
@@ -4,21 +4,6 @@
 
 package org.hyperledger.fabric.samples.privatedata;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.ThrowableAssert.catchThrowable;
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.hyperledger.fabric.samples.privatedata.AssetTransfer.AGREEMENT_KEYPREFIX;
-import static org.hyperledger.fabric.samples.privatedata.AssetTransfer.ASSET_COLLECTION_NAME;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
-import static org.mockito.Mockito.when;
-
-import java.io.IOException;
-import java.security.cert.CertificateException;
-import java.util.HashMap;
-import java.util.Map;
 import org.hyperledger.fabric.contract.ClientIdentity;
 import org.hyperledger.fabric.contract.Context;
 import org.hyperledger.fabric.shim.ChaincodeException;
@@ -26,6 +11,20 @@ import org.hyperledger.fabric.shim.ChaincodeStub;
 import org.hyperledger.fabric.shim.ledger.CompositeKey;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.ThrowableAssert.catchThrowable;
+import static org.hyperledger.fabric.samples.privatedata.AssetTransfer.AGREEMENT_KEYPREFIX;
+import static org.hyperledger.fabric.samples.privatedata.AssetTransfer.ASSET_COLLECTION_NAME;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 public final class AssetTransferTest {
 
@@ -38,11 +37,11 @@ public final class AssetTransferTest {
             Context ctx = mock(Context.class);
             ChaincodeStub stub = mock(ChaincodeStub.class);
             when(ctx.getStub()).thenReturn(stub);
-            Map<String, byte[]> m = new HashMap<String, byte[]>();
-            m.put("asset_properties", dataAsset1Bytes);
+            Map<String, byte[]> m = new HashMap<>();
+            m.put("asset_properties", DATA_ASSET_1_BYTES);
             when(ctx.getStub().getTransient()).thenReturn(m);
-            when(stub.getPrivateData(ASSET_COLLECTION_NAME, testAsset1ID))
-                    .thenReturn(dataAsset1Bytes);
+            when(stub.getPrivateData(ASSET_COLLECTION_NAME, TEST_ASSET_1_ID))
+                    .thenReturn(DATA_ASSET_1_BYTES);
 
             Throwable thrown = catchThrowable(() -> {
                 contract.CreateAsset(ctx);
@@ -54,62 +53,62 @@ public final class AssetTransferTest {
         }
 
         @Test
-        public void createAssetWhenNewAssetIsCreated() throws CertificateException, IOException {
+        public void createAssetWhenNewAssetIsCreated() {
              AssetTransfer contract = new AssetTransfer();
             Context ctx = mock(Context.class);
             ChaincodeStub stub = mock(ChaincodeStub.class);
             when(ctx.getStub()).thenReturn(stub);
-            when(stub.getMspId()).thenReturn(testOrgOneMSP);
+            when(stub.getMspId()).thenReturn(TEST_ORG_1_MSP);
             ClientIdentity ci = mock(ClientIdentity.class);
-            when(ci.getId()).thenReturn(testOrg1Client);
-            when(ci.getMSPID()).thenReturn(testOrgOneMSP);
+            when(ci.getId()).thenReturn(TEST_ORG_1_USER);
+            when(ci.getMSPID()).thenReturn(TEST_ORG_1_MSP);
             when(ctx.getClientIdentity()).thenReturn(ci);
 
-            Map<String, byte[]> m = new HashMap<String, byte[]>();
-            m.put("asset_properties", dataAsset1Bytes);
+            Map<String, byte[]> m = new HashMap<>();
+            m.put("asset_properties", DATA_ASSET_1_BYTES);
             when(ctx.getStub().getTransient()).thenReturn(m);
 
-            when(stub.getPrivateData(ASSET_COLLECTION_NAME, testAsset1ID))
+            when(stub.getPrivateData(ASSET_COLLECTION_NAME, TEST_ASSET_1_ID))
                     .thenReturn(new byte[0]);
 
             Asset created = contract.CreateAsset(ctx);
-            assertThat(created).isEqualTo(testAsset1);
+            assertThat(created).isEqualTo(TEST_ASSET_1);
 
-            verify(stub).putPrivateData(ASSET_COLLECTION_NAME, testAsset1ID, created.serialize());
+            verify(stub).putPrivateData(ASSET_COLLECTION_NAME, TEST_ASSET_1_ID, created.serialize());
         }
 
         @Test
-        public void transferAssetWhenExistingAssetIsTransferred() throws CertificateException, IOException {
+        public void transferAssetWhenExistingAssetIsTransferred() {
             AssetTransfer contract = new AssetTransfer();
             Context ctx = mock(Context.class);
             ChaincodeStub stub = mock(ChaincodeStub.class);
             when(ctx.getStub()).thenReturn(stub);
-            when(stub.getMspId()).thenReturn(testOrgOneMSP);
+            when(stub.getMspId()).thenReturn(TEST_ORG_1_MSP);
             ClientIdentity ci = mock(ClientIdentity.class);
-            when(ci.getId()).thenReturn(testOrg1Client);
+            when(ci.getId()).thenReturn(TEST_ORG_1_USER);
             when(ctx.getClientIdentity()).thenReturn(ci);
-            when(ci.getMSPID()).thenReturn(testOrgOneMSP);
+            when(ci.getMSPID()).thenReturn(TEST_ORG_1_MSP);
             final String recipientOrgMsp = "TestOrg2";
             final String buyerIdentity = "TestOrg2User";
-            Map<String, byte[]> m = new HashMap<String, byte[]>();
-            m.put("asset_owner", ("{ \"buyerMSP\": \"" + recipientOrgMsp + "\", \"assetID\": \"" + testAsset1ID + "\" }").getBytes());
+            Map<String, byte[]> m = new HashMap<>();
+            m.put("asset_owner", ("{ \"buyerMSP\": \"" + recipientOrgMsp + "\", \"assetID\": \"" + TEST_ASSET_1_ID + "\" }").getBytes());
             when(ctx.getStub().getTransient()).thenReturn(m);
 
             when(stub.getPrivateDataHash(anyString(), anyString())).thenReturn("TestHashValue".getBytes());
-            when(stub.getPrivateData(ASSET_COLLECTION_NAME, testAsset1ID))
-                    .thenReturn(dataAsset1Bytes);
+            when(stub.getPrivateData(ASSET_COLLECTION_NAME, TEST_ASSET_1_ID))
+                    .thenReturn(DATA_ASSET_1_BYTES);
             CompositeKey ck = mock(CompositeKey.class);
-            when(ck.toString()).thenReturn(AGREEMENT_KEYPREFIX + testAsset1ID);
-            when(stub.createCompositeKey(AGREEMENT_KEYPREFIX, testAsset1ID)).thenReturn(ck);
-            when(stub.getPrivateData(ASSET_COLLECTION_NAME, AGREEMENT_KEYPREFIX + testAsset1ID)).thenReturn(buyerIdentity.getBytes(UTF_8));
+            when(ck.toString()).thenReturn(AGREEMENT_KEYPREFIX + TEST_ASSET_1_ID);
+            when(stub.createCompositeKey(AGREEMENT_KEYPREFIX, TEST_ASSET_1_ID)).thenReturn(ck);
+            when(stub.getPrivateData(ASSET_COLLECTION_NAME, AGREEMENT_KEYPREFIX + TEST_ASSET_1_ID)).thenReturn(buyerIdentity.getBytes(UTF_8));
             contract.TransferAsset(ctx);
 
             Asset exptectedAfterTransfer  = Asset.deserialize("{ \"objectType\": \"testasset\", \"assetID\": \"asset1\", \"color\": \"blue\", \"size\": 5, \"owner\": \"" +  buyerIdentity + "\", \"appraisedValue\": 300 }");
 
-            verify(stub).putPrivateData(ASSET_COLLECTION_NAME, testAsset1ID, exptectedAfterTransfer.serialize());
-            String collectionOwner = testOrgOneMSP + "PrivateCollection";
-            verify(stub).delPrivateData(collectionOwner, testAsset1ID);
-            verify(stub).delPrivateData(ASSET_COLLECTION_NAME, AGREEMENT_KEYPREFIX + testAsset1ID);
+            verify(stub).putPrivateData(ASSET_COLLECTION_NAME, TEST_ASSET_1_ID, exptectedAfterTransfer.serialize());
+            String collectionOwner = TEST_ORG_1_MSP + "PrivateCollection";
+            verify(stub).delPrivateData(collectionOwner, TEST_ASSET_1_ID);
+            verify(stub).delPrivateData(ASSET_COLLECTION_NAME, AGREEMENT_KEYPREFIX + TEST_ASSET_1_ID);
         }
     }
 
@@ -122,12 +121,12 @@ public final class AssetTransferTest {
             Context ctx = mock(Context.class);
             ChaincodeStub stub = mock(ChaincodeStub.class);
             when(ctx.getStub()).thenReturn(stub);
-            when(stub.getPrivateData(ASSET_COLLECTION_NAME, testAsset1ID))
-                    .thenReturn(dataAsset1Bytes);
+            when(stub.getPrivateData(ASSET_COLLECTION_NAME, TEST_ASSET_1_ID))
+                    .thenReturn(DATA_ASSET_1_BYTES);
 
-            Asset asset = contract.ReadAsset(ctx, testAsset1ID);
+            Asset asset = contract.ReadAsset(ctx, TEST_ASSET_1_ID);
 
-            assertThat(asset).isEqualTo(testAsset1);
+            assertThat(asset).isEqualTo(TEST_ASSET_1);
         }
 
         @Test
@@ -136,9 +135,9 @@ public final class AssetTransferTest {
             Context ctx = mock(Context.class);
             ChaincodeStub stub = mock(ChaincodeStub.class);
             when(ctx.getStub()).thenReturn(stub);
-            when(stub.getStringState(testAsset1ID)).thenReturn(null);
+            when(stub.getStringState(TEST_ASSET_1_ID)).thenReturn(null);
 
-            Asset asset = contract.ReadAsset(ctx, testAsset1ID);
+            Asset asset = contract.ReadAsset(ctx, TEST_ASSET_1_ID);
             assertThat(asset).isNull();
         }
 
@@ -155,16 +154,15 @@ public final class AssetTransferTest {
                     .hasMessage("Undefined contract method called");
             assertThat(((ChaincodeException) thrown).getPayload()).isEqualTo(null);
 
-            verifyZeroInteractions(ctx);
+            verifyNoInteractions(ctx);
         }
 
     }
 
-    private static String testOrgOneMSP = "TestOrg1";
-    private static String testOrg1Client = "testOrg1User";
+    private static final String TEST_ORG_1_MSP = "TestOrg1";
+    private static final String TEST_ORG_1_USER = "testOrg1User";
 
-    private static String testAsset1ID = "asset1";
-    private static Asset testAsset1 = new Asset("testasset", "asset1", "blue", 5, testOrg1Client);
-    private static byte[] dataAsset1Bytes = "{ \"objectType\": \"testasset\", \"assetID\": \"asset1\", \"color\": \"blue\", \"size\": 5, \"owner\": \"testOrg1User\", \"appraisedValue\": 300 }".getBytes();
-
+    private static final String TEST_ASSET_1_ID = "asset1";
+    private static final Asset TEST_ASSET_1 = new Asset("testasset", "asset1", "blue", 5, TEST_ORG_1_USER);
+    private static final byte[] DATA_ASSET_1_BYTES = "{ \"objectType\": \"testasset\", \"assetID\": \"asset1\", \"color\": \"blue\", \"size\": 5, \"owner\": \"testOrg1User\", \"appraisedValue\": 300 }".getBytes();
 }

--- a/token-erc-20/chaincode-java/build.gradle
+++ b/token-erc-20/chaincode-java/build.gradle
@@ -17,10 +17,9 @@ dependencies {
     implementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.5.+'
     implementation 'org.json:json:+'
     implementation 'com.owlike:genson:1.5'
-    testImplementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.5.+'
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.4.2'
-    testImplementation 'org.assertj:assertj-core:3.11.1'
-    testImplementation 'org.mockito:mockito-core:2.+'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
+    testImplementation 'org.assertj:assertj-core:3.25.3'
+    testImplementation 'org.mockito:mockito-core:5.12.0'
     testRuntimeOnly("net.bytebuddy:byte-buddy:1.10.6")
 
 }

--- a/token-erc-721/chaincode-java/build.gradle
+++ b/token-erc-721/chaincode-java/build.gradle
@@ -17,10 +17,9 @@ dependencies {
     implementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.5.+'
     implementation 'org.json:json:+'
     implementation 'com.owlike:genson:1.5'
-    testImplementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.5.+'
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.4.2'
-    testImplementation 'org.assertj:assertj-core:3.11.1'
-    testImplementation 'org.mockito:mockito-core:2.23.4'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
+    testImplementation 'org.assertj:assertj-core:3.25.3'
+    testImplementation 'org.mockito:mockito-core:5.12.0'
     testRuntimeOnly("net.bytebuddy:byte-buddy:1.10.6")
 
 }

--- a/token-erc-721/chaincode-java/src/test/java/org/hyperledger/fabric/samples/erc721/ERC721TokenContractTest.java
+++ b/token-erc-721/chaincode-java/src/test/java/org/hyperledger/fabric/samples/erc721/ERC721TokenContractTest.java
@@ -28,7 +28,7 @@ import static org.mockito.Mockito.when;
 
 public class ERC721TokenContractTest {
 
-  private final class MockKeyValue implements KeyValue {
+  private static final class MockKeyValue implements KeyValue {
 
     private final String key;
     private final String value;
@@ -55,7 +55,7 @@ public class ERC721TokenContractTest {
     }
   }
 
-  private final class MockAssetResultsIterator implements QueryResultsIterator<KeyValue> {
+  private static final class MockAssetResultsIterator implements QueryResultsIterator<KeyValue> {
 
     private final List<KeyValue> assetList;
 
@@ -166,7 +166,7 @@ public class ERC721TokenContractTest {
     }
 
     @Test
-    public void whenSenderisApprovedClientOfToken()
+    public void whenSenderIsApprovedClientOfToken()
         throws CertificateException, JSONException, IOException {
       Approval approval = new Approval("Alice", "Charlie", false);
       CompositeKey ck = mock(CompositeKey.class);
@@ -184,7 +184,7 @@ public class ERC721TokenContractTest {
     }
 
     @Test
-    public void whenSenderisAuthorizedOperatorOfToken()
+    public void whenSenderIsAuthorizedOperatorOfToken()
         throws CertificateException, JSONException, IOException {
       Approval approval = new Approval("Alice", "Dave", true);
       CompositeKey ck = mock(CompositeKey.class);
@@ -254,7 +254,7 @@ public class ERC721TokenContractTest {
   class ERC721ApproveFunctionalitiesTest {
 
     @Test
-    public void invokeAprrove() throws CertificateException, JSONException, IOException {
+    public void invokeApprove() throws CertificateException, JSONException, IOException {
       Context ctx = mock(Context.class);
       ChaincodeStub stub = mock(ChaincodeStub.class);
       NFT nft = new NFT("101", "Alice", "http://test.com", "");


### PR DESCRIPTION
This resolves mocking errors using the latest Java chaincode shim and very old versions of Mockito.