### PR TITLE
Remove cli from podman compose file

### DIFF
--- a/test-network/compose/podman/podman-compose-test-net.yaml
+++ b/test-network/compose/podman/podman-compose-test-net.yaml
@@ -14,6 +14,3 @@ services:
     volumes:
       - ./podman/peercfg:/etc/hyperledger/peercfg
 
-  cli:
-    volumes:
-      - ./podman/peercfg:/etc/hyperledger/peercfg


### PR DESCRIPTION
I removed the `cli` entry from the `podman-compose-test-net.yaml` file.

This PR closes #1258.