### PR TITLE
Update runtime and tool versions

### DIFF
--- a/.github/actions/fsat-setup/action.yaml
+++ b/.github/actions/fsat-setup/action.yaml
@@ -3,16 +3,16 @@ description: Set up the Full Stack Asset Transfer Guide Dependencies
 inputs:
   node-version:
     description: Version of node
-    default: 20.x
+    default: "lts/*"
   just-version:
     description: Just Version
-    default: "1.24.0"
+    default: "1.43.0"
   k9s-version:
     description: k9s Version
-    default: v0.25.3
+    default: v0.50.15
   fabric-version:
     description: Version of Hyperledger Fabric
-    default: "2.5.13"
+    default: "2.5.14"
   ca-version:
     description: Version of Hyperledger Fabric CA
     default: "1.5.15"
@@ -20,7 +20,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v6
       with:
         node-version: ${{ inputs.node-version }}
         cache: "npm"
@@ -29,8 +29,8 @@ runs:
     - name: Install k9s
       shell: bash
       run: |
-        curl --fail --silent --show-error -L https://github.com/derailed/k9s/releases/download/${{ inputs.k9s-version }}/k9s_Linux_x86_64.tar.gz -o /tmp/k9s_Linux_x86_64.tar.gz
-        tar -zxf /tmp/k9s_Linux_x86_64.tar.gz -C /usr/local/bin k9s
+        curl --fail --silent --show-error -L https://github.com/derailed/k9s/releases/download/${{ inputs.k9s-version }}/k9s_Linux_amd64.tar.gz -o /tmp/k9s_Linux_amd64.tar.gz
+        tar -zxf /tmp/k9s_Linux_amd64.tar.gz -C /usr/local/bin k9s
         sudo chown root /usr/local/bin/k9s
         sudo chmod 755 /usr/local/bin/k9s
 

--- a/.github/actions/test-network-setup/action.yaml
+++ b/.github/actions/test-network-setup/action.yaml
@@ -3,16 +3,16 @@ description: Set up the Test Network Runtime
 inputs:
   go-version:
     description: Version of go
-    default: "1.23"
+    default: stable
   node-version:
     description: Version of node
-    default: 20.x
+    default: "lts/*"
   java-version:
     description: Version of JDK
     default: 25.x
   fabric-version:
     description: Version of Hyperledger Fabric
-    default: 2.5.13
+    default: 2.5.14
   ca-version:
     description: Version of Hyperledger Fabric CA
     default: 1.5.15
@@ -20,18 +20,18 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-go@v5
+    - uses: actions/setup-go@v6
       with:
         go-version: ${{ inputs.go-version }}
         cache-dependency-path: "**/go.sum"
 
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v6
       with:
         node-version: ${{ inputs.node-version }}
         cache: "npm"
         cache-dependency-path: "**/package-lock.json"
 
-    - uses: actions/setup-java@v4
+    - uses: actions/setup-java@v5
       with:
         distribution: temurin
         java-version: ${{ inputs.java-version }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -16,17 +16,16 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VER: "1.23"
-  NODE_VER: 20.x
+  NODE_VER: "lts/*"
   JAVA_VER: 25.x
 
 jobs:
   go:
     runs-on: ${{ github.repository == 'hyperledger/fabric-samples' && 'fabric-ubuntu-22.04' || 'ubuntu-22.04' }}
     steps:
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
-          go-version: ${{ env.GO_VER }}
+          go-version: stable
       - uses: actions/checkout@v5
       - run: go install golang.org/x/tools/cmd/goimports@latest
       - run: ci/scripts/lint-go.sh
@@ -35,7 +34,7 @@ jobs:
     runs-on: ${{ github.repository == 'hyperledger/fabric-samples' && 'fabric-ubuntu-22.04' || 'ubuntu-22.04' }}
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VER }}
       - run: ci/scripts/lint-typescript.sh
@@ -44,7 +43,7 @@ jobs:
     runs-on: ${{ github.repository == 'hyperledger/fabric-samples' && 'fabric-ubuntu-22.04' || 'ubuntu-22.04' }}
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VER }}
       - run: ci/scripts/lint-javascript.sh
@@ -53,7 +52,7 @@ jobs:
     runs-on: ${{ github.repository == 'hyperledger/fabric-samples' && 'fabric-ubuntu-22.04' || 'ubuntu-22.04' }}
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: ${{ env.JAVA_VER }}

--- a/.github/workflows/rest-sample.yaml
+++ b/.github/workflows/rest-sample.yaml
@@ -5,7 +5,7 @@ name: REST Sample 🐧
 run-name: ${{ github.actor }} is testing the REST Sample 🐧
 
 env:
-  NODE_VER: 20.x
+  NODE_VER: "lts/*"
 
 on:
   workflow_dispatch:
@@ -28,7 +28,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VER }}
           cache: "npm"

--- a/.github/workflows/test-network-bft-orderer.yaml
+++ b/.github/workflows/test-network-bft-orderer.yaml
@@ -7,9 +7,9 @@ run-name: ${{ github.actor }} is running the Test Network with BFT Orderer tests
 on:
   workflow_dispatch:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -38,7 +38,7 @@ jobs:
         # Note: The default Fabric version for CI is currently the latest LTS (v2.5.x).
         # To test BFT Orderers, Fabric v3.x is explicitly specified here.
         with:
-          fabric-version: 3.1.1
+          fabric-version: 3.1.3
 
       - name: Run Test Network with BFT Orderers
         working-directory: test-network

--- a/asset-transfer-basic/chaincode-external/Dockerfile
+++ b/asset-transfer-basic/chaincode-external/Dockerfile
@@ -2,10 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-ARG GO_VER=1.23
-ARG ALPINE_VER=3.21
-
-FROM golang:${GO_VER}-alpine${ALPINE_VER}
+FROM golang:alpine
 
 WORKDIR /go/src/github.com/hyperledger/fabric-samples/asset-transfer-basic/chaincode-external
 COPY . .

--- a/asset-transfer-basic/chaincode-typescript/Dockerfile
+++ b/asset-transfer-basic/chaincode-typescript/Dockerfile
@@ -1,7 +1,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-FROM node:22 AS builder
+FROM node:lts AS builder
 
 WORKDIR /usr/src/app
 
@@ -11,7 +11,7 @@ ENV npm_config_cache=/usr/src/app
 RUN npm ci && npm run package
 
 
-FROM node:22 AS production
+FROM node:lts AS production
 ARG CC_SERVER_PORT
 
 # Setup tini to work better handle signals

--- a/asset-transfer-basic/rest-api-typescript/Dockerfile
+++ b/asset-transfer-basic/rest-api-typescript/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-alpine AS build
+FROM node:lts-alpine AS build
 
 RUN apk add --no-cache g++ make python3 dumb-init
 
@@ -10,7 +10,7 @@ RUN npm ci
 RUN npm run build
 RUN npm prune --production
 
-FROM node:22-alpine
+FROM node:lts-alpine
 ENV NODE_ENV production
 WORKDIR /app
 

--- a/asset-transfer-private-data/chaincode-typescript/Dockerfile
+++ b/asset-transfer-private-data/chaincode-typescript/Dockerfile
@@ -1,7 +1,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-FROM node:22 AS builder
+FROM node:lts AS builder
 
 WORKDIR /usr/src/app
 
@@ -11,7 +11,7 @@ ENV npm_config_cache=/usr/src/app
 RUN npm ci && npm run package
 
 
-FROM node:22 AS production
+FROM node:lts AS production
 ARG CC_SERVER_PORT
 
 # Setup tini to work better handle signals

--- a/full-stack-asset-transfer-guide/applications/rest-api/Dockerfile
+++ b/full-stack-asset-transfer-guide/applications/rest-api/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-alpine AS build
+FROM node:lts-alpine AS build
 WORKDIR /app
 COPY package.json /app
 RUN npm install

--- a/full-stack-asset-transfer-guide/check.sh
+++ b/full-stack-asset-transfer-guide/check.sh
@@ -78,12 +78,12 @@ then
       echo "curl --fail --silent --show-error -L https://github.com/derailed/k9s/releases/download/v${K9S_VERSION}/k9s_Darwin_arm64.tar.gz -o /tmp/k9s_Darwin_arm64.tar.gz"
       echo "tar -zxf /tmp/k9s_Darwin_arm64.tar.gz -C /usr/local/bin k9s"
     else
-      echo "curl --fail --silent --show-error -L https://github.com/derailed/k9s/releases/download/v${K9S_VERSION}/k9s_Darwin_x86_64.tar.gz -o /tmp/k9s_Darwin_x86_64.tar.gz"
-      echo "tar -zxf /tmp/k9s_Darwin_x86_64.tar.gz -C /usr/local/bin k9s"
+      echo "curl --fail --silent --show-error -L https://github.com/derailed/k9s/releases/download/v${K9S_VERSION}/k9s_Darwin_amd64.tar.gz -o /tmp/k9s_Darwin_amd64.tar.gz"
+      echo "tar -zxf /tmp/k9s_Darwin_amd64.tar.gz -C /usr/local/bin k9s"
     fi
   else
-    echo "curl --fail --silent --show-error -L https://github.com/derailed/k9s/releases/download/v${K9S_VERSION}/k9s_Linux_x86_64.tar.gz -o /tmp/k9s_Linux_x86_64.tar.gz"
-    echo "tar -zxf /tmp/k9s_Linux_x86_64.tar.gz -C /usr/local/bin k9s"
+    echo "curl --fail --silent --show-error -L https://github.com/derailed/k9s/releases/download/v${K9S_VERSION}/k9s_Linux_amd64.tar.gz -o /tmp/k9s_Linux_amd64.tar.gz"
+    echo "tar -zxf /tmp/k9s_Linux_amd64.tar.gz -C /usr/local/bin k9s"
   fi
   echo "sudo chown root /usr/local/bin/k9s"
   echo "sudo chmod 755 /usr/local/bin/k9s"

--- a/full-stack-asset-transfer-guide/contracts/asset-transfer-typescript/Dockerfile
+++ b/full-stack-asset-transfer-guide/contracts/asset-transfer-typescript/Dockerfile
@@ -1,7 +1,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-FROM node:22 AS builder
+FROM node:lts AS builder
 
 WORKDIR /usr/src/app
 
@@ -12,7 +12,7 @@ RUN npm install
 RUN npm run build && npm shrinkwrap
 
 
-FROM node:22 as prod-builder
+FROM node:lts as prod-builder
 WORKDIR /usr/src/app
 COPY --chown=node:node --from=builder /usr/src/app/dist ./dist
 COPY --chown=node:node --from=builder /usr/src/app/package.json ./
@@ -21,7 +21,7 @@ RUN npm ci --omit=dev && npm cache clean --force
 
 # ------------------------------------------------------------------------------
 # Builds the Chaincode as a Service docker version
-FROM node:22 AS ccaas
+FROM node:lts AS ccaas
 WORKDIR /usr/src/app
 
 ARG TARGETARCH
@@ -47,7 +47,7 @@ ENTRYPOINT [ "/tini", "--", "/usr/src/app/docker-entrypoint.sh" ]
 
 # ------------------------------------------------------------------------------
 # Builds the chaincode for the k8s builder
-FROM node:22 AS k8s
+FROM node:lts AS k8s
 WORKDIR /usr/src/app
 
 ARG TARGETARCH
@@ -66,4 +66,3 @@ RUN chmod +x /tini
 ENV NODE_ENV=production
 USER node
 ENTRYPOINT [ "/tini", "--", "/usr/src/app/docker-entrypoint.sh" ]
-

--- a/full-stack-asset-transfer-guide/infrastructure/ec2-cloud-config.yaml
+++ b/full-stack-asset-transfer-guide/infrastructure/ec2-cloud-config.yaml
@@ -2,7 +2,7 @@
 
 write_files:
   - path: /config/provision-root.sh
-    permissions: '0744'
+    permissions: "0744"
     content: |
       #!/usr/bin/env bash
       set -ex
@@ -33,8 +33,8 @@ write_files:
       # Install k9s
       K9S_VERSION=0.25.3
       if [ ! -x "/usr/local/bin/k9s" ]; then
-        curl --fail --silent --show-error -L "https://github.com/derailed/k9s/releases/download/v${K9S_VERSION}/k9s_Linux_x86_64.tar.gz" -o "/tmp/k9s_Linux_x86_64.tar.gz"
-        tar -zxf "/tmp/k9s_Linux_x86_64.tar.gz" -C /usr/local/bin k9s
+        curl --fail --silent --show-error -L "https://github.com/derailed/k9s/releases/download/v${K9S_VERSION}/k9s_Linux_amd64.tar.gz" -o "/tmp/k9s_Linux_amd64.tar.gz"
+        tar -zxf "/tmp/k9s_Linux_amd64.tar.gz" -C /usr/local/bin k9s
         chown root:root /usr/local/bin/k9s
         chmod 755 /usr/local/bin/k9s
       fi

--- a/full-stack-asset-transfer-guide/infrastructure/multipass-cloud-config.yaml
+++ b/full-stack-asset-transfer-guide/infrastructure/multipass-cloud-config.yaml
@@ -6,10 +6,9 @@ users:
       - docker
     lock_passwd: false
     shell: /bin/bash
-    sudo: ['ALL=(ALL) NOPASSWD:ALL']
+    sudo: ["ALL=(ALL) NOPASSWD:ALL"]
 #    ssh-authorized-keys:
 #      - ssh-rsa <SNIP>
-
 
 pacakge_update: true
 package_upgrade: true
@@ -19,102 +18,102 @@ packages:
   - software-properties-common
 
 write_files:
-- path: /config/provision-root.sh
-  permissions: '0744'
-  content: |
-    #!/usr/bin/env bash
-    set -ex
-    # set -o errexit
-    # set -o pipefail
+  - path: /config/provision-root.sh
+    permissions: "0744"
+    content: |
+      #!/usr/bin/env bash
+      set -ex
+      # set -o errexit
+      # set -o pipefail
 
-    if [ -z $1 ]; then
-      HLF_VERSION=2.2.0
-    else
-      HLF_VERSION=$1
-    fi
+      if [ -z $1 ]; then
+        HLF_VERSION=2.5.14
+      else
+        HLF_VERSION=$1
+      fi
 
-    if [ ${HLF_VERSION:0:4} = '2.5.'  -o ${HLF_VERSION:0:4} = '2.4.']; then
-      export GO_VERSION=1.23.6
-    elif [ ${HLF_VERSION:0:4} = '2.2.' -o ${HLF_VERSION:0:4} = '2.3.' ]; then
-      export GO_VERSION=1.14.11
-    elif [ ${HLF_VERSION:0:4} = '2.0.' -o ${HLF_VERSION:0:4} = '2.1.' ]; then
-      export GO_VERSION=1.13.15
-    elif [ ${HLF_VERSION:0:4} = '1.2.' -o ${HLF_VERSION:0:4} = '1.3.' -o ${HLF_VERSION:0:4} = '1.4.' ]; then
-      export GO_VERSION=1.10.4
-    elif [ ${HLF_VERSION:0:4} = '1.1.' ]; then
-      export GO_VERSION=1.9.7
-    else
-      >&2 echo "Unexpected HLF_VERSION ${HLF_VERSION}"
-      >&2 echo "HLF_VERSION must be a 1.1.x, 1.2.x, 1.3.x, 1.4.x, 2.0.x, 2.1.x, 2.2.x, 2.3.x, 2.4.x, or 2.5.x version"
-      exit 1
-    fi
+      if [ ${HLF_VERSION:0:4} = '2.5.'  -o ${HLF_VERSION:0:4} = '2.4.']; then
+        export GO_VERSION=1.25.3
+      elif [ ${HLF_VERSION:0:4} = '2.2.' -o ${HLF_VERSION:0:4} = '2.3.' ]; then
+        export GO_VERSION=1.14.11
+      elif [ ${HLF_VERSION:0:4} = '2.0.' -o ${HLF_VERSION:0:4} = '2.1.' ]; then
+        export GO_VERSION=1.13.15
+      elif [ ${HLF_VERSION:0:4} = '1.2.' -o ${HLF_VERSION:0:4} = '1.3.' -o ${HLF_VERSION:0:4} = '1.4.' ]; then
+        export GO_VERSION=1.10.4
+      elif [ ${HLF_VERSION:0:4} = '1.1.' ]; then
+        export GO_VERSION=1.9.7
+      else
+        >&2 echo "Unexpected HLF_VERSION ${HLF_VERSION}"
+        >&2 echo "HLF_VERSION must be a 1.1.x, 1.2.x, 1.3.x, 1.4.x, 2.0.x, 2.1.x, 2.2.x, 2.3.x, 2.4.x, or 2.5.x version"
+        exit 1
+      fi
 
 
-    # APT setup for kubectl
-    curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
-    apt-add-repository "deb http://apt.kubernetes.io/ kubernetes-xenial main"
+      # APT setup for kubectl
+      curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
+      apt-add-repository "deb http://apt.kubernetes.io/ kubernetes-xenial main"
 
-    # Install kubectl
-    apt-get -y --no-upgrade install kubectl
+      # Install kubectl
+      apt-get -y --no-upgrade install kubectl
 
-    # Install yq
-    YQ_VERSION=4.23.1
-    if [ ! -x "/usr/local/bin/yq" ]; then
-      curl --fail --silent --show-error -L "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64" -o /usr/local/bin/yq
-      chmod 755 /usr/local/bin/yq
-    fi
+      # Install yq
+      YQ_VERSION=4.48.1
+      if [ ! -x "/usr/local/bin/yq" ]; then
+        curl --fail --silent --show-error -L "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64" -o /usr/local/bin/yq
+        chmod 755 /usr/local/bin/yq
+      fi
 
-    # Install docker compose
-    if [ ! -x /usr/local/bin/docker-compose ]; then
-      curl --fail --silent --show-error -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-      chmod 755 /usr/local/bin/docker-compose
-    fi
+      # Install docker compose
+      if [ ! -x /usr/local/bin/docker-compose ]; then
+        curl --fail --silent --show-error -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+        chmod 755 /usr/local/bin/docker-compose
+      fi
 
-    # Install kind
-    KIND_VERSION=0.14.0
-    if [ ! -x "/usr/local/bin/kind" ]; then
-      curl --fail --silent --show-error -L "https://kind.sigs.k8s.io/dl/v${KIND_VERSION}/kind-linux-amd64" -o /usr/local/bin/kind
-      chmod 755 /usr/local/bin/kind
-    fi
+      # Install kind
+      KIND_VERSION=0.30.0
+      if [ ! -x "/usr/local/bin/kind" ]; then
+        curl --fail --silent --show-error -L "https://kind.sigs.k8s.io/dl/v${KIND_VERSION}/kind-linux-amd64" -o /usr/local/bin/kind
+        chmod 755 /usr/local/bin/kind
+      fi
 
-    # Install k9s
-    K9S_VERSION=0.25.3
-    if [ ! -x "/usr/local/bin/k9s" ]; then
-      curl --fail --silent --show-error -L "https://github.com/derailed/k9s/releases/download/v${K9S_VERSION}/k9s_Linux_x86_64.tar.gz" -o "/tmp/k9s_Linux_x86_64.tar.gz"
-      tar -zxf "/tmp/k9s_Linux_x86_64.tar.gz" -C /usr/local/bin k9s
-      chown root:root /usr/local/bin/k9s
-      chmod 755 /usr/local/bin/k9s
-    fi
+      # Install k9s
+      K9S_VERSION=0.50.15
+      if [ ! -x "/usr/local/bin/k9s" ]; then
+        curl --fail --silent --show-error -L "https://github.com/derailed/k9s/releases/download/v${K9S_VERSION}/k9s_Linux_amd64.tar.gz" -o "/tmp/k9s_Linux_amd64.tar.gz"
+        tar -zxf "/tmp/k9s_Linux_amd64.tar.gz" -C /usr/local/bin k9s
+        chown root:root /usr/local/bin/k9s
+        chmod 755 /usr/local/bin/k9s
+      fi
 
-    # Install ccmetadata
-    CCMETADATA_VERSION=0.2.0
-    if [ ! -x "/usr/local/bin/ccmetadata" ]; then
-      curl --fail --silent --show-error -L "https://github.com/hyperledgendary/ccmetadata/releases/download/v${CCMETADATA_VERSION}/ccmetadata-Linux-X64.tgz" -o "/tmp/ccmetadata-Linux-X64.tgz"
-      tar -zxf "/tmp/ccmetadata-Linux-X64.tgz" -C /usr/local/bin ccmetadata
-      chown root:root /usr/local/bin/ccmetadata
-      chmod 755 /usr/local/bin/ccmetadata
-    fi
+      # Install ccmetadata
+      CCMETADATA_VERSION=0.2.0
+      if [ ! -x "/usr/local/bin/ccmetadata" ]; then
+        curl --fail --silent --show-error -L "https://github.com/hyperledgendary/ccmetadata/releases/download/v${CCMETADATA_VERSION}/ccmetadata-Linux-X64.tgz" -o "/tmp/ccmetadata-Linux-X64.tgz"
+        tar -zxf "/tmp/ccmetadata-Linux-X64.tgz" -C /usr/local/bin ccmetadata
+        chown root:root /usr/local/bin/ccmetadata
+        chmod 755 /usr/local/bin/ccmetadata
+      fi
 
-    # Install just
-    JUST_VERSION=1.2.0
-    if [ ! -x "/usr/local/bin/just" ]; then
-      curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --tag ${JUST_VERSION} --to /usr/local/bin
-      chown root:root /usr/local/bin/just
-      chmod 755 /usr/local/bin/just
-    fi
+      # Install just
+      JUST_VERSION=1.43.0
+      if [ ! -x "/usr/local/bin/just" ]; then
+        curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --tag ${JUST_VERSION} --to /usr/local/bin
+        chown root:root /usr/local/bin/just
+        chmod 755 /usr/local/bin/just
+      fi
 
-- path: /config/provision-user.sh
-  permissions: '0777'
-  owner: ubuntu:ubuntu
-  content: |
-    export NVM_DIR="$HOME/.nvm"
-    [ -s "$NVM_DIR/nvm.sh" ] || curl --fail --silent --show-error -o- https://raw.githubusercontent.com/creationix/nvm/v0.31.3/install.sh | bash
-    . "$NVM_DIR/nvm.sh"
+  - path: /config/provision-user.sh
+    permissions: "0777"
+    owner: ubuntu:ubuntu
+    content: |
+      export NVM_DIR="$HOME/.nvm"
+      [ -s "$NVM_DIR/nvm.sh" ] || curl --fail --silent --show-error -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
+      . "$NVM_DIR/nvm.sh"
 
-    # Install latest node v16.x, latest typescript, weft
-    nvm install 16
-    npm install -g typescript
-    npm install -g @hyperledger-labs/weft
+      # Install latest node LTS version, latest typescript, weft
+      nvm install --lts
+      npm install -g typescript
+      npm install -g @hyperledger-labs/weft
 
 # Use Google DNS as the mac resolvers are not 100% reliable for the npm dependency builds in Docker
 bootcmd:

--- a/full-stack-asset-transfer-guide/infrastructure/sample-network/network
+++ b/full-stack-asset-transfer-guide/infrastructure/sample-network/network
@@ -33,7 +33,7 @@ function context() {
   export ${name}="${!override_name:-${default_value}}"
 }
 
-context FABRIC_VERSION            2.5.13
+context FABRIC_VERSION            2.5.14
 context FABRIC_CA_VERSION         1.5.15
 
 context CLUSTER_RUNTIME           kind                  # or k3s for Rancher
@@ -82,7 +82,7 @@ context PEER_IMAGE_LABEL          0.11.0 # When using k8s-fabric-peer in Fabric 
 context ORDERER_IMAGE             ${FABRIC_CONTAINER_REGISTRY}/fabric-orderer
 context ORDERER_IMAGE_LABEL       ${FABRIC_VERSION}
 context OPERATOR_IMAGE            ghcr.io/hyperledger-labs/fabric-operator
-context OPERATOR_IMAGE_LABEL      1.0.4
+context OPERATOR_IMAGE_LABEL      latest
 context INIT_IMAGE                registry.access.redhat.com/ubi8/ubi-minimal
 context INIT_IMAGE_LABEL          latest
 context GRPCWEB_IMAGE             ghcr.io/hyperledger-labs/grpc-web

--- a/test-network/scripts/utils.sh
+++ b/test-network/scripts/utils.sh
@@ -17,9 +17,9 @@ function printHelp() {
     println
     println "    Flags:"
     println "    Used with \033[0;32mnetwork.sh prereq\033[0m:"
-    println "    -i     FabricVersion (default: '2.5.13')"
+    println "    -i     FabricVersion (default: '2.5.14')"
     println "    -cai   Fabric CA Version (default: '1.5.15')"
-    println  
+    println
   elif [ "$USAGE" == "up" ]; then
     println "Usage: "
     println "  network.sh \033[0;32mup\033[0m [Flags]"
@@ -109,7 +109,7 @@ function printHelp() {
     println
     println " Examples:"
     println "   network.sh deployCCAAS  -ccn basicj -ccp ../asset-transfer-basic/chaincode-java"
-    println "   network.sh deployCCAAS  -ccn basict -ccp ../asset-transfer-basic/chaincode-typescript -ccaasdocker false" 
+    println "   network.sh deployCCAAS  -ccn basict -ccp ../asset-transfer-basic/chaincode-typescript -ccaasdocker false"
   elif [ "$USAGE" == "cc" ] ; then
     println "Usage: "
     println "  network.sh cc <Mode> [Flags]"
@@ -121,7 +121,7 @@ function printHelp() {
     println "      \033[0;32mquery\033[0m - execute an query operation"
     println
     println "    Flags:"
-    println "    -org <number>     - Org number for the executing the command (1,2,etc) (default is 1)."    
+    println "    -org <number>     - Org number for the executing the command (1,2,etc) (default is 1)."
     println "    -c <channel name> - Name of channel"
     println "    -ccn <name>       - Chaincode name."
     println "    -ccl <language>   - Programming language of chaincode to deploy: go, java, javascript, typescript"
@@ -159,7 +159,7 @@ function printHelp() {
     println
     println "    Flags:"
     println "    Used with \033[0;32mnetwork.sh prereq\033[0m"
-    println "    -i     FabricVersion (default: '2.5.13')"
+    println "    -i     FabricVersion (default: '2.5.14')"
     println "    -cai   Fabric CA Version (default: '1.5.15')"
     println
     println "    Used with \033[0;32mnetwork.sh up\033[0m, \033[0;32mnetwork.sh createChannel\033[0m:"
@@ -207,21 +207,21 @@ function installPrereqs() {
 
   infoln "installing prereqs"
 
-  FILE=../install-fabric.sh     
+  FILE=../install-fabric.sh
   if [ ! -f $FILE ]; then
     curl -sSLO https://raw.githubusercontent.com/hyperledger/fabric/main/scripts/install-fabric.sh && chmod +x install-fabric.sh
     cp install-fabric.sh ..
   fi
-  
+
   IMAGE_PARAMETER=""
   if [ "$IMAGETAG" != "default" ]; then
     IMAGE_PARAMETER="-f ${IMAGETAG}"
-  fi 
+  fi
 
   CA_IMAGE_PARAMETER=""
   if [ "$CA_IMAGETAG" != "default" ]; then
     CA_IMAGE_PARAMETER="-c ${CA_IMAGETAG}"
-  fi 
+  fi
 
   cd ..
   ./install-fabric.sh ${IMAGE_PARAMETER} ${CA_IMAGE_PARAMETER} docker binary

--- a/token-sdk/Dockerfile
+++ b/token-sdk/Dockerfile
@@ -1,5 +1,5 @@
 #build stage
-FROM golang:1.23-bookworm AS builder
+FROM golang:latest AS builder
 WORKDIR /go/src/app
 COPY go.mod .
 COPY go.sum .
@@ -8,7 +8,7 @@ COPY . .
 RUN go build -o /go/bin/app
 
 #final stage
-FROM golang:1.23-bookworm
+FROM golang:latest
 COPY --from=builder /go/bin/app /app
 ENTRYPOINT /app
 LABEL Name=tokens Version=0.1.0

--- a/token-sdk/tokenchaincode/Dockerfile
+++ b/token-sdk/tokenchaincode/Dockerfile
@@ -1,17 +1,17 @@
-FROM golang:1.23 as builder
+FROM golang:latest as builder
 RUN git clone https://github.com/hyperledger-labs/fabric-token-sdk.git
-WORKDIR fabric-token-sdk 
+WORKDIR fabric-token-sdk
 
 # Change the hash to checkout a different commit / version. It should be the same as in app/go.mod.
 RUN git checkout v0.3.0 && go mod download
 RUN CGO_ENABLED=1 go build -buildvcs=false -o /tcc token/services/network/fabric/tcc/main/main.go && chmod +x /tcc
 
 # Final image
-FROM golang:1.23
+FROM golang:latest
 COPY --from=builder /tcc .
 EXPOSE 9999
 
-# zkatdlog is the output of the tokengen command. It contains the certificates 
+# zkatdlog is the output of the tokengen command. It contains the certificates
 # of the issuer and auditor and the CA that issues owner account credentials,
 # As well as cryptographic curves needed by the chaincode to verify proofs.
 # It is generated once to initialize the network, when the 'init' function is


### PR DESCRIPTION
- Node latest LTS
- Go latest stable
- Fabric 2.5.14, 3.1.3
- Just 1.43.0
- k9s 0.50.15
- Kind 0.30.0
- yq 4.48.1
- nvm 0.40.3

This addresses build breakages due to back-level versions.