### PR TITLE
Update chaincode container versions in k8s samples

### DIFF
--- a/full-stack-asset-transfer-guide/infrastructure/sample-network/config/core.yaml
+++ b/full-stack-asset-transfer-guide/infrastructure/sample-network/config/core.yaml
@@ -560,15 +560,15 @@ chaincode:
         dynamicLink: false
 
     java:
-        # This is an image based on java:openjdk-8 with addition compiler
+        # This is an image based on eclipse temurin with addition compiler
         # tools added for java shim layer packaging.
         # This image is packed with shim layer libraries that are necessary
         # for Java chaincode runtime.
-        runtime: $(DOCKER_NS)/fabric-javaenv:$(TWO_DIGIT_VERSION)
+        runtime: $(DOCKER_NS)/fabric-javaenv:2.5
 
     node:
         # This is an image based on node:$(NODE_VER)-alpine
-        runtime: $(DOCKER_NS)/fabric-nodeenv:$(TWO_DIGIT_VERSION)
+        runtime: $(DOCKER_NS)/fabric-nodeenv:2.5
 
     # List of directories to treat as external builders and launchers for
     # chaincode. The external builder detection processing will iterate over the

--- a/test-network-k8s/config/org1/core.yaml
+++ b/test-network-k8s/config/org1/core.yaml
@@ -544,15 +544,15 @@ chaincode:
         dynamicLink: false
 
     java:
-        # This is an image based on java:openjdk-8 with addition compiler
+        # This is an image based on eclipse temurin with addition compiler
         # tools added for java shim layer packaging.
         # This image is packed with shim layer libraries that are necessary
         # for Java chaincode runtime.
-        runtime: $(DOCKER_NS)/fabric-javaenv:$(TWO_DIGIT_VERSION)
+        runtime: $(DOCKER_NS)/fabric-javaenv:2.5
 
     node:
         # This is an image based on node:$(NODE_VER)-alpine
-        runtime: $(DOCKER_NS)/fabric-nodeenv:$(TWO_DIGIT_VERSION)
+        runtime: $(DOCKER_NS)/fabric-nodeenv:2.5
 
     # List of directories to treat as external builders and launchers for
     # chaincode. The external builder detection processing will iterate over the

--- a/test-network-k8s/config/org2/core.yaml
+++ b/test-network-k8s/config/org2/core.yaml
@@ -544,15 +544,15 @@ chaincode:
         dynamicLink: false
 
     java:
-        # This is an image based on java:openjdk-8 with addition compiler
+        # This is an image based on eclipse temurin with addition compiler
         # tools added for java shim layer packaging.
         # This image is packed with shim layer libraries that are necessary
         # for Java chaincode runtime.
-        runtime: $(DOCKER_NS)/fabric-javaenv:$(TWO_DIGIT_VERSION)
+        runtime: $(DOCKER_NS)/fabric-javaenv:2.5
 
     node:
         # This is an image based on node:$(NODE_VER)-alpine
-        runtime: $(DOCKER_NS)/fabric-nodeenv:$(TWO_DIGIT_VERSION)
+        runtime: $(DOCKER_NS)/fabric-nodeenv:2.5
 
     # List of directories to treat as external builders and launchers for
     # chaincode. The external builder detection processing will iterate over the


### PR DESCRIPTION
This patch updates chaincode container versions to 2.5 in the following samples:
- test-network-k8s
- full-stack-asset-transfer-guide

## Related Issues/PRs
- https://github.com/hyperledger/fabric-samples/issues/1267
- https://github.com/hyperledger/fabric-samples/pull/1266