### PR TITLE
Update CA server bin path in test-network-nano-bash

### DIFF
--- a/test-network-nano-bash/ordererca.sh
+++ b/test-network-nano-bash/ordererca.sh
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-export PATH="${PWD}"/../../fabric/build/bin:"${PWD}"/../bin:"${PATH}"
+export PATH="${PWD}"/../../fabric-ca/bin:"${PWD}"/../bin:"${PATH}"
 export FABRIC_CFG_PATH="${PWD}"/../config
 
 #Configure the CA_NAME, CA_PORT, OPERATIONS_PORT and CSR_HOSTS for the CA

--- a/test-network-nano-bash/org1ca.sh
+++ b/test-network-nano-bash/org1ca.sh
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-export PATH="${PWD}"/../../fabric/build/bin:"${PWD}"/../bin:"${PATH}"
+export PATH="${PWD}"/../../fabric-ca/bin:"${PWD}"/../bin:"${PATH}"
 export FABRIC_CFG_PATH="${PWD}"/../config
 
 #Configure the CA_NAME, CA_PORT, OPERATIONS_PORT and CSR_HOSTS for the CA

--- a/test-network-nano-bash/org2ca.sh
+++ b/test-network-nano-bash/org2ca.sh
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-export PATH="${PWD}"/../../fabric/build/bin:"${PWD}"/../bin:"${PATH}"
+export PATH="${PWD}"/../../fabric-ca/bin:"${PWD}"/../bin:"${PATH}"
 export FABRIC_CFG_PATH="${PWD}"/../config
 
 #Configure the CA_NAME, CA_PORT, OPERATIONS_PORT and CSR_HOSTS for the CA


### PR DESCRIPTION
test-network-nano-bash is often used with locally built fabric and fabric-ca binaries.
As such the intent is to first look for locally
built binaries and then fall back to binaries downloaded with the samples.
This was correct for fabric binaries but not the fabric-ca binaries.