### PR TITLE
Update maintainers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -5,11 +5,8 @@ fabric-samples uses a non-author code review policy, requiring a single approval
 
 | Name                      | GitHub           | Discord ID       | email                               |
 |---------------------------|------------------|------------------|-------------------------------------|
-| Arnaud Le Hors            | lehors           | Arnaud J Le Hors | lehors@us.ibm.com                   |
 | Dave Enyeart              | denyeart         | Dave Enyeart     | enyeart@us.ibm.com                  |
-| Josh Kneubuhl             | jkneubuh         | jkneubuhl        | jkneubuh@us.ibm.com                 |
-| Matthew B White           | mbwhite          | mbwhite          | whitemat@uk.ibm.com                 |
-| Nikhil Gupta              | nikhil550        | negupta          | nikhilg550@gmail.com                |
+| Mark Lewis                | bestbeforetoday  | bestbeforetoday  | Mark.S.Lewis@outlook.com            |
 | Tatsuya Sato              | satota2          | satota2          | tatsuya.sato.so@hitachi.com         |
 
 Also: Please see the [Release Manager section](https://github.com/hyperledger/fabric/blob/main/MAINTAINERS.md)


### PR DESCRIPTION
Update maintainers to reflect activty from the past year.
- Retire Josh Kneubuhl, Matthew White, Arnaud Le Hors, Nikhil Gupta.
- Add Mark Lewis