### PR TITLE
Use Gradle wrapper in asset-transfer-ledger-queries

### DIFF
--- a/ci/scripts/run-test-network-ledger.sh
+++ b/ci/scripts/run-test-network-ledger.sh
@@ -28,7 +28,7 @@ createNetwork
 print "Initializing Java application"
 pushd ../asset-transfer-ledger-queries/application-java
 print "Executing Gradle Run"
-gradle run
+./gradlew run
 popd
 stopNetwork
 


### PR DESCRIPTION
The CI script invoked Gradle directly, which could picker newer Gradle versions not compatible with the build definition. This change uses the Gradle wrapper included in the client application sample.