### PR TITLE
Generate crypto using CA for BFT consensus fix

### DIFF
--- a/test-network-nano-bash/bft-config/configtx.yaml
+++ b/test-network-nano-bash/bft-config/configtx.yaml
@@ -287,28 +287,28 @@ Profiles:
           Host: 127.0.0.1
           Port: 6050
           MSPID: OrdererMSP
-          Identity: ../crypto-config/ordererOrganizations/example.com/orderers/orderer.example.com/msp/signcerts/orderer.example.com-cert.pem
+          Identity: ../crypto-config/ordererOrganizations/example.com/orderers/orderer.example.com/msp/signcerts/cert.pem
           ClientTLSCert: ../crypto-config/ordererOrganizations/example.com/orderers/orderer.example.com/tls/server.crt
           ServerTLSCert: ../crypto-config/ordererOrganizations/example.com/orderers/orderer.example.com/tls/server.crt
         - ID: 2
           Host: 127.0.0.1
           Port: 6051
           MSPID: OrdererMSP
-          Identity: ../crypto-config/ordererOrganizations/example.com/orderers/orderer2.example.com/msp/signcerts/orderer2.example.com-cert.pem
+          Identity: ../crypto-config/ordererOrganizations/example.com/orderers/orderer2.example.com/msp/signcerts/cert.pem
           ClientTLSCert: ../crypto-config/ordererOrganizations/example.com/orderers/orderer2.example.com/tls/server.crt
           ServerTLSCert: ../crypto-config/ordererOrganizations/example.com/orderers/orderer2.example.com/tls/server.crt
         - ID: 3
           Host: 127.0.0.1
           Port: 6052
           MSPID: OrdererMSP
-          Identity: ../crypto-config/ordererOrganizations/example.com/orderers/orderer3.example.com/msp/signcerts/orderer3.example.com-cert.pem
+          Identity: ../crypto-config/ordererOrganizations/example.com/orderers/orderer3.example.com/msp/signcerts/cert.pem
           ClientTLSCert: ../crypto-config/ordererOrganizations/example.com/orderers/orderer3.example.com/tls/server.crt
           ServerTLSCert: ../crypto-config/ordererOrganizations/example.com/orderers/orderer3.example.com/tls/server.crt
         - ID: 4
           Host: 127.0.0.1
           Port: 6053
           MSPID: OrdererMSP
-          Identity: ../crypto-config/ordererOrganizations/example.com/orderers/orderer4.example.com/msp/signcerts/orderer4.example.com-cert.pem
+          Identity: ../crypto-config/ordererOrganizations/example.com/orderers/orderer4.example.com/msp/signcerts/cert.pem
           ClientTLSCert: ../crypto-config/ordererOrganizations/example.com/orderers/orderer4.example.com/tls/server.crt
           ServerTLSCert: ../crypto-config/ordererOrganizations/example.com/orderers/orderer4.example.com/tls/server.crt
     Application:

--- a/test-network-nano-bash/ca/createEnrollments.sh
+++ b/test-network-nano-bash/ca/createEnrollments.sh
@@ -76,7 +76,7 @@ registerAndEnroll "5052" "orderer2" "orderer2pw" "orderer" "" "${orderer2_dir}" 
 registerAndEnroll "5052" "orderer3" "orderer3pw" "orderer" "" "${orderer3_dir}" "${orderer_org_dir}" "${orderer_org_tls}"
 
 # Create enrollment and TLS certificates for orderer4
-registerAndEnroll "5052" "orderer4" "orderer4pw" "orderer" "" "${orderer4_dir}" "${orderer_org}" "${orderer_org_tls}"
+registerAndEnroll "5052" "orderer4" "orderer4pw" "orderer" "" "${orderer4_dir}" "${orderer_org_dir}" "${orderer_org_tls}"
 
 # Create enrollment and TLS certificates for orderer5
 registerAndEnroll "5052" "orderer5" "orderer5pw" "orderer" "" "${orderer5_dir}" "${orderer_org_dir}" "${orderer_org_tls}"


### PR DESCRIPTION
**Bug Description:**
Encountered an issue in fabric-samples version 3.0 where deployment of ordering org with BFT consensus is providing error at generating artifacts step using CA.

**Steps to Reproduce:**
Run generate_artifacts.sh script with arguments included like ./generate_artifacts -o BFT -ca

**Expected Behavior:**
It should generate crypto-config and channel-artifacts required for the deployment.

**Environment:**
fabric-samples version: 3.0
Hyperledger Fabric version: 3.0
OS: Ubuntu 22.04

**Changes done to fix it:**
Make below changes,
1) ca/createEnrollments.sh -> Updated line 79 from

registerAndEnroll "5052" "orderer4" "orderer4pw" "orderer" "" "${orderer4_dir}" "${orderer_org}" "${orderer_org_tls}"
to
registerAndEnroll "5052" "orderer4" "orderer4pw" "orderer" "" "${orderer4_dir}" "${orderer_org_dir}" "${orderer_org_tls}"


2) Updated below Identity field in all 4 orderers in bft-config/configtx.yaml 

from

Identity: ../crypto-config/ordererOrganizations/example.com/orderers/orderer.example.com/msp/signcerts/orderer.example.com-cert.pem
to
Identity: ../crypto-config/ordererOrganizations/example.com/orderers/orderer.example.com/msp/signcerts/cert.pem