### PR TITLE
Add external builders for golang and node chaincode to test-network-n…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,7 @@ package-lock.json
 .settings
 
 # installed Fabric binaries etc.
-bin/
+/bin/
 builders/
 config/
 external-chaincode/

--- a/test-network-nano-bash/README.md
+++ b/test-network-nano-bash/README.md
@@ -38,6 +38,34 @@ If you have [yq](https://mikefarah.gitbook.io/yq/) installed, run the following 
 yq -i 'del(.chaincode.externalBuilders) | .chaincode.externalBuilders[0].name = "ccaas_builder" | .chaincode.externalBuilders[0].path = env(PWD) + "/builders/ccaas" | .chaincode.externalBuilders[0].propagateEnvironment[0] = "CHAINCODE_AS_A_SERVICE_BUILDER_CONFIG"' config/core.yaml
 ```
 
+## Run the chaincode without docker
+You can run chaincode as binaries by enabling the external builders in the core.yaml.  The external builders are configured to work with golang and node chaincode.  This is accomplished by running the following command:
+
+```
+$ ./configureExternalBuilders.sh
+```
+
+This script copies the config files from `fabric-samples/config` to `fabric-samples/test-network-nano-bash/config` and adds the external builders to the core.yaml.  The following is an example of the additions to core.yaml.
+
+```
+    externalBuilders:
+       - name: golang
+         path: /Users/nanofab/fabric-samples/test-network-nano-bash/external_builders/golang
+         propagateEnvironment:
+           - HOME   
+       - name: node
+         path: /Users/nanofab/fabric-samples/test-network-nano-bash/external_builders/node
+         propagateEnvironment:
+           - HOME
+           - npm_config_cache
+```
+
+Note:  Golang chaincode will require at least Go 1.20 installed and in the path.  Node chaincode will require at least Node 20 be installed.
+
+
+The peer shell scripts detect the presence of the config directory in the `test-network-nano-bash/` directory and will use these config files if they exist.  In order to revert to docker, simply delete the config directory in `test-network-nano-bash/`.
+
+
 # Instructions for starting network
 ## Running each component separately
 

--- a/test-network-nano-bash/configureExternalBuilders.sh
+++ b/test-network-nano-bash/configureExternalBuilders.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+
+mkdir -p config
+
+sed -e '/externalBuilders:/r ./external_builders/core_yaml_change.yaml' ../config/core.yaml | sed -e "s|_working_dir_|$PWD|g" > ./config/core.yaml
+

--- a/test-network-nano-bash/external_builders/core_yaml_change.yaml
+++ b/test-network-nano-bash/external_builders/core_yaml_change.yaml
@@ -1,0 +1,12 @@
+       - name: golang
+         path: _working_dir_/external_builders/golang
+         propagateEnvironment:
+           - GOCACHE
+           - GOENV
+           - HOME   
+           - GOPROXY
+       - name: node
+         path: _working_dir_/external_builders/node
+         propagateEnvironment:
+           - HOME
+           - npm_config_cache

--- a/test-network-nano-bash/external_builders/golang/bin/build
+++ b/test-network-nano-bash/external_builders/golang/bin/build
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+set -euo pipefail
+exec 1>&2
+CHAINCODE_SOURCE_DIR="$1"
+CHAINCODE_METADATA_DIR="$2"
+BUILD_OUTPUT_DIR="$3"
+GO_PACKAGE_PATH="$(jq -r .path "${CHAINCODE_METADATA_DIR}/metadata.json")"
+if [ -f "${CHAINCODE_SOURCE_DIR}/src/go.mod" ]; then
+    cd "${CHAINCODE_SOURCE_DIR}/src"
+    CGO_ENABLED=0 go build -v -o "${BUILD_OUTPUT_DIR}/chaincode" "${GO_PACKAGE_PATH}"
+else
+    CGO_ENABLED=0 GOPATH="${CHAINCODE_SOURCE_DIR}" GO111MODULE=off go build -v  -o "${BUILD_OUTPUT_DIR}/chaincode" "${GO_PACKAGE_PATH}"
+fi

--- a/test-network-nano-bash/external_builders/golang/bin/detect
+++ b/test-network-nano-bash/external_builders/golang/bin/detect
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+set -euo pipefail
+exec 1>&2
+CHAINCODE_METADATA_DIR="$2"
+if [ "$(jq -r .type "${CHAINCODE_METADATA_DIR}/metadata.json" | tr '[:upper:]' '[:lower:]')" = "golang" ]; then
+    exit 0
+fi
+exit 1

--- a/test-network-nano-bash/external_builders/golang/bin/release
+++ b/test-network-nano-bash/external_builders/golang/bin/release
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+set -xeuo pipefail
+exec 1>&2
+
+BUILD_OUTPUT_DIR="$1"
+RELEASE_OUTPUT_DIR="$2"
+if [ -d "${BUILD_OUTPUT_DIR}/META-INF" ] ; then
+   cp -a "${BUILD_OUTPUT_DIR}/META-INF/"* "${RELEASE_OUTPUT_DIR}/"
+fi

--- a/test-network-nano-bash/external_builders/golang/bin/run
+++ b/test-network-nano-bash/external_builders/golang/bin/run
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+set -xeuo pipefail
+exec 1>&2
+BUILD_OUTPUT_DIR="$1"
+RUN_METADATA_DIR="$2"
+
+#######################################
+# Export environment variables and extract certificate files from chaincode.json
+# Globals:
+#   None
+# Arguments:
+#   METADATA_DIR: Location of the chaincode.json file
+# Returns:
+#   None
+#######################################
+function process_chaincode_metadata_json {
+    local METADATA_DIR=${RUN_METADATA_DIR}
+
+    CORE_CHAINCODE_ID_NAME="$(jq -r .chaincode_id "$METADATA_DIR/chaincode.json")"
+    CORE_PEER_ADDRESS="$(jq -r .peer_address "$METADATA_DIR/chaincode.json")"
+    CORE_PEER_LOCALMSPID="$(jq -r .mspid "$METADATA_DIR/chaincode.json")"
+    export CORE_CHAINCODE_ID_NAME
+    export CORE_PEER_ADDRESS
+    export CORE_PEER_LOCALMSPID
+
+    if [ -z "$(jq -r .client_cert "$METADATA_DIR/chaincode.json")" ]; then
+        CORE_PEER_TLS_ENABLED="false"
+        export CORE_PEER_TLS_ENABLED
+    else
+        CORE_PEER_TLS_ENABLED="true"
+        CORE_TLS_CLIENT_CERT_FILE="$BUILD_OUTPUT_DIR/client.crt"
+        CORE_TLS_CLIENT_KEY_FILE="$BUILD_OUTPUT_DIR/client.key"
+        CORE_PEER_TLS_ROOTCERT_FILE="$BUILD_OUTPUT_DIR/root.crt"
+        export CORE_PEER_TLS_ENABLED
+        export CORE_TLS_CLIENT_CERT_FILE
+        export CORE_TLS_CLIENT_KEY_FILE
+        export CORE_PEER_TLS_ROOTCERT_FILE
+
+        jq -r .client_cert "$METADATA_DIR/chaincode.json" >"$CORE_TLS_CLIENT_CERT_FILE"
+        jq -r .client_key "$METADATA_DIR/chaincode.json" >"$CORE_TLS_CLIENT_KEY_FILE"
+        jq -r .root_cert "$METADATA_DIR/chaincode.json" >"$CORE_PEER_TLS_ROOTCERT_FILE"
+    fi
+}
+
+# extract the required environment variables
+process_chaincode_metadata_json
+
+# output for debug purposes
+env | grep CORE | sort
+
+
+exec "${BUILD_OUTPUT_DIR}/chaincode" -peer.address="${CORE_PEER_ADDRESS}"

--- a/test-network-nano-bash/external_builders/node/bin/build
+++ b/test-network-nano-bash/external_builders/node/bin/build
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+set -euo pipefail
+exec 1>&2
+CHAINCODE_SOURCE_DIR="$1"
+# CHAINCODE_METADATA_DIR="$2"
+BUILD_OUTPUT_DIR="$3"
+cd "${CHAINCODE_SOURCE_DIR}/src"
+tar cf - . | (cd "${BUILD_OUTPUT_DIR}" && tar xf -)
+cd "${BUILD_OUTPUT_DIR}"
+if [ -f package-lock.json ] || [ -f npm-shrinkwrap.json ]; then
+    npm ci --only=production
+else
+    npm install --production
+fi

--- a/test-network-nano-bash/external_builders/node/bin/detect
+++ b/test-network-nano-bash/external_builders/node/bin/detect
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+set -euo pipefail
+exec 1>&2
+CHAINCODE_METADATA_DIR="$2"
+if [ "$(jq -r .type "${CHAINCODE_METADATA_DIR}/metadata.json" | tr '[:upper:]' '[:lower:]')" = "node" ]; then
+    exit 0
+fi
+exit 1

--- a/test-network-nano-bash/external_builders/node/bin/release
+++ b/test-network-nano-bash/external_builders/node/bin/release
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+set -euo pipefail
+exec 1>&2
+BUILD_OUTPUT_DIR="$1"
+RELEASE_OUTPUT_DIR="$2"
+if [ -d "${BUILD_OUTPUT_DIR}/META-INF" ] ; then
+   cp -a "${BUILD_OUTPUT_DIR}/META-INF/"* "${RELEASE_OUTPUT_DIR}/"
+fi

--- a/test-network-nano-bash/external_builders/node/bin/run
+++ b/test-network-nano-bash/external_builders/node/bin/run
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+set -xeuo pipefail
+exec 1>&2
+
+BUILD_OUTPUT_DIR="$1"
+RUN_METADATA_DIR="$2"
+
+cd "${BUILD_OUTPUT_DIR}"
+ls -lart
+
+# extract the id, mspid, and peer address
+CORE_CHAINCODE_ID_NAME="$(jq -r .chaincode_id "${RUN_METADATA_DIR}/chaincode.json")"
+CORE_PEER_LOCALMSPID="$(jq -r .mspid "${RUN_METADATA_DIR}/chaincode.json")"
+CORE_PEER_ADDRESS="$(jq -r .peer_address "${RUN_METADATA_DIR}/chaincode.json")"
+export CORE_CHAINCODE_ID_NAME CORE_PEER_LOCALMSPID CORE_PEER_ADDRESS
+
+# process the TLS options if needed
+if [ -z "$(jq -r .client_cert "$RUN_METADATA_DIR/chaincode.json")" ]; then
+    CORE_PEER_TLS_ENABLED="false"
+    export CORE_PEER_TLS_ENABLED
+else
+    
+    export CORE_PEER_TLS_ENABLED="true"
+    export CORE_TLS_CLIENT_CERT_FILE="$BUILD_OUTPUT_DIR/client-pem.crt"
+    export CORE_TLS_CLIENT_KEY_FILE="$BUILD_OUTPUT_DIR/client-pem.key"
+    export CORE_TLS_CLIENT_CERT_PATH="$BUILD_OUTPUT_DIR/client.crt"
+    export CORE_TLS_CLIENT_KEY_PATH="$BUILD_OUTPUT_DIR/client.key"
+    
+    export CORE_PEER_TLS_ROOTCERT_FILE="$BUILD_OUTPUT_DIR/root.crt"
+
+    jq -r .client_cert "$RUN_METADATA_DIR/chaincode.json" > "$CORE_TLS_CLIENT_CERT_FILE"
+    jq -r .client_key  "$RUN_METADATA_DIR/chaincode.json" > "$CORE_TLS_CLIENT_KEY_FILE"
+    jq -r .root_cert   "$RUN_METADATA_DIR/chaincode.json" > "$CORE_PEER_TLS_ROOTCERT_FILE"
+    
+    base64 -i "${CORE_TLS_CLIENT_CERT_FILE}" > "${CORE_TLS_CLIENT_CERT_PATH}"
+    base64 -i "${CORE_TLS_CLIENT_KEY_FILE}" > "${CORE_TLS_CLIENT_KEY_PATH}"
+
+    #base64 -w 0 "${CORE_TLS_CLIENT_CERT_FILE}" > "${CORE_TLS_CLIENT_CERT_PATH}"
+    #base64 -w 0 "${CORE_TLS_CLIENT_KEY_FILE}" > "${CORE_TLS_CLIENT_KEY_PATH}"
+
+    ls -lart "$BUILD_OUTPUT_DIR"
+fi
+
+# output for debug purposes
+env | grep CORE | sort
+
+# run the chaincode
+exec npm start -- --peer.address="${CORE_PEER_ADDRESS}"

--- a/test-network-nano-bash/peer1.sh
+++ b/test-network-nano-bash/peer1.sh
@@ -4,15 +4,21 @@
 #
 set -eu
 
-if [ "$(uname)" = "Linux" ] ; then
+if [ "$(uname)" = "Linux" ] || [  -d config ]
+then
   CCADDR="127.0.0.1"
 else
   CCADDR="host.docker.internal"
 fi
 
+if [  -d config  ] ; then
+  export FABRIC_CFG_PATH="${PWD}"/config
+else
+  export FABRIC_CFG_PATH="${PWD}"/../config
+fi
+
 # look for binaries in local dev environment /build/bin directory and then in local samples /bin directory
 export PATH="${PWD}"/../../fabric/build/bin:"${PWD}"/../bin:"$PATH"
-export FABRIC_CFG_PATH="${PWD}"/../config
 
 export FABRIC_LOGGING_SPEC=debug:cauthdsl,policies,msp,grpc,peer.gossip.mcs,gossip,leveldbhelper=info
 export CORE_PEER_TLS_ENABLED=true

--- a/test-network-nano-bash/peer2.sh
+++ b/test-network-nano-bash/peer2.sh
@@ -4,15 +4,21 @@
 #
 set -eu
 
-if [ "$(uname)" = "Linux" ] ; then
+if [ "$(uname)" = "Linux" ] || [  -d config ]
+then
   CCADDR="127.0.0.1"
 else
   CCADDR="host.docker.internal"
 fi
 
+if [  -d config  ] ; then
+  export FABRIC_CFG_PATH="${PWD}"/config
+else
+  export FABRIC_CFG_PATH="${PWD}"/../config
+fi
+
 # look for binaries in local dev environment /build/bin directory and then in local samples /bin directory
 export PATH="${PWD}"/../../fabric/build/bin:"${PWD}"/../bin:"$PATH"
-export FABRIC_CFG_PATH="${PWD}"/../config
 
 export FABRIC_LOGGING_SPEC=debug:cauthdsl,policies,msp,grpc,peer.gossip.mcs,gossip,leveldbhelper=info
 export CORE_PEER_TLS_ENABLED=true

--- a/test-network-nano-bash/peer3.sh
+++ b/test-network-nano-bash/peer3.sh
@@ -4,15 +4,21 @@
 #
 set -eu
 
-if [ "$(uname)" = "Linux" ] ; then
+if [ "$(uname)" = "Linux" ] || [  -d config ]
+then
   CCADDR="127.0.0.1"
 else
   CCADDR="host.docker.internal"
 fi
 
+if [  -d config  ] ; then
+  export FABRIC_CFG_PATH="${PWD}"/config
+else
+  export FABRIC_CFG_PATH="${PWD}"/../config
+fi
+
 # look for binaries in local dev environment /build/bin directory and then in local samples /bin directory
 export PATH="${PWD}"/../../fabric/build/bin:"${PWD}"/../bin:"$PATH"
-export FABRIC_CFG_PATH="${PWD}"/../config
 
 export FABRIC_LOGGING_SPEC=debug:cauthdsl,policies,msp,grpc,peer.gossip.mcs,gossip,leveldbhelper=info
 export CORE_PEER_TLS_ENABLED=true

--- a/test-network-nano-bash/peer4.sh
+++ b/test-network-nano-bash/peer4.sh
@@ -4,15 +4,21 @@
 #
 set -eu
 
-if [ "$(uname)" = "Linux" ] ; then
+if [ "$(uname)" = "Linux" ] || [  -d config ]
+then
   CCADDR="127.0.0.1"
 else
   CCADDR="host.docker.internal"
 fi
 
+if [  -d config  ] ; then
+  export FABRIC_CFG_PATH="${PWD}"/config
+else
+  export FABRIC_CFG_PATH="${PWD}"/../config
+fi
+
 # look for binaries in local dev environment /build/bin directory and then in local samples /bin directory
 export PATH="${PWD}"/../../fabric/build/bin:"${PWD}"/../bin:"$PATH"
-export FABRIC_CFG_PATH="${PWD}"/../config
 
 export FABRIC_LOGGING_SPEC=debug:cauthdsl,policies,msp,grpc,peer.gossip.mcs,gossip,leveldbhelper=info
 export CORE_PEER_TLS_ENABLED=true


### PR DESCRIPTION
…ano-bash

The external builders will build and launch binary chaincode instead of docker containers.