### PR TITLE
enable CGO on installation of tokensdk

### DIFF
--- a/token-sdk/README.md
+++ b/token-sdk/README.md
@@ -82,6 +82,7 @@ Prerequisites:
 
 - bash
 - golang 1.20+
+- build-essential
 - git
 - docker
 - docker-compose
@@ -115,7 +116,7 @@ Validate that the CA is at 1.5.7 by executing `fabric-ca-client version`.
 Install tokengen. Tokengen is a tool to create the configuration file for the token chaincode (once, when deploying the chaincode). It generates the public parameters that the network participants will use to generate their proofs, and it specifies the public identities of the issuer, auditor and CA for signature validation.
 
 ```bash
-go install github.com/hyperledger-labs/fabric-token-sdk/cmd/tokengen@v0.3.0
+CGO_ENABLED=1 go install github.com/hyperledger-labs/fabric-token-sdk/cmd/tokengen@v0.3.0
 ```
 
 ### Quick start


### PR DESCRIPTION
According to the issue https://github.com/hyperledger/fabric-samples/issues/1273 , installation of tokensdk might be not successful. After research, I've found the CGO_ENABLED variable should be set to 1.

In addition, after merging the changes of #1315 there were some dependency errors when building the tokensdk images.

Signed-off-by: Mohammad Reza Nasrabadi <nasr.mareza1378@gmail.com