### PR TITLE
Bump fabric to v2.5.12

### DIFF
--- a/.github/actions/fsat-setup/action.yaml
+++ b/.github/actions/fsat-setup/action.yaml
@@ -12,7 +12,7 @@ inputs:
     default: v0.25.3
   fabric-version:
     description: Version of Hyperledger Fabric
-    default: "2.5.11"
+    default: "2.5.12"
   ca-version:
     description: Version of Hyperledger Fabric CA
     default: "1.5.15"

--- a/.github/actions/test-network-setup/action.yaml
+++ b/.github/actions/test-network-setup/action.yaml
@@ -12,7 +12,7 @@ inputs:
     default: 11.x
   fabric-version:
     description: Version of Hyperledger Fabric
-    default: 2.5.11
+    default: 2.5.12
   ca-version:
     description: Version of Hyperledger Fabric CA
     default: 1.5.15

--- a/full-stack-asset-transfer-guide/infrastructure/sample-network/network
+++ b/full-stack-asset-transfer-guide/infrastructure/sample-network/network
@@ -33,8 +33,8 @@ function context() {
   export ${name}="${!override_name:-${default_value}}"
 }
 
-context FABRIC_VERSION            2.5.11
-context FABRIC_CA_VERSION         1.5.14
+context FABRIC_VERSION            2.5.12
+context FABRIC_CA_VERSION         1.5.15
 
 context CLUSTER_RUNTIME           kind                  # or k3s for Rancher
 context CONTAINER_CLI             docker                # or nerdctl for containerd

--- a/test-network/network.config
+++ b/test-network/network.config
@@ -1,7 +1,7 @@
-# default image tag, example: "2.5.11".  "default" will download the latest. (-i)
+# default image tag, example: "2.5.12".  "default" will download the latest. (-i)
 IMAGETAG="default"
 
-# default ca image tag, example: "1.5.14". "default" will download the latest. (-cai)
+# default ca image tag, example: "1.5.15". "default" will download the latest. (-cai)
 CA_IMAGETAG="default"
 
 # Using crpto vs CA. default is cryptogen

--- a/test-network/scripts/utils.sh
+++ b/test-network/scripts/utils.sh
@@ -17,8 +17,8 @@ function printHelp() {
     println
     println "    Flags:"
     println "    Used with \033[0;32mnetwork.sh prereq\033[0m:"
-    println "    -i     FabricVersion (default: '2.5.11')"
-    println "    -cai   Fabric CA Version (default: '1.5.14')"
+    println "    -i     FabricVersion (default: '2.5.12')"
+    println "    -cai   Fabric CA Version (default: '1.5.15')"
     println  
   elif [ "$USAGE" == "up" ]; then
     println "Usage: "
@@ -159,8 +159,8 @@ function printHelp() {
     println
     println "    Flags:"
     println "    Used with \033[0;32mnetwork.sh prereq\033[0m"
-    println "    -i     FabricVersion (default: '2.5.11')"
-    println "    -cai   Fabric CA Version (default: '1.5.14')"
+    println "    -i     FabricVersion (default: '2.5.12')"
+    println "    -cai   Fabric CA Version (default: '1.5.15')"
     println
     println "    Used with \033[0;32mnetwork.sh up\033[0m, \033[0;32mnetwork.sh createChannel\033[0m:"
     println "    -ca - Use Certificate Authorities to generate network crypto material"


### PR DESCRIPTION
This patch bumps fabric to v2.5.12.
It also updates some parts of fabric-ca that were missed in the previous update.