### PR TITLE
test-network-k8s: Improve prereqs logic

### DIFF
--- a/test-network-k8s/scripts/prereqs.sh
+++ b/test-network-k8s/scripts/prereqs.sh
@@ -42,17 +42,41 @@ function check_prereqs() {
     exit 1
   fi
 
-  # Use the local fabric binaries if available.  If not, go get them.
+  # Define the sed expression to extract the version number
+  VERSION_SED_EXPR='s/^ Version: v\?\(.*\)$/\1/p'
+
+  # Use the fabric peer and ca containers to check fabric image versions
+  # NOTE: About extracting the version number:
+  # In older versions, the prefix 'v' was not included in the version string,
+  # but in recent versions, 'v' has been added.
+  # The following commands remove the optional 'v' to standardize the format.
+  FABRIC_IMAGE_VERSION=$(${CONTAINER_CLI} run --rm ${FABRIC_PEER_IMAGE} peer version | sed -ne "$VERSION_SED_EXPR")
+  FABRIC_CA_IMAGE_VERSION=$(${CONTAINER_CLI} run --rm ${FABRIC_CONTAINER_REGISTRY}/fabric-ca:$FABRIC_CA_VERSION fabric-ca-server version | sed -ne "$VERSION_SED_EXPR")
+  echo "Fabric image versions: Peer ($FABRIC_IMAGE_VERSION), CA ($FABRIC_CA_IMAGE_VERSION)"
+  if [ -z "$FABRIC_IMAGE_VERSION" ] || [ -z "$FABRIC_CA_IMAGE_VERSION" ]; then
+    echo "It seems some of the specified Fabric images are not available."
+    exit 1
+  fi
+
+  # Use the local fabric binaries if available. If not, go get them.
   bin/peer version &> /dev/null
   if [[ $? -ne 0 ]]; then
-    echo "Downloading LATEST Fabric binaries and config"
-    curl -sSL https://raw.githubusercontent.com/hyperledger/fabric/main/scripts/bootstrap.sh \
-      | bash -s -- -s -d
+    echo "Downloading Fabric binaries and config"
+    curl -sSL https://raw.githubusercontent.com/hyperledger/fabric/main/scripts/install-fabric.sh \
+      | bash -s -- -f ${FABRIC_IMAGE_VERSION} -c ${FABRIC_CA_IMAGE_VERSION} binary
 
     # remove sample config files extracted by the installation script
     rm config/configtx.yaml
     rm config/core.yaml
     rm config/orderer.yaml
+  fi
+
+  # Check if the binaries match your docker images
+  FABRIC_LOCAL_VERSION=$(bin/peer version | sed -ne "$VERSION_SED_EXPR")
+  FABRIC_CA_LOCAL_VERSION=$(bin/fabric-ca-client version | sed -ne "$VERSION_SED_EXPR")
+    echo "Fabric binary versions: Peer ($FABRIC_LOCAL_VERSION), CA ($FABRIC_CA_LOCAL_VERSION)"
+  if [ "$FABRIC_LOCAL_VERSION" != "$FABRIC_IMAGE_VERSION" ] || [ "$FABRIC_CA_LOCAL_VERSION" != "$FABRIC_CA_IMAGE_VERSION" ]; then
+    echo "WARN: Local fabric binaries and docker images are out of sync. This may cause problems."
   fi
 
   export PATH=bin:$PATH

--- a/test-network/network.sh
+++ b/test-network/network.sh
@@ -79,7 +79,7 @@ function checkPrereqs() {
   infoln "DOCKER_IMAGE_VERSION=$DOCKER_IMAGE_VERSION"
 
   if [ "$LOCAL_VERSION" != "$DOCKER_IMAGE_VERSION" ]; then
-    warnln "Local fabric binaries and docker images are out of  sync. This may cause problems."
+    warnln "Local fabric binaries and docker images are out of sync. This may cause problems."
   fi
 
   for UNSUPPORTED_VERSION in $NONWORKING_VERSIONS; do


### PR DESCRIPTION
It seems that PR #1205 has stalled, so I have created a new PR that builds upon the considerations from that one while addressing the issues raised. 

This PR resolves issue #1204 and also addresses the concerns mentioned in PR #1205. Specifically, it:
- Uses the newer install script instead of bootstrap.sh.
- Downloads binaries corresponding to the image versions, supporting both two-digit and three-digit Fabric version specifications.

Related issue:
Resolves #1204