### PR TITLE
CI: Add BFT Orderer support

### DIFF
--- a/.github/workflows/test-network-bft-orderer.yaml
+++ b/.github/workflows/test-network-bft-orderer.yaml
@@ -1,0 +1,45 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+name: Test Network BFT Orderer 🍟
+run-name: ${{ github.actor }} is running the Test Network with BFT Orderer tests 🍟
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  basic:
+    runs-on: ${{ github.repository == 'hyperledger/fabric-samples' && 'fabric-ubuntu-22.04' || 'ubuntu-22.04' }}
+    strategy:
+      matrix:
+        chaincode-language:
+          - go
+          - javascript
+          - typescript
+          - java
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up the test network runtime
+        uses: ./.github/actions/test-network-setup
+        # Note: The default Fabric version for CI is currently the latest LTS (v2.5.x).
+        # To test BFT Orderers, Fabric v3.0 is explicitly specified here.
+        with:
+          fabric-version: 3.0.0
+
+      - name: Run Test Network with BFT Orderers
+        working-directory: test-network
+        run: ../ci/scripts/run-test-network-basic.sh
+        env:
+          CHAINCODE_LANGUAGE: ${{ matrix.chaincode-language }}
+          ORDERER_TYPE: bft

--- a/.github/workflows/test-network-k8s.yaml
+++ b/.github/workflows/test-network-k8s.yaml
@@ -68,3 +68,22 @@ jobs:
           CHAINCODE_NAME: basic
           CHAINCODE_LANGUAGE: java
           CHAINCODE_BUILDER: k8s
+
+  bft-orderer:
+    runs-on: ${{ github.repository == 'hyperledger/fabric-samples' && 'fabric-ubuntu-22.04' || 'ubuntu-22.04' }}
+    # This job requires Fabric v3.0 or later, which is only supported on 'main'.
+    # Ensure it does not run on 'release-2.5' or earlier versions.
+    if: ${{ github.ref == 'refs/heads/main' || github.event.pull_request.base.ref == 'main' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Test the network
+        working-directory: test-network-k8s
+        run: ../ci/scripts/run-k8s-test-network-basic.sh
+        env:
+          CLIENT_LANGUAGE: typescript
+          CHAINCODE_LANGUAGE: java
+          # Note: The default Fabric version for CI is currently the latest LTS (v2.5.x).
+          # To test BFT Orderers, Fabric v3.0 is explicitly specified here.
+          FABRIC_VERSION: '3.0'
+          ORDERER_TYPE: bft

--- a/ci/scripts/run-k8s-test-network-basic.sh
+++ b/ci/scripts/run-k8s-test-network-basic.sh
@@ -12,6 +12,12 @@ export CLIENT_LANGUAGE=${CLIENT_LANGUAGE:-typescript}
 export CHAINCODE_LANGUAGE=${CHAINCODE_LANGUAGE:-java}
 export TEST_NETWORK_CHAINCODE_BUILDER=${CHAINCODE_BUILDER:-ccaas}
 
+# Fabric version
+export TEST_NETWORK_FABRIC_VERSION=${FABRIC_VERSION:-}
+
+# Orderer parameters
+export TEST_NETWORK_ORDERER_TYPE=${ORDERER_TYPE:-raft}
+
 # test-network-k8s parameters
 export TEST_TAG=$(git describe)
 export TEST_NETWORK_KIND_CLUSTER_NAME=${TEST_NETWORK_KIND_CLUSTER_NAME:-kind}
@@ -79,6 +85,7 @@ trap "quitterLaScene" EXIT
 
 createNetwork
 
+sleep 5
 print "Inserting and querying assets"
 ( ./network chaincode metadata $CHAINCODE_NAME \
   && ./network chaincode invoke $CHAINCODE_NAME '{"Args":["InitLedger"]}' \

--- a/ci/scripts/run-test-network-basic.sh
+++ b/ci/scripts/run-test-network-basic.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 
 CHAINCODE_LANGUAGE=${CHAINCODE_LANGUAGE:-go}
 CHAINCODE_PATH=${CHAINCODE_PATH:-../asset-transfer-basic}
+ORDERER_TYPE=${ORDERER_TYPE:-raft}
 
 function print() {
 	GREEN='\033[0;32m'
@@ -12,12 +13,25 @@ function print() {
 	echo -e "${GREEN}${1}${NC}"
 }
 
-function createNetwork() {
-  print "Creating 3 Org network"
+function createNetworkWithRaft() {
+  print "Creating 3 Org network with Raft Orderers"
   ./network.sh up createChannel -ca -s couchdb
   cd addOrg3
   ./addOrg3.sh up -ca -s couchdb
   cd ..
+}
+
+function createNetworkWithBFT() {
+  print "Creating 2 Org network with BFT Orderers"
+  ./network.sh up createChannel -bft
+}
+
+function createNetwork() {
+  if  [ "${ORDERER_TYPE}" == "bft" ]; then
+    createNetworkWithBFT
+  else
+    createNetworkWithRaft
+  fi
 }
 
 function deployChaincode() {


### PR DESCRIPTION
### Description
This patch adds BFT Orderer testing to the CI workflows. The following test environments are updated:
- test-network
- test-network-k8s

### Supplementary Information
Currently, the fabric-samples CI is primarily focused on the latest LTS version, Fabric v2.5.x. However, BFT Orderer support is available only in Fabric v3.0 or later.
To address this, the BFT Orderer tests explicitly specify Fabric v3.0, while other tests continue to use the default version (v2.5.x).
I believe this approach ensures that both the latest LTS version (v2.5) and v3.0 tests are supported with minimal changes.

### Related PRs
- https://github.com/hyperledger/fabric-samples/pull/1294
