### PR TITLE
Add connection profile to test-network-nano-bash

### DIFF
--- a/test-network-nano-bash/ca/ccp-generate.sh
+++ b/test-network-nano-bash/ca/ccp-generate.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+function one_line_pem {
+    echo "`awk 'NF {sub(/\\n/, ""); printf "%s\\\\\\\n",$0;}' $1`"
+}
+
+function json_ccp {
+    local PP=$(one_line_pem $4)
+    local CP=$(one_line_pem $5)
+    sed -e "s/\${ORG}/$1/" \
+        -e "s/\${P0PORT}/$2/" \
+        -e "s/\${CAPORT}/$3/" \
+        -e "s#\${PEERPEM}#$PP#" \
+        -e "s#\${CAPEM}#$CP#" \
+        ./ca/ccp-template.json
+}
+
+function yaml_ccp {
+    local PP=$(one_line_pem $4)
+    local CP=$(one_line_pem $5)
+    sed -e "s/\${ORG}/$1/" \
+        -e "s/\${P0PORT}/$2/" \
+        -e "s/\${CAPORT}/$3/" \
+        -e "s#\${PEERPEM}#$PP#" \
+        -e "s#\${CAPEM}#$CP#" \
+        ./ca/ccp-template.yaml | sed -e $'s/\\\\n/\\\n          /g'
+}
+
+ORG=1
+P0PORT=7051
+CAPORT=5053
+PEERPEM=./crypto-config/peerOrganizations/org1.example.com/msp/tlscacerts/tlsca.org1.example.com-cert.pem
+CAPEM=./crypto-config/peerOrganizations/org1.example.com/ca/msp/cacerts/ca.org1.example.com-cert.pem
+
+echo "$(json_ccp $ORG $P0PORT $CAPORT $PEERPEM $CAPEM)" > ./crypto-config/peerOrganizations/org1.example.com/connection-org1.json
+echo "$(yaml_ccp $ORG $P0PORT $CAPORT $PEERPEM $CAPEM)" > ./crypto-config/peerOrganizations/org1.example.com/connection-org1.yaml
+
+ORG=2
+P0PORT=7054
+CAPORT=5054
+PEERPEM=./crypto-config/peerOrganizations/org2.example.com/msp/tlscacerts/tlsca.org2.example.com-cert.pem
+CAPEM=./crypto-config/peerOrganizations/org2.example.com/ca/msp/cacerts/ca.org2.example.com-cert.pem
+
+echo "$(json_ccp $ORG $P0PORT $CAPORT $PEERPEM $CAPEM)" > ./crypto-config/peerOrganizations/org2.example.com/connection-org2.json
+echo "$(yaml_ccp $ORG $P0PORT $CAPORT $PEERPEM $CAPEM)" > ./crypto-config/peerOrganizations/org2.example.com/connection-org2.yaml

--- a/test-network-nano-bash/ca/ccp-template.json
+++ b/test-network-nano-bash/ca/ccp-template.json
@@ -1,0 +1,48 @@
+{
+    "name": "test-network-org${ORG}",
+    "version": "1.0.0",
+    "client": {
+        "organization": "Org${ORG}",
+        "connection": {
+            "timeout": {
+                "peer": {
+                    "endorser": "300"
+                }
+            }
+        }
+    },
+    "organizations": {
+        "Org${ORG}": {
+            "mspid": "Org${ORG}MSP",
+            "peers": [
+                "peer0.org${ORG}.example.com"
+            ],
+            "certificateAuthorities": [
+                "ca.org${ORG}.example.com"
+            ]
+        }
+    },
+    "peers": {
+        "peer0.org${ORG}.example.com": {
+            "url": "grpcs://127.0.0.1:${P0PORT}",
+            "tlsCACerts": {
+                "pem": "${PEERPEM}"
+            },
+            "grpcOptions": {
+                "ssl-target-name-override": "localhost"
+            }
+        }
+    },
+    "certificateAuthorities": {
+        "ca.org${ORG}.example.com": {
+            "url": "https://127.0.0.1:${CAPORT}",
+            "caName": "ca",
+            "tlsCACerts": {
+                "pem": ["${CAPEM}"]
+            },
+            "httpOptions": {
+                "verify": false
+            }
+        }
+    }
+}

--- a/test-network-nano-bash/ca/ccp-template.yaml
+++ b/test-network-nano-bash/ca/ccp-template.yaml
@@ -1,0 +1,34 @@
+---
+name: test-network-org${ORG}
+version: 1.0.0
+client:
+  organization: Org${ORG}
+  connection:
+    timeout:
+      peer:
+        endorser: '300'
+organizations:
+  Org${ORG}:
+    mspid: Org${ORG}MSP
+    peers:
+    - peer0.org${ORG}.example.com
+    certificateAuthorities:
+    - ca.org${ORG}.example.com
+peers:
+  peer0.org${ORG}.example.com:
+    url: grpcs://127.0.0.1:${P0PORT}
+    tlsCACerts:
+      pem: |
+          ${PEERPEM}
+    grpcOptions:
+      ssl-target-name-override: localhost
+certificateAuthorities:
+  ca.org${ORG}.example.com:
+    url: https://127.0.0.1:${CAPORT}
+    caName: ca
+    tlsCACerts:
+      pem: 
+        - |
+          ${CAPEM}
+    httpOptions:
+      verify: false

--- a/test-network-nano-bash/ca/createEnrollments.sh
+++ b/test-network-nano-bash/ca/createEnrollments.sh
@@ -116,3 +116,12 @@ createMSP "org1ca" "org1" "${org1_dir}"
 
 # Create the MSP for Org2
 createMSP "org2ca" "org2" "${org2_dir}"
+
+######################################################################################
+#  Generate CCP files for Org1 and Org2
+######################################################################################
+
+# Generate CCP files for Org1 and Org2"
+echo "Generating CCP files for Org1 and Org2"
+./ca/ccp-generate.sh
+echo "Generated CCP files for Org1 and Org2"


### PR DESCRIPTION
Add connection profile to test-network-nano-bash
to enable legacy SDK apps.

Approach copied from test-network connection profiles.