### PR TITLE
make version regex posix compliant so that it works on mac

### DIFF
--- a/test-network-k8s/scripts/prereqs.sh
+++ b/test-network-k8s/scripts/prereqs.sh
@@ -43,7 +43,7 @@ function check_prereqs() {
   fi
 
   # Define the sed expression to extract the version number
-  VERSION_SED_EXPR='s/^ Version: v\?\(.*\)$/\1/p'
+  VERSION_SED_EXPR='s/^ Version: v\{0,1\}\(.*\)$/\1/p'
 
   # Use the fabric peer and ca containers to check fabric image versions
   # NOTE: About extracting the version number:


### PR DESCRIPTION
The kubernetes network does not start correctly on Mac due to a different interpretation of the regex by sed.

```bash
./test-network-k8s/network 
Fabric image versions: Peer (), CA ()
It seems some of the specified Fabric images are not available.
```

Examples for testing the fix:

```bash
# current: returns empty line on mac
docker run --rm hyperledger/fabric-peer:2.5 peer version | sed -ne 's/^ Version: v\?\(.*\)$/\1/p'

# now: works when executed in the linux OS of the container
docker run --rm hyperledger/fabric-peer:2.5 bash -c "peer version | sed -ne 's/^ Version: v\{0,1\}\(.*\)$/\1/p'"
2.5.9

# works on mac
docker run --rm hyperledger/fabric-peer:2.5 peer version | sed -ne 's/^ Version: v\{0,1\}\(.*\)$/\1/p'
2.5.9

# works without a 'v'
docker run --rm hyperledger/fabric-peer:2.5 bash -c "echo ' Version: 2.5.9' | sed -ne 's/^ Version: v\{0,1\}\(.*\)$/\1/p'"
2.5.9
```