### PR TITLE
Pull Fabric images from GitHub Container Registry

### DIFF
--- a/.github/actions/fsat-setup/action.yaml
+++ b/.github/actions/fsat-setup/action.yaml
@@ -6,16 +6,16 @@ inputs:
     default: 18.x
   just-version:
     description: Just Version
-    default: '1.24.0'
+    default: "1.24.0"
   k9s-version:
     description: k9s Version
     default: v0.25.3
   fabric-version:
     description: Version of Hyperledger Fabric
-    default: '2.5.11'
+    default: "2.5.11"
   ca-version:
     description: Version of Hyperledger Fabric CA
-    default: '1.5.14'
+    default: "1.5.15"
 
 runs:
   using: "composite"
@@ -23,8 +23,8 @@ runs:
     - uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node-version }}
-        cache: 'npm'
-        cache-dependency-path: '**/package-lock.json'
+        cache: "npm"
+        cache-dependency-path: "**/package-lock.json"
 
     - name: Install k9s
       shell: bash

--- a/.github/actions/test-network-setup/action.yaml
+++ b/.github/actions/test-network-setup/action.yaml
@@ -3,7 +3,7 @@ description: Set up the Test Network Runtime
 inputs:
   go-version:
     description: Version of go
-    default: '1.23'
+    default: "1.23"
   node-version:
     description: Version of node
     default: 18.x
@@ -15,7 +15,7 @@ inputs:
     default: 2.5.11
   ca-version:
     description: Version of Hyperledger Fabric CA
-    default: 1.5.14
+    default: 1.5.15
 
 runs:
   using: "composite"
@@ -23,13 +23,13 @@ runs:
     - uses: actions/setup-go@v5
       with:
         go-version: ${{ inputs.go-version }}
-        cache-dependency-path: '**/go.sum'
+        cache-dependency-path: "**/go.sum"
 
     - uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node-version }}
-        cache: 'npm'
-        cache-dependency-path: '**/package-lock.json'
+        cache: "npm"
+        cache-dependency-path: "**/package-lock.json"
 
     - uses: actions/setup-java@v4
       with:
@@ -49,6 +49,14 @@ runs:
       run: |
         curl -sSL https://raw.githubusercontent.com/hyperledger/fabric/main/scripts/install-fabric.sh \
           | bash -s -- docker --fabric-version ${{ inputs.fabric-version }} --ca-version ${{ inputs.ca-version }}
+
+    - name: Pull chaincode container images
+      shell: bash
+      run: |
+        docker pull ghcr.io/hyperledger/fabric-nodeenv:2.5
+        docker tag ghcr.io/hyperledger/fabric-nodeenv:2.5 hyperledger/fabric-nodeenv:2.5
+        docker pull ghcr.io/hyperledger/fabric-javaenv:2.5
+        docker tag ghcr.io/hyperledger/fabric-javaenv:2.5 hyperledger/fabric-javaenv:2.5
 
     - name: Install retry CLI
       shell: bash


### PR DESCRIPTION
By default, Docker images are referenced from Docker Hub. This has now applied rate limiting that is causing builds to fail. Current Fabric v2.5 and chaincode container Docker images are also published to GitHub Container Registry, which does not impose rate limits and will be located closer to the GitHub Actions runners.

This change:

- Updates to latest Fabric component versions, which are available in GHCR. The Fabric install script defaults to GHCR as the Docker registry for versions that are available here.
- Pulls and re-tags chaincode container images from GHCR in advance of running tests in the build. This avoids them being pulled from Docker Hub during test execution.