### PR TITLE
test-network-k8s: Introduce initial support for BFT orderers

### DIFF
--- a/test-network-k8s/config/org0/bft/configtx-template.yaml
+++ b/test-network-k8s/config/org0/bft/configtx-template.yaml
@@ -45,6 +45,7 @@ Organizations:
       - org0-orderer1.${ORG0_NS}.svc.cluster.local:6050
       - org0-orderer2.${ORG0_NS}.svc.cluster.local:6050
       - org0-orderer3.${ORG0_NS}.svc.cluster.local:6050
+      - org0-orderer4.${ORG0_NS}.svc.cluster.local:6050
 
   - &Org1
     # DefaultOrg defines the organization which is used in the sampleconfig
@@ -139,13 +140,13 @@ Capabilities:
   # supported by both.
   # Set the value of the capability to true to require it.
   Channel: &ChannelCapabilities
-    # V2_0 capability ensures that orderers and peers behave according
-    # to v2.0 channel capabilities. Orderers and peers from
-    # prior releases would behave in an incompatible way, and are therefore
-    # not able to participate in channels at v2.0 capability.
-    # Prior to enabling V2.0 channel capabilities, ensure that all
-    # orderers and peers on a channel are at v2.0.0 or later.
-    V2_0: true
+    # V3.0 for Channel is a catchall flag for behavior which has been
+    # determined to be desired for all orderers and peers running at the v3.0.0
+    # level, but which would be incompatible with orderers and peers from
+    # prior releases.
+    # Prior to enabling V3.0 channel capabilities, ensure that all
+    # orderers and peers on a channel are at v3.0.0 or later.
+    V3_0: true
 
   # Orderer capabilities apply only to the orderers, and may be safely
   # used with prior release peers.
@@ -216,54 +217,6 @@ Application: &ApplicationDefaults
 #
 ################################################################################
 Orderer: &OrdererDefaults
-
-  # Orderer Type: The orderer implementation to start
-  OrdererType: etcdraft
-
-  EtcdRaft:
-    Consenters:
-      - Host: org0-orderer1
-        Port: 6050
-        ClientTLSCert: ./channel-msp/ordererOrganizations/org0/orderers/org0-orderer1/tls/signcerts/tls-cert.pem
-        ServerTLSCert: ./channel-msp/ordererOrganizations/org0/orderers/org0-orderer1/tls/signcerts/tls-cert.pem
-      - Host: org0-orderer2
-        Port: 6050
-        ClientTLSCert: ./channel-msp/ordererOrganizations/org0/orderers/org0-orderer2/tls/signcerts/tls-cert.pem
-        ServerTLSCert: ./channel-msp/ordererOrganizations/org0/orderers/org0-orderer2/tls/signcerts/tls-cert.pem
-      - Host: org0-orderer3
-        Port: 6050
-        ClientTLSCert: ./channel-msp/ordererOrganizations/org0/orderers/org0-orderer3/tls/signcerts/tls-cert.pem
-        ServerTLSCert: ./channel-msp/ordererOrganizations/org0/orderers/org0-orderer3/tls/signcerts/tls-cert.pem
-
-
-    # Options to be specified for all the etcd/raft nodes. The values here
-    # are the defaults for all new channels and can be modified on a
-    # per-channel basis via configuration updates.
-    Options:
-      # TickInterval is the time interval between two Node.Tick invocations.
-      #TickInterval: 500ms default
-      TickInterval: 2500ms
-
-      # ElectionTick is the number of Node.Tick invocations that must pass
-      # between elections. That is, if a follower does not receive any
-      # message from the leader of current term before ElectionTick has
-      # elapsed, it will become candidate and start an election.
-      # ElectionTick must be greater than HeartbeatTick.
-      # ElectionTick: 10 default
-      ElectionTick: 5
-
-      # HeartbeatTick is the number of Node.Tick invocations that must
-      # pass between heartbeats. That is, a leader sends heartbeat
-      # messages to maintain its leadership every HeartbeatTick ticks.
-      HeartbeatTick: 1
-
-      # MaxInflightBlocks limits the max number of in-flight append messages
-      # during optimistic replication phase.
-      MaxInflightBlocks: 5
-
-      # SnapshotIntervalSize defines number of bytes per which a snapshot is taken
-      SnapshotIntervalSize: 16 MB
-
   # Batch Timeout: The amount of time to wait before creating a batch
   BatchTimeout: 2s
 
@@ -346,70 +299,60 @@ Channel: &ChannelDefaults
 #
 ################################################################################
 Profiles:
-
-  # test network profile with application (not system) channel.
-  TwoOrgsApplicationGenesis:
+  ChannelUsingBFT:
     <<: *ChannelDefaults
     Orderer:
       <<: *OrdererDefaults
       Organizations:
         - *OrdererOrg
       Capabilities: *OrdererCapabilities
+      OrdererType: BFT
+      SmartBFT:
+        RequestBatchMaxCount: 100
+        RequestBatchMaxInterval: 50ms
+        RequestForwardTimeout: 2s
+        RequestComplainTimeout: 20s
+        RequestAutoRemoveTimeout: 3m0s
+        ViewChangeResendInterval: 5s
+        ViewChangeTimeout: 20s
+        LeaderHeartbeatTimeout: 1m0s
+        CollectTimeout: 1s
+        RequestBatchMaxBytes: 10485760
+        IncomingMessageBufferSize: 200
+        RequestPoolSize: 100000
+        LeaderHeartbeatCount: 10
+      ConsenterMapping:
+        - ID: 1
+          Host: org0-orderer1
+          Port: 6050
+          MSPID: OrdererMSP
+          Identity: ./channel-msp/ordererOrganizations/org0/orderers/org0-orderer1/cert.pem
+          ClientTLSCert: ./channel-msp/ordererOrganizations/org0/orderers/org0-orderer1/tls/signcerts/tls-cert.pem
+          ServerTLSCert: ./channel-msp/ordererOrganizations/org0/orderers/org0-orderer1/tls/signcerts/tls-cert.pem
+        - ID: 2
+          Host: org0-orderer2
+          Port: 6050
+          MSPID: OrdererMSP
+          Identity: ./channel-msp/ordererOrganizations/org0/orderers/org0-orderer2/cert.pem
+          ClientTLSCert: ./channel-msp/ordererOrganizations/org0/orderers/org0-orderer2/tls/signcerts/tls-cert.pem
+          ServerTLSCert: ./channel-msp/ordererOrganizations/org0/orderers/org0-orderer2/tls/signcerts/tls-cert.pem
+        - ID: 3
+          Host: org0-orderer3
+          Port: 6050
+          MSPID: OrdererMSP
+          Identity: ./channel-msp/ordererOrganizations/org0/orderers/org0-orderer3/cert.pem
+          ClientTLSCert: ./channel-msp/ordererOrganizations/org0/orderers/org0-orderer3/tls/signcerts/tls-cert.pem
+          ServerTLSCert: ./channel-msp/ordererOrganizations/org0/orderers/org0-orderer3/tls/signcerts/tls-cert.pem
+        - ID: 4
+          Host: org0-orderer4
+          Port: 6050
+          MSPID: OrdererMSP
+          Identity: ./channel-msp/ordererOrganizations/org0/orderers/org0-orderer4/cert.pem
+          ClientTLSCert: ./channel-msp/ordererOrganizations/org0/orderers/org0-orderer4/tls/signcerts/tls-cert.pem
+          ServerTLSCert: ./channel-msp/ordererOrganizations/org0/orderers/org0-orderer4/tls/signcerts/tls-cert.pem
     Application:
       <<: *ApplicationDefaults
       Organizations:
         - *Org1
         - *Org2
       Capabilities: *ApplicationCapabilities
-
-
-  #
-  # Unclear lineage for these profiles:  nano-fab?
-  #
-  # TwoOrgsOrdererGenesis will construct a system channel as it has a Consortiums stanza, which is not
-  # compatible with osnadmin.
-  #
-  # @enyeart - which profile should be used for the kube test network?
-  #
-  TwoOrgsOrdererGenesis:
-    <<: *ChannelDefaults
-    Orderer:
-      <<: *OrdererDefaults
-      OrdererType: etcdraft
-      Organizations:
-        - *OrdererOrg
-      Capabilities:
-        <<: *OrdererCapabilities
-    Consortiums:
-      SampleConsortium:
-        Organizations:
-          - *Org1
-          - *Org2
-  TwoOrgsChannel:
-    Consortium: SampleConsortium
-    <<: *ChannelDefaults
-    Application:
-      <<: *ApplicationDefaults
-      Organizations:
-        - *Org1
-        - *Org2
-      Capabilities:
-        <<: *ApplicationCapabilities
-  Org1Channel:
-    Consortium: SampleConsortium
-    <<: *ChannelDefaults
-    Application:
-      <<: *ApplicationDefaults
-      Organizations:
-        - *Org1
-      Capabilities:
-        <<: *ApplicationCapabilities
-  Org2Channel:
-    Consortium: SampleConsortium
-    <<: *ChannelDefaults
-    Application:
-      <<: *ApplicationDefaults
-      Organizations:
-        - *Org2
-      Capabilities:
-        <<: *ApplicationCapabilities

--- a/test-network-k8s/kube/org0/org0-orderer4.yaml
+++ b/test-network-k8s/kube/org0/org0-orderer4.yaml
@@ -1,0 +1,160 @@
+#
+# Copyright IBM Corp. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: org0-orderer4-tls-cert
+  namespace: ${ORG0_NS}
+spec:
+  isCA: false
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  dnsNames:
+    - localhost
+    - org0-orderer4
+    - org0-orderer4.${ORG0_NS}.svc.cluster.local
+    - org0-orderer4.${DOMAIN}
+    - org0-orderer4-admin.${DOMAIN}
+  ipAddresses:
+    - 127.0.0.1
+  secretName: org0-orderer4-tls-cert
+  issuerRef:
+    name: org0-tls-cert-issuer
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: org0-orderer4-env
+data:
+  FABRIC_CFG_PATH: /var/hyperledger/fabric/config
+  FABRIC_LOGGING_SPEC: INFO # debug:cauthdsl,policies,msp,common.configtx,common.channelconfig=info
+  ORDERER_GENERAL_LISTENADDRESS: 0.0.0.0
+  ORDERER_GENERAL_LISTENPORT: "6050"
+  ORDERER_GENERAL_LOCALMSPID: OrdererMSP
+  ORDERER_GENERAL_LOCALMSPDIR: /var/hyperledger/fabric/organizations/ordererOrganizations/org0.example.com/orderers/org0-orderer4.org0.example.com/msp
+  ORDERER_GENERAL_TLS_ENABLED: "true"
+  ORDERER_GENERAL_TLS_CERTIFICATE: /var/hyperledger/fabric/config/tls/tls.crt
+  ORDERER_GENERAL_TLS_ROOTCAS: /var/hyperledger/fabric/config/tls/ca.crt
+  ORDERER_GENERAL_TLS_PRIVATEKEY: /var/hyperledger/fabric/config/tls/tls.key
+  ORDERER_GENERAL_BOOTSTRAPMETHOD: none
+  ORDERER_CHANNELPARTICIPATION_ENABLED: "true"
+  ORDERER_ADMIN_TLS_ENABLED: "true"
+  ORDERER_ADMIN_TLS_CERTIFICATE: /var/hyperledger/fabric/config/tls/tls.crt
+  ORDERER_ADMIN_TLS_ROOTCAS: /var/hyperledger/fabric/config/tls/ca.crt
+  ORDERER_ADMIN_TLS_PRIVATEKEY: /var/hyperledger/fabric/config/tls/tls.key
+  # Authenticate client connections with the org's ecert / admin user enrollments
+  ORDERER_ADMIN_TLS_CLIENTROOTCAS: "[/var/hyperledger/fabric/organizations/ordererOrganizations/org0.example.com/orderers/org0-orderer4.org0.example.com/msp/cacerts/org0-ca.pem]"
+  ORDERER_FILELEDGER_LOCATION: /var/hyperledger/fabric/data/orderer4
+  ORDERER_CONSENSUS_WALDIR: /var/hyperledger/fabric/data/orderer4/etcdraft/wal
+  ORDERER_CONSENSUS_SNAPDIR: /var/hyperledger/fabric/data/orderer4/etcdraft/wal
+  ORDERER_OPERATIONS_LISTENADDRESS: 0.0.0.0:8443
+  ORDERER_ADMIN_LISTENADDRESS: 0.0.0.0:9443
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: org0-orderer4
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: org0-orderer4
+  template:
+    metadata:
+      labels:
+        app: org0-orderer4
+    spec:
+      containers:
+        - name: main
+          image: ${FABRIC_CONTAINER_REGISTRY}/fabric-orderer:${FABRIC_VERSION}
+          imagePullPolicy: IfNotPresent
+          envFrom:
+            - configMapRef:
+                name: org0-orderer4-env
+          ports:
+            - containerPort: 6050
+            - containerPort: 8443
+            - containerPort: 9443
+          volumeMounts:
+            - name: fabric-volume
+              mountPath: /var/hyperledger
+            - name: fabric-config
+              mountPath: /var/hyperledger/fabric/config
+            - name: tls-cert-volume
+              mountPath: /var/hyperledger/fabric/config/tls
+              readOnly: true
+      volumes:
+        - name: fabric-volume
+          persistentVolumeClaim:
+            claimName: fabric-org0
+        - name: fabric-config
+          configMap:
+            name: org0-config
+        - name: tls-cert-volume
+          secret:
+            secretName: org0-orderer4-tls-cert
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: org0-orderer4
+spec:
+  ports:
+    - name: general
+      port: 6050
+      protocol: TCP
+    - name: operations
+      port: 8443
+      protocol: TCP
+    - name: admin
+      port: 9443
+      protocol: TCP
+  selector:
+    app: org0-orderer4
+
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-connect-timeout: 60s
+    nginx.ingress.kubernetes.io/ssl-passthrough: "true"
+  labels:
+    app: org0-orderer4
+  name: org0-orderer4
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: org0-orderer4.${DOMAIN}
+      http:
+        paths:
+          - backend:
+              service:
+                name: org0-orderer4
+                port:
+                  name: general
+            path: /
+            pathType: ImplementationSpecific
+    - host: org0-orderer4-admin.${DOMAIN}
+      http:
+        paths:
+          - backend:
+              service:
+                name: org0-orderer4
+                port:
+                  name: admin
+            path: /
+            pathType: ImplementationSpecific
+  tls:
+    - hosts:
+        - org0-orderer4.${DOMAIN}
+    - hosts:
+        - org0-orderer4-admin.${DOMAIN}

--- a/test-network-k8s/network
+++ b/test-network-k8s/network
@@ -47,6 +47,7 @@ context ORG1_NS                       ${NS}
 context ORG2_NS                       ${NS}
 context DOMAIN                        localho.st
 context CHANNEL_NAME                  mychannel
+context ORDERER_TYPE                  raft                  # or bft for BFT Orderer (for Fabric v3.0+)
 context ORDERER_TIMEOUT               10s                   # see https://github.com/hyperledger/fabric/issues/3372
 context TEMP_DIR                      ${PWD}/build
 context CHAINCODE_BUILDER             ccaas                 # see https://github.com/hyperledgendary/fabric-builder-k8s/blob/main/docs/TEST_NETWORK_K8S.md
@@ -77,6 +78,7 @@ function print_help() {
   log "Network name       \t\t: ${NETWORK_NAME}"
   log "Ingress domain     \t\t: ${DOMAIN}"
   log "Channel name       \t\t: ${CHANNEL_NAME}"
+  log "Orderer type       \t\t: ${ORDERER_TYPE}"
   log
   log "--- Cluster Information"
   log "Cluster runtime      \t: ${CLUSTER_RUNTIME}"

--- a/test-network-k8s/scripts/test_network.sh
+++ b/test-network-k8s/scripts/test_network.sh
@@ -16,6 +16,11 @@ function launch_orderers() {
   kubectl -n $ORG0_NS rollout status deploy/org0-orderer2
   kubectl -n $ORG0_NS rollout status deploy/org0-orderer3
 
+  if  [ "${ORDERER_TYPE}" == "bft" ]; then
+    apply_template kube/org0/org0-orderer4.yaml $ORG0_NS
+    kubectl -n $ORG0_NS rollout status deploy/org0-orderer4
+  fi
+
   pop_fn
 }
 
@@ -115,6 +120,9 @@ function create_local_MSP() {
   create_orderer_local_MSP org0 orderer1
   create_orderer_local_MSP org0 orderer2
   create_orderer_local_MSP org0 orderer3
+  if  [ "${ORDERER_TYPE}" == "bft" ]; then
+    create_orderer_local_MSP org0 orderer4
+  fi
 
   create_peer_local_MSP org1 peer1 $ORG1_NS
   create_peer_local_MSP org1 peer2 $ORG1_NS


### PR DESCRIPTION
This PR adds initial support for BFT orderers in the test-network-k8s.
When `TEST_NETWORK_ORDERER_TYPE` is set to `bft`, the network launches four orderers configured with SmartBFT.

I plan to update the documentation after this PR is merged.

### How to try

```bash
cd test-network-k8s

export TEST_NETWORK_FABRIC_VERSION=3.0
export TEST_NETWORK_ORDERER_TYPE=bft

./network kind
./network cluster init
./network up
./network channel create

./network chaincode deploy asset-transfer-basic ../asset-transfer-basic/chaincode-java
./network chaincode invoke asset-transfer-basic '{"Args":["InitLedger"]}'
./network chaincode query  asset-transfer-basic '{"Args":["ReadAsset","asset1"]}'
```