### PR TITLE
Bump ubuntu to 22.04 in CI

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -22,7 +22,7 @@ env:
 
 jobs:
   go:
-    runs-on: ${{ github.repository == 'hyperledger/fabric-samples' && 'fabric-ubuntu-20.04' || 'ubuntu-20.04' }}
+    runs-on: ${{ github.repository == 'hyperledger/fabric-samples' && 'fabric-ubuntu-22.04' || 'ubuntu-22.04' }}
     steps:
       - uses: actions/setup-go@v5
         with:
@@ -32,7 +32,7 @@ jobs:
       - run: ci/scripts/lint-go.sh
 
   typescript:
-    runs-on: ${{ github.repository == 'hyperledger/fabric-samples' && 'fabric-ubuntu-20.04' || 'ubuntu-20.04' }}
+    runs-on: ${{ github.repository == 'hyperledger/fabric-samples' && 'fabric-ubuntu-22.04' || 'ubuntu-22.04' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -41,7 +41,7 @@ jobs:
       - run: ci/scripts/lint-typescript.sh
 
   javascript:
-    runs-on: ${{ github.repository == 'hyperledger/fabric-samples' && 'fabric-ubuntu-20.04' || 'ubuntu-20.04' }}
+    runs-on: ${{ github.repository == 'hyperledger/fabric-samples' && 'fabric-ubuntu-22.04' || 'ubuntu-22.04' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -50,7 +50,7 @@ jobs:
       - run: ci/scripts/lint-javascript.sh
 
   java:
-    runs-on: ${{ github.repository == 'hyperledger/fabric-samples' && 'fabric-ubuntu-20.04' || 'ubuntu-20.04' }}
+    runs-on: ${{ github.repository == 'hyperledger/fabric-samples' && 'fabric-ubuntu-22.04' || 'ubuntu-22.04' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
@@ -60,7 +60,7 @@ jobs:
       - run: ci/scripts/lint-java.sh
 
   shell:
-    runs-on: ${{ github.repository == 'hyperledger/fabric-samples' && 'fabric-ubuntu-20.04' || 'ubuntu-20.04' }}
+    runs-on: ${{ github.repository == 'hyperledger/fabric-samples' && 'fabric-ubuntu-22.04' || 'ubuntu-22.04' }}
     steps:
       - uses: actions/checkout@v4
       - run: ci/scripts/lint-shell.sh

--- a/.github/workflows/rest-sample.yaml
+++ b/.github/workflows/rest-sample.yaml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   test-sample:
-    runs-on: ${{ github.repository == 'hyperledger/fabric-samples' && 'fabric-ubuntu-20.04' || 'ubuntu-20.04' }}
+    runs-on: ${{ github.repository == 'hyperledger/fabric-samples' && 'fabric-ubuntu-22.04' || 'ubuntu-22.04' }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/test-fsat.yaml
+++ b/.github/workflows/test-fsat.yaml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   ansible:
-    runs-on: ${{ github.repository == 'hyperledger/fabric-samples' && 'fabric-ubuntu-20.04' || 'ubuntu-20.04' }}
+    runs-on: ${{ github.repository == 'hyperledger/fabric-samples' && 'fabric-ubuntu-22.04' || 'ubuntu-22.04' }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up Full Stack Runtime
@@ -23,7 +23,7 @@ jobs:
         working-directory: full-stack-asset-transfer-guide
 
   appdev:
-    runs-on: ${{ github.repository == 'hyperledger/fabric-samples' && 'fabric-ubuntu-20.04' || 'ubuntu-20.04' }}
+    runs-on: ${{ github.repository == 'hyperledger/fabric-samples' && 'fabric-ubuntu-22.04' || 'ubuntu-22.04' }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up Full Stack Runtime
@@ -32,7 +32,7 @@ jobs:
         working-directory: full-stack-asset-transfer-guide
 
   chaincode:
-    runs-on: ${{ github.repository == 'hyperledger/fabric-samples' && 'fabric-ubuntu-20.04' || 'ubuntu-20.04' }}
+    runs-on: ${{ github.repository == 'hyperledger/fabric-samples' && 'fabric-ubuntu-22.04' || 'ubuntu-22.04' }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up Full Stack Runtime
@@ -41,7 +41,7 @@ jobs:
         working-directory: full-stack-asset-transfer-guide
 
   cloud:
-    runs-on: ${{ github.repository == 'hyperledger/fabric-samples' && 'fabric-ubuntu-20.04' || 'ubuntu-20.04' }}
+    runs-on: ${{ github.repository == 'hyperledger/fabric-samples' && 'fabric-ubuntu-22.04' || 'ubuntu-22.04' }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up Full Stack Runtime
@@ -50,7 +50,7 @@ jobs:
         working-directory: full-stack-asset-transfer-guide
 
   console:
-    runs-on: ${{ github.repository == 'hyperledger/fabric-samples' && 'fabric-ubuntu-20.04' || 'ubuntu-20.04' }}
+    runs-on: ${{ github.repository == 'hyperledger/fabric-samples' && 'fabric-ubuntu-22.04' || 'ubuntu-22.04' }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up Full Stack Runtime

--- a/.github/workflows/test-network-basic.yaml
+++ b/.github/workflows/test-network-basic.yaml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   basic:
-    runs-on: ${{ github.repository == 'hyperledger/fabric-samples' && 'fabric-ubuntu-20.04' || 'ubuntu-20.04' }}
+    runs-on: ${{ github.repository == 'hyperledger/fabric-samples' && 'fabric-ubuntu-22.04' || 'ubuntu-22.04' }}
     strategy:
       matrix:
         chaincode-language:

--- a/.github/workflows/test-network-events.yaml
+++ b/.github/workflows/test-network-events.yaml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   events:
-    runs-on: ${{ github.repository == 'hyperledger/fabric-samples' && 'fabric-ubuntu-20.04' || 'ubuntu-20.04' }}
+    runs-on: ${{ github.repository == 'hyperledger/fabric-samples' && 'fabric-ubuntu-22.04' || 'ubuntu-22.04' }}
     strategy:
       matrix:
         chaincode-language:

--- a/.github/workflows/test-network-hsm.yaml
+++ b/.github/workflows/test-network-hsm.yaml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   hsm:
-    runs-on: ${{ github.repository == 'hyperledger/fabric-samples' && 'fabric-ubuntu-20.04' || 'ubuntu-20.04' }}
+    runs-on: ${{ github.repository == 'hyperledger/fabric-samples' && 'fabric-ubuntu-22.04' || 'ubuntu-22.04' }}
     strategy:
       matrix:
         chaincode-language:

--- a/.github/workflows/test-network-k8s.yaml
+++ b/.github/workflows/test-network-k8s.yaml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   ccaas-java:
-    runs-on: ${{ github.repository == 'hyperledger/fabric-samples' && 'fabric-ubuntu-20.04' || 'ubuntu-20.04' }}
+    runs-on: ${{ github.repository == 'hyperledger/fabric-samples' && 'fabric-ubuntu-22.04' || 'ubuntu-22.04' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -29,7 +29,7 @@ jobs:
           CHAINCODE_LANGUAGE: java
 
   ccaas-external:
-    runs-on: ${{ github.repository == 'hyperledger/fabric-samples' && 'fabric-ubuntu-20.04' || 'ubuntu-20.04' }}
+    runs-on: ${{ github.repository == 'hyperledger/fabric-samples' && 'fabric-ubuntu-22.04' || 'ubuntu-22.04' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -41,7 +41,7 @@ jobs:
           CHAINCODE_LANGUAGE: external
 
   k8s-builder:
-    runs-on: ${{ github.repository == 'hyperledger/fabric-samples' && 'fabric-ubuntu-20.04' || 'ubuntu-20.04' }}
+    runs-on: ${{ github.repository == 'hyperledger/fabric-samples' && 'fabric-ubuntu-22.04' || 'ubuntu-22.04' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -54,7 +54,7 @@ jobs:
           CHAINCODE_BUILDER: k8s
 
   multi-namespace:
-    runs-on: ${{ github.repository == 'hyperledger/fabric-samples' && 'fabric-ubuntu-20.04' || 'ubuntu-20.04' }}
+    runs-on: ${{ github.repository == 'hyperledger/fabric-samples' && 'fabric-ubuntu-22.04' || 'ubuntu-22.04' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test-network-ledger.yaml
+++ b/.github/workflows/test-network-ledger.yaml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   basic:
-    runs-on: ${{ github.repository == 'hyperledger/fabric-samples' && 'fabric-ubuntu-20.04' || 'ubuntu-20.04' }}
+    runs-on: ${{ github.repository == 'hyperledger/fabric-samples' && 'fabric-ubuntu-22.04' || 'ubuntu-22.04' }}
     strategy:
       matrix:
         chaincode-language:

--- a/.github/workflows/test-network-off-chain.yaml
+++ b/.github/workflows/test-network-off-chain.yaml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   off-chain:
-    runs-on: ${{ github.repository == 'hyperledger/fabric-samples' && 'fabric-ubuntu-20.04' || 'ubuntu-20.04' }}
+    runs-on: ${{ github.repository == 'hyperledger/fabric-samples' && 'fabric-ubuntu-22.04' || 'ubuntu-22.04' }}
     strategy:
       matrix:
         chaincode-language:

--- a/.github/workflows/test-network-private.yaml
+++ b/.github/workflows/test-network-private.yaml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   private:
-    runs-on: ${{ github.repository == 'hyperledger/fabric-samples' && 'fabric-ubuntu-20.04' || 'ubuntu-20.04' }}
+    runs-on: ${{ github.repository == 'hyperledger/fabric-samples' && 'fabric-ubuntu-22.04' || 'ubuntu-22.04' }}
     strategy:
       matrix:
         chaincode-language:

--- a/.github/workflows/test-network-sbe.yaml
+++ b/.github/workflows/test-network-sbe.yaml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   SBE:
-    runs-on: ${{ github.repository == 'hyperledger/fabric-samples' && 'fabric-ubuntu-20.04' || 'ubuntu-20.04' }}
+    runs-on: ${{ github.repository == 'hyperledger/fabric-samples' && 'fabric-ubuntu-22.04' || 'ubuntu-22.04' }}
     strategy:
       matrix:
         chaincode-language:

--- a/.github/workflows/test-network-secured.yaml
+++ b/.github/workflows/test-network-secured.yaml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   secured:
-    runs-on: ${{ github.repository == 'hyperledger/fabric-samples' && 'fabric-ubuntu-20.04' || 'ubuntu-20.04' }}
+    runs-on: ${{ github.repository == 'hyperledger/fabric-samples' && 'fabric-ubuntu-22.04' || 'ubuntu-22.04' }}
     strategy:
       matrix:
         chaincode-language:

--- a/test-network-nano-bash/orderer1.sh
+++ b/test-network-nano-bash/orderer1.sh
@@ -27,7 +27,7 @@ then
         echo "Unsupported input consensus type ${1}"
         exit 1
     fi
-    export ORDERER_CONSENSUS_TYPE=${1}
+    export ORDERER_CONSENSUS_TYPE="${1}"
 fi
 export ORDERER_CONSENSUS_WALDIR="${PWD}"/data/orderer/consensus/wal
 export ORDERER_CONSENSUS_SNAPDIR="${PWD}"/data/orderer/consensus/snap

--- a/test-network-nano-bash/orderer2.sh
+++ b/test-network-nano-bash/orderer2.sh
@@ -27,7 +27,7 @@ then
         echo "Unsupported input consensus type ${1}"
         exit 1
     fi
-    export ORDERER_CONSENSUS_TYPE=${1}
+    export ORDERER_CONSENSUS_TYPE="${1}"
 fi
 export ORDERER_CONSENSUS_WALDIR="${PWD}"/data/orderer2/consensus/wal
 export ORDERER_CONSENSUS_SNAPDIR="${PWD}"/data/orderer2/consensus/snap

--- a/test-network-nano-bash/orderer3.sh
+++ b/test-network-nano-bash/orderer3.sh
@@ -27,7 +27,7 @@ then
         echo "Unsupported input consensus type ${1}"
         exit 1
     fi
-    export ORDERER_CONSENSUS_TYPE=${1}
+    export ORDERER_CONSENSUS_TYPE="${1}"
 fi
 export ORDERER_CONSENSUS_WALDIR="${PWD}"/data/orderer3/consensus/wal
 export ORDERER_CONSENSUS_SNAPDIR="${PWD}"/data/orderer3/consensus/snap

--- a/test-network-nano-bash/orderer4.sh
+++ b/test-network-nano-bash/orderer4.sh
@@ -27,7 +27,7 @@ then
         echo "Unsupported input consensus type ${1}"
         exit 1
     fi
-    export ORDERER_CONSENSUS_TYPE=${1}
+    export ORDERER_CONSENSUS_TYPE="${1}"
 fi
 export ORDERER_CONSENSUS_WALDIR="${PWD}"/data/orderer4/consensus/wal
 export ORDERER_CONSENSUS_SNAPDIR="${PWD}"/data/orderer4/consensus/snap


### PR DESCRIPTION
Since Fabric v3.0 builds on ubuntu 22.04,
it will be necessary for samples CI to run on ubuntu 22.04.

Both Fabric v2.5 components (ubuntu 20.04) and
Fabric v3.0 components (ubuntu 22.04) work on
ubuntu 22.04 runtime.

The update also requires shell script updates to pass linting.