### PR TITLE
Fix test-network-nano-bash orderer4 enrollment

### DIFF
--- a/test-network-nano-bash/ca/ca_utils.sh
+++ b/test-network-nano-bash/ca/ca_utils.sh
@@ -21,6 +21,10 @@ createEnrollment() {
 
   # Enroll the identity
   fabric-ca-client enroll -d -u https://${username}:${password}@localhost:${port} --caname ca --mspdir "${component_dir}/msp" --tls.certfiles $tlscert
+  if [ $? -ne 0 ]; then
+    echo "fabric-ca-client admin enroll failed, make sure CA service is available. Exiting..."
+    exit 1
+  fi
 
   # Rename private key to mimic cryptogen
   find ${component_dir} -type f -name '*_sk'  | sed -e 'p;s/\(.*\)\/\(.*\)$/\1\/priv_sk/' | xargs -n2 mv -v
@@ -80,9 +84,17 @@ registerAndEnroll() {
 
   # Register the username
   fabric-ca-client register -d -u https://localhost:${port} --id.name ${username} --id.secret ${password} --id.type ${type} --id.attrs "${attrs}" --caname ca --tls.certfiles $tlscert --mspdir "${org_dir}/ca/msp"
+  if [ $? -ne 0 ]; then
+    echo "fabric-ca-client register failed, make sure CA service is available. Exiting..."
+    exit 1
+  fi
 
   # Enroll the identity
   fabric-ca-client enroll -d -u https://${username}:${password}@localhost:${port} --caname ca --mspdir "${component_dir}/msp" --tls.certfiles $tlscert
+  if [ $? -ne 0 ]; then
+    echo "fabric-ca-client enroll failed, make sure CA service is available. Exiting..."
+    exit 1
+  fi
 
   # Rename private key to mimic cryptogen
   find ${component_dir} -type f -name '*_sk'  | sed -e 'p;s/\(.*\)\/\(.*\)$/\1\/priv_sk/' | xargs -n2 mv -v
@@ -98,7 +110,11 @@ registerAndEnroll() {
 
     # Enroll the TLS cert
     fabric-ca-client enroll -d -u https://${username}:${password}@localhost:${port} --caname tlsca --mspdir "${component_dir}/tls" --tls.certfiles $tlscert --csr.hosts 'localhost,127.0.0.1'
-    
+    if [ $? -ne 0 ]; then
+      echo "fabric-ca-client TLS enroll failed, make sure CA service is available. Exiting..."
+      exit 1
+    fi
+
     # Rename private key to mimic cryptogen
     find ${component_dir} -type f -name '*_sk'  | sed -e 'p;s/\(.*\)\/\(.*\)$/\1\/priv_sk/' | xargs -n2 mv -v
 

--- a/test-network-nano-bash/ca/createEnrollments.sh
+++ b/test-network-nano-bash/ca/createEnrollments.sh
@@ -76,7 +76,7 @@ registerAndEnroll "5052" "orderer2" "orderer2pw" "orderer" "" "${orderer2_dir}" 
 registerAndEnroll "5052" "orderer3" "orderer3pw" "orderer" "" "${orderer3_dir}" "${orderer_org_dir}" "${orderer_org_tls}"
 
 # Create enrollment and TLS certificates for orderer4
-registerAndEnroll "5052" "orderer4" "orderer4pw" "orderer" "" "${orderer4_dir}" "${orderer_org}" "${orderer_org_tls}"
+registerAndEnroll "5052" "orderer4" "orderer4pw" "orderer" "" "${orderer4_dir}" "${orderer_org_dir}" "${orderer_org_tls}"
 
 # Create enrollment and TLS certificates for orderer5
 registerAndEnroll "5052" "orderer5" "orderer5pw" "orderer" "" "${orderer5_dir}" "${orderer_org_dir}" "${orderer_org_tls}"

--- a/test-network-nano-bash/generate_artifacts.sh
+++ b/test-network-nano-bash/generate_artifacts.sh
@@ -46,8 +46,8 @@ else
   mkdir -p "${PWD}"/logs
 
   # execute the script to configure the default set of enrollments
-  echo "Generating MSP certificates using the Fabric CAs"
-  ./ca/createEnrollments.sh > ./logs/createEnrollments.log 2>&1 
+  echo "Generating MSP certificates using the Fabric CAs, see results in ./logs/createEnrollments.log"
+  ./ca/createEnrollments.sh > ./logs/createEnrollments.log 2>&1
 
 fi
 


### PR DESCRIPTION
Fix test-network-nano-bash orderer4 enrollment.
Also improve error handling and messages in CA interaction.