### PR TITLE
Fix the default chaincode version to "1.0" in test-network

### DIFF
--- a/test-network/network.config
+++ b/test-network/network.config
@@ -26,7 +26,7 @@ ORG=1
 CC_SRC_LANGUAGE="go"
 
 # Chaincode version (-ccv)
-CC_VERSION="1.0.1"
+CC_VERSION="1.0"
 
 # chaincode name defaults to "NA" (-ccn)
 CC_NAME="basic"

--- a/test-network/scripts/packageCC.sh
+++ b/test-network/scripts/packageCC.sh
@@ -20,15 +20,15 @@ FABRIC_CFG_PATH=$PWD/../config/
 
 #User has not provided a name
 if [ -z "$CC_NAME" ] || [ "$CC_NAME" = "NA" ]; then
-  fatalln "No chaincode name was provided. Valid call example: ./network.sh packageCC -ccn basic -ccp chaincode/asset-transfer-basic/chaincode-go -ccv 1.0.0 -ccl go"
+  fatalln "No chaincode name was provided. Valid call example: ./network.sh packageCC -ccn basic -ccp chaincode/asset-transfer-basic/chaincode-go -ccv 1.0 -ccl go"
 
 # User has not provided a path
 elif [ -z "$CC_SRC_PATH" ] || [ "$CC_SRC_PATH" = "NA" ]; then
-  fatalln "No chaincode path was provided. Valid call example: ./network.sh packageCC -ccn basic -ccp chaincode/asset-transfer-basic/chaincode-go -ccv 1.0.0 -ccl go"
+  fatalln "No chaincode path was provided. Valid call example: ./network.sh packageCC -ccn basic -ccp chaincode/asset-transfer-basic/chaincode-go -ccv 1.0 -ccl go"
 
 # User has not provided a language
 elif [ -z "$CC_SRC_LANGUAGE" ] || [ "$CC_SRC_LANGUAGE" = "NA" ]; then
-  fatalln "No chaincode language was provided. Valid call example: ./network.sh packageCC -ccn basic -ccp chaincode/asset-transfer-basic/chaincode-go -ccv 1.0.0 -ccl go"
+  fatalln "No chaincode language was provided. Valid call example: ./network.sh packageCC -ccn basic -ccp chaincode/asset-transfer-basic/chaincode-go -ccv 1.0 -ccl go"
 
 ## Make sure that the path to the chaincode exists
 elif [ ! -d "$CC_SRC_PATH" ]; then


### PR DESCRIPTION
This patch fixes the default chaincode version to "1.0" in test-network.
See [this discussion](https://github.com/hyperledger/fabric/pull/4770).