### PR TITLE
Use only v2.2.x chaincode package dependencies (release-2.2)

### DIFF
--- a/asset-transfer-basic/chaincode-javascript/package.json
+++ b/asset-transfer-basic/chaincode-javascript/package.json
@@ -17,8 +17,8 @@
     "author": "Hyperledger",
     "license": "Apache-2.0",
     "dependencies": {
-        "fabric-contract-api": "^2.0.0",
-        "fabric-shim": "^2.0.0"
+        "fabric-contract-api": "~2.2",
+        "fabric-shim": "~2.2"
     },
     "devDependencies": {
         "chai": "^4.1.2",

--- a/asset-transfer-basic/chaincode-typescript/package.json
+++ b/asset-transfer-basic/chaincode-typescript/package.json
@@ -21,8 +21,8 @@
     "author": "Hyperledger",
     "license": "Apache-2.0",
     "dependencies": {
-        "fabric-contract-api": "^2.0.0",
-        "fabric-shim": "^2.0.0"
+        "fabric-contract-api": "~2.2",
+        "fabric-shim": "~2.2"
     },
     "devDependencies": {
         "@types/chai": "^4.1.7",

--- a/asset-transfer-events/chaincode-javascript/package.json
+++ b/asset-transfer-events/chaincode-javascript/package.json
@@ -17,8 +17,8 @@
     "author": "Hyperledger",
     "license": "Apache-2.0",
     "dependencies": {
-        "fabric-contract-api": "^2.0.0",
-        "fabric-shim": "^2.0.0"
+        "fabric-contract-api": "~2.2",
+        "fabric-shim": "~2.2"
     },
     "devDependencies": {
         "chai": "^4.1.2",

--- a/asset-transfer-ledger-queries/chaincode-javascript/package.json
+++ b/asset-transfer-ledger-queries/chaincode-javascript/package.json
@@ -13,7 +13,7 @@
 	"engine-strict": true,
 	"license": "Apache-2.0",
 	"dependencies": {
-		"fabric-contract-api": "^2.0.0",
-		"fabric-shim": "^2.0.0"
+		"fabric-contract-api": "~2.2",
+		"fabric-shim": "~2.2"
 	}
 }

--- a/asset-transfer-sbe/chaincode-typescript/package.json
+++ b/asset-transfer-sbe/chaincode-typescript/package.json
@@ -21,8 +21,8 @@
   "author": "Hyperledger",
   "license": "Apache-2.0",
   "dependencies": {
-    "fabric-contract-api": "^2.0.0",
-    "fabric-shim": "^2.0.0"
+    "fabric-contract-api": "~2.2",
+    "fabric-shim": "~2.2"
   },
   "devDependencies": {
     "@types/chai": "^4.2.11",

--- a/chaincode/abstore/javascript/package.json
+++ b/chaincode/abstore/javascript/package.json
@@ -12,6 +12,6 @@
 	"engine-strict": true,
 	"license": "Apache-2.0",
 	"dependencies": {
-		"fabric-shim": "^2.0.0"
+		"fabric-shim": "~2.2"
 	}
 }

--- a/chaincode/fabcar/javascript/package.json
+++ b/chaincode/fabcar/javascript/package.json
@@ -17,8 +17,8 @@
     "author": "Hyperledger",
     "license": "Apache-2.0",
     "dependencies": {
-        "fabric-contract-api": "^2.0.0",
-        "fabric-shim": "^2.0.0"
+        "fabric-contract-api": "~2.2",
+        "fabric-shim": "~2.2"
     },
     "devDependencies": {
         "chai": "^4.1.2",

--- a/chaincode/fabcar/typescript/package.json
+++ b/chaincode/fabcar/typescript/package.json
@@ -21,8 +21,8 @@
     "author": "Hyperledger",
     "license": "Apache-2.0",
     "dependencies": {
-        "fabric-contract-api": "^2.0.0",
-        "fabric-shim": "^2.0.0"
+        "fabric-contract-api": "~2.2",
+        "fabric-shim": "~2.2"
     },
     "devDependencies": {
         "@types/chai": "^4.1.7",

--- a/chaincode/marbles02/javascript/package.json
+++ b/chaincode/marbles02/javascript/package.json
@@ -12,6 +12,6 @@
 	"engine-strict": true,
 	"license": "Apache-2.0",
 	"dependencies": {
-		"fabric-shim": "^2.0.0"
+		"fabric-shim": "~2.2"
 	}
 }

--- a/commercial-paper/organization/digibank/contract/package.json
+++ b/commercial-paper/organization/digibank/contract/package.json
@@ -18,8 +18,8 @@
     "author": "hyperledger",
     "license": "Apache-2.0",
     "dependencies": {
-        "fabric-contract-api": "^2.0.0",
-        "fabric-shim": "^2.0.0"
+        "fabric-contract-api": "~2.2",
+        "fabric-shim": "~2.2"
     },
     "devDependencies": {
         "chai": "^4.1.2",

--- a/commercial-paper/organization/magnetocorp/contract/package.json
+++ b/commercial-paper/organization/magnetocorp/contract/package.json
@@ -18,8 +18,8 @@
     "author": "hyperledger",
     "license": "Apache-2.0",
     "dependencies": {
-        "fabric-contract-api": "^2.0.0",
-        "fabric-shim": "^2.0.0"
+        "fabric-contract-api": "~2.2",
+        "fabric-shim": "~2.2"
     },
     "devDependencies": {
         "chai": "^4.1.2",

--- a/token-erc-20/chaincode-javascript/package.json
+++ b/token-erc-20/chaincode-javascript/package.json
@@ -18,8 +18,8 @@
     "author": "Hyperledger",
     "license": "Apache-2.0",
     "dependencies": {
-        "fabric-contract-api": "^2.0.0",
-        "fabric-shim": "^2.0.0"
+        "fabric-contract-api": "~2.2",
+        "fabric-shim": "~2.2"
     },
     "devDependencies": {
         "chai": "^4.1.2",


### PR DESCRIPTION
Avoid chaincode packages picking up dependencies on later v2.x releases, such as v2.5.x. Later releases may exploit features not compatible with the v2.2 chaincode container runtime.