### PR TITLE
Fix build with new microfab release

### DIFF
--- a/full-stack-asset-transfer-guide/justfile
+++ b/full-stack-asset-transfer-guide/justfile
@@ -168,15 +168,16 @@ microfab: microfab-down
             }
 
         ],
-        "capability_level":"V2_0"
+        "capability_level":"V2_5"
     }'
 
     mkdir -p $CFG
     echo
     echo "Stating microfab...."
 
-    docker run --name microfab -p 8080:8080 --add-host host.docker.internal:host-gateway --rm -d -e MICROFAB_CONFIG="${MICROFAB_CONFIG}" ghcr.io/hyperledger-labs/microfab:latest
-    sleep 5
+    timeout 60s bash -c \
+        'docker run --name microfab -p 8080:8080 --add-host host.docker.internal:host-gateway --rm -d -e MICROFAB_CONFIG="${MICROFAB_CONFIG}" ghcr.io/hyperledger-labs/microfab:latest \
+        && docker logs -f microfab | grep --max-count=1 "Microfab started"'
 
     curl -s http://console.127-0-0-1.nip.io:8080/ak/api/v1/components | weft microfab -w $CFG/_wallets -p $CFG/_gateways -m $CFG/_msp -f
     cat << EOF > $CFG/org1admin.env

--- a/full-stack-asset-transfer-guide/tests/10-appdev-e2e.sh
+++ b/full-stack-asset-transfer-guide/tests/10-appdev-e2e.sh
@@ -36,7 +36,7 @@ source "${WORKSHOP_PATH}/_cfg/uf/org1admin.env"
 cd "${WORKSHOP_PATH}/contracts/asset-transfer-typescript"
 npm install
 npm run build
-npm run start:server-nontls &
+node_modules/.bin/fabric-chaincode-node server --chaincode-address="${CHAINCODE_SERVER_ADDRESS}" --chaincode-id="${CHAINCODE_ID}" &
 CHAINCODE_PID=$!
 
 sleep 5


### PR DESCRIPTION
The new microfab release seems to start slower than the previous release. This might be due to a change from solo to raft consensus. This causes failures in the full-stack-asset-transfer appdev tests. Chaincode deployment fails since the channel is not yet available.

Instead of increasing the sleep time after launching microfab, this change attempts to wait however long is required by looking for the "Microfab started" message in the container log before proceeding.

The test script is also updated to correctly stop the external chaincode process when the script exits. Previously the process ID of the npm command used to lauch the chaincode was captured rather than the actual chaincode process.