### PR TITLE
update fabric operations console docs

### DIFF
--- a/full-stack-asset-transfer-guide/docs/CloudReady/21-fabric-operations-console.md
+++ b/full-stack-asset-transfer-guide/docs/CloudReady/21-fabric-operations-console.md
@@ -28,6 +28,14 @@ kubectl apply -k https://github.com/hyperledger-labs/fabric-operator.git/config/
 
 ```
 
+- Open the file located at `infrastructure/sample-network/config/console/hlf-operations-console.yaml` and adjust the `arch` field according to your machine's architecture.
+
+```yaml
+spec:
+  arch:
+    - amd64
+```
+
 - Install the Fabric operator and console in the target namespace: 
 ```shell
 

--- a/full-stack-asset-transfer-guide/infrastructure/sample-network/config/console/hlf-operations-console.yaml
+++ b/full-stack-asset-transfer-guide/infrastructure/sample-network/config/console/hlf-operations-console.yaml
@@ -5,6 +5,7 @@ metadata:
   name: hlf-console
 spec:
   arch:
+    # amd64 (x86, Intel/ AMD) or arm64 (ARM, Apple silicon)
     - amd64
   license:
     accept: true


### PR DESCRIPTION
Update docs for Mac users when deploying fabric operations console on local machines.