### PR TITLE
Fix intermittent errors with test-network ca

### DIFF
--- a/test-network/network.sh
+++ b/test-network/network.sh
@@ -224,6 +224,8 @@ function createOrgs() {
     infoln "Generating certificates using Fabric CA"
     ${CONTAINER_CLI_COMPOSE} -f compose/$COMPOSE_FILE_CA -f compose/$CONTAINER_CLI/${CONTAINER_CLI}-$COMPOSE_FILE_CA up -d 2>&1
 
+    # Allow CAs to initialize and then make register and enroll requests
+    sleep 3
     . organizations/fabric-ca/registerEnroll.sh
 
     while :


### PR DESCRIPTION
If CA server hasn't finished initialization then the initial register and enroll requests will fail.
Waiting 3 seconds resolves the issue.