### PR TITLE
Update test-network chaincode container versions

### DIFF
--- a/test-network/addOrg3/compose/docker/peercfg/core.yaml
+++ b/test-network/addOrg3/compose/docker/peercfg/core.yaml
@@ -573,11 +573,11 @@ chaincode:
         # tools added for java shim layer packaging.
         # This image is packed with shim layer libraries that are necessary
         # for Java chaincode runtime.
-        runtime: $(DOCKER_NS)/fabric-javaenv:$(TWO_DIGIT_VERSION)
+        runtime: $(DOCKER_NS)/fabric-javaenv:2.5
 
     node:
         # This is an image based on node:$(NODE_VER)-alpine
-        runtime: $(DOCKER_NS)/fabric-nodeenv:$(TWO_DIGIT_VERSION)
+        runtime: $(DOCKER_NS)/fabric-nodeenv:2.5
 
     # List of directories to treat as external builders and launchers for
     # chaincode. The external builder detection processing will iterate over the

--- a/test-network/addOrg3/compose/podman/peercfg/core.yaml
+++ b/test-network/addOrg3/compose/podman/peercfg/core.yaml
@@ -573,11 +573,11 @@ chaincode:
         # tools added for java shim layer packaging.
         # This image is packed with shim layer libraries that are necessary
         # for Java chaincode runtime.
-        runtime: $(DOCKER_NS)/fabric-javaenv:$(TWO_DIGIT_VERSION)
+        runtime: $(DOCKER_NS)/fabric-javaenv:2.5
 
     node:
         # This is an image based on node:$(NODE_VER)-alpine
-        runtime: $(DOCKER_NS)/fabric-nodeenv:$(TWO_DIGIT_VERSION)
+        runtime: $(DOCKER_NS)/fabric-nodeenv:2.5
 
     # List of directories to treat as external builders and launchers for
     # chaincode. The external builder detection processing will iterate over the

--- a/test-network/compose/docker/peercfg/core.yaml
+++ b/test-network/compose/docker/peercfg/core.yaml
@@ -573,11 +573,11 @@ chaincode:
         # tools added for java shim layer packaging.
         # This image is packed with shim layer libraries that are necessary
         # for Java chaincode runtime.
-        runtime: $(DOCKER_NS)/fabric-javaenv:$(TWO_DIGIT_VERSION)
+        runtime: $(DOCKER_NS)/fabric-javaenv:2.5
 
     node:
         # This is an image based on node:$(NODE_VER)-alpine
-        runtime: $(DOCKER_NS)/fabric-nodeenv:$(TWO_DIGIT_VERSION)
+        runtime: $(DOCKER_NS)/fabric-nodeenv:2.5
 
     # List of directories to treat as external builders and launchers for
     # chaincode. The external builder detection processing will iterate over the

--- a/test-network/compose/podman/peercfg/core.yaml
+++ b/test-network/compose/podman/peercfg/core.yaml
@@ -573,11 +573,11 @@ chaincode:
         # tools added for java shim layer packaging.
         # This image is packed with shim layer libraries that are necessary
         # for Java chaincode runtime.
-        runtime: $(DOCKER_NS)/fabric-javaenv:$(TWO_DIGIT_VERSION)
+        runtime: $(DOCKER_NS)/fabric-javaenv:2.5
 
     node:
         # This is an image based on node:$(NODE_VER)-alpine
-        runtime: $(DOCKER_NS)/fabric-nodeenv:$(TWO_DIGIT_VERSION)
+        runtime: $(DOCKER_NS)/fabric-nodeenv:2.5
 
     # List of directories to treat as external builders and launchers for
     # chaincode. The external builder detection processing will iterate over the


### PR DESCRIPTION
The test-network peer configuration specifies $(TWO_DIGIT_VERSION) as the tag for the Node and Java chaincode containers. For Fabric v3.0, this requests fabric-nodeenv:3.0 and fabric-javaenv:3.0 Docker images to host Node and Java chaincode respectively. These images do not exist, which causes deployment of Node and Java chaincode to fail when using Fabric v3.0. Fabric v3.0 continues to use fabric-nodeenv:2.5 and fabric-javaenv:2.5.

This change updates the test-network peer configuration to explicitly specify `2.5` as the Node and Java chaincode Docker image tags. This is (currently) the correct version for both Fabric v2.5 and Fabric v3.0.

Closes #1267 