### PR TITLE
Enhance Go off_chain_data for consistency

### DIFF
--- a/off_chain_data/application-go/parser/block.go
+++ b/off_chain_data/application-go/parser/block.go
@@ -26,6 +26,10 @@ func (b *Block) Transactions() ([]*Transaction, error) {
 	return b.transactions()
 }
 
+func (b *Block) ToProto() *common.Block {
+	return b.block
+}
+
 func (b *Block) unmarshalTransactions() ([]*Transaction, error) {
 	envelopes, err := b.unmarshalEnvelopes()
 	if err != nil {

--- a/off_chain_data/application-go/parser/namespaceReadWriteSet.go
+++ b/off_chain_data/application-go/parser/namespaceReadWriteSet.go
@@ -27,6 +27,10 @@ func (p *NamespaceReadWriteSet) ReadWriteSet() (*kvrwset.KVRWSet, error) {
 	return p.readWriteSet()
 }
 
+func (p *NamespaceReadWriteSet) ToProto() *rwset.NsReadWriteSet {
+	return p.nsReadWriteSet
+}
+
 func (p *NamespaceReadWriteSet) unmarshalReadWriteSet() (*kvrwset.KVRWSet, error) {
 	result := &kvrwset.KVRWSet{}
 	if err := proto.Unmarshal(p.nsReadWriteSet.GetRwset(), result); err != nil {

--- a/off_chain_data/application-go/parser/transaction.go
+++ b/off_chain_data/application-go/parser/transaction.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"github.com/hyperledger/fabric-gateway/pkg/identity"
 	"github.com/hyperledger/fabric-protos-go-apiv2/common"
 )
 
@@ -14,6 +15,10 @@ func newTransaction(payload *payload) *Transaction {
 
 func (t *Transaction) ChannelHeader() *common.ChannelHeader {
 	return t.payload.channelHeader
+}
+
+func (t *Transaction) Creator() identity.Identity {
+	return t.payload.creator
 }
 
 func (t *Transaction) NamespaceReadWriteSets() ([]*NamespaceReadWriteSet, error) {
@@ -36,4 +41,12 @@ func (t *Transaction) NamespaceReadWriteSets() ([]*NamespaceReadWriteSet, error)
 
 func (t *Transaction) IsValid() bool {
 	return t.payload.isValid()
+}
+
+func (t *Transaction) ToProto() *common.Payload {
+	return t.payload.commonPayload
+}
+
+func (t *Transaction) ValidationCode() int32 {
+	return t.payload.statusCode
 }


### PR DESCRIPTION
Add some methods to the parsing API within the Go off_chain_data sample for consistency with the Node and Java implementations:

- ToProto() on Block, Transaction and NamespaceReadWriteSet.
- ValidationCode() on Transaction.
- Creator() on Transaction

Addresses [review comments](https://github.com/hyperledger/fabric-samples/pull/1269#pullrequestreview-2661860821) from the initial contribution.