### PR TITLE
Remove obsolete version element from compose files

### DIFF
--- a/asset-transfer-basic/chaincode-external/docker-compose-chaincode.yaml
+++ b/asset-transfer-basic/chaincode-external/docker-compose-chaincode.yaml
@@ -1,5 +1,3 @@
-version: "3.6"
-
 networks:
     docker_test:
         external: true

--- a/asset-transfer-basic/rest-api-typescript/docker-compose.yaml
+++ b/asset-transfer-basic/rest-api-typescript/docker-compose.yaml
@@ -1,17 +1,17 @@
-version: '3'
-# Replace network name with the fabric test-network name 
+# Replace network name with the fabric test-network name
 services:
-  redis: 
-    image: 'redis'
-    command: ['--maxmemory-policy','noeviction','--requirepass','${REDIS_PASSWORD}']
+  redis:
+    image: "redis"
+    command:
+      ["--maxmemory-policy", "noeviction", "--requirepass", "${REDIS_PASSWORD}"]
     ports:
       - 6379:6379
     networks:
       - fabric_test
-  
+
   nodeapp:
-    image: 'ghcr.io/hyperledger/fabric-rest-sample:latest'
-    command: ['start:dotenv']
+    image: "ghcr.io/hyperledger/fabric-rest-sample:latest"
+    command: ["start:dotenv"]
     ports:
       - 3000:3000
     env_file:
@@ -19,9 +19,8 @@ services:
     environment:
       - REDIS_PASSWORD
     networks:
-        - fabric_test
-
+      - fabric_test
 
 networks:
   fabric_test:
-    external: true 
+    external: true

--- a/test-network/addOrg3/compose/compose-ca-org3.yaml
+++ b/test-network/addOrg3/compose/compose-ca-org3.yaml
@@ -3,8 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-version: '3.7'
-
 networks:
   test:
     name: fabric_test

--- a/test-network/addOrg3/compose/compose-couch-org3.yaml
+++ b/test-network/addOrg3/compose/compose-couch-org3.yaml
@@ -3,8 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-version: '3.7'
-
 networks:
   test:
     name: fabric_test

--- a/test-network/addOrg3/compose/compose-org3.yaml
+++ b/test-network/addOrg3/compose/compose-org3.yaml
@@ -3,8 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-version: '3.7'
-
 volumes:
   peer0.org3.example.com:
 

--- a/test-network/addOrg3/compose/docker/docker-compose-ca-org3.yaml
+++ b/test-network/addOrg3/compose/docker/docker-compose-ca-org3.yaml
@@ -2,6 +2,3 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-
-version: '3.7'
-

--- a/test-network/addOrg3/compose/docker/docker-compose-couch-org3.yaml
+++ b/test-network/addOrg3/compose/docker/docker-compose-couch-org3.yaml
@@ -2,6 +2,3 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-
-version: '3.7'
-

--- a/test-network/addOrg3/compose/docker/docker-compose-org3.yaml
+++ b/test-network/addOrg3/compose/docker/docker-compose-org3.yaml
@@ -3,14 +3,11 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-version: '3.7'
-
 networks:
   test:
     name: fabric_test
 
 services:
-
   peer0.org3.example.com:
     container_name: peer0.org3.example.com
     image: hyperledger/fabric-peer:latest

--- a/test-network/addOrg3/compose/podman/podman-compose-ca-org3.yaml
+++ b/test-network/addOrg3/compose/podman/podman-compose-ca-org3.yaml
@@ -3,8 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-version: '3.7'
-
 networks:
   test:
     name: fabric_test

--- a/test-network/addOrg3/compose/podman/podman-compose-couch-org3.yaml
+++ b/test-network/addOrg3/compose/podman/podman-compose-couch-org3.yaml
@@ -3,8 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-version: '3.7'
-
 networks:
   test:
     name: fabric_test

--- a/test-network/addOrg3/compose/podman/podman-compose-org3.yaml
+++ b/test-network/addOrg3/compose/podman/podman-compose-org3.yaml
@@ -3,8 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-version: '3.7'
-
 volumes:
   peer0.org3.example.com:
 

--- a/test-network/compose/compose-bft-test-net.yaml
+++ b/test-network/compose/compose-bft-test-net.yaml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 volumes:
   orderer.example.com:
   orderer2.example.com:

--- a/test-network/compose/compose-ca.yaml
+++ b/test-network/compose/compose-ca.yaml
@@ -3,8 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-version: '3.7'
-
 networks:
   test:
     name: fabric_test

--- a/test-network/compose/compose-couch.yaml
+++ b/test-network/compose/compose-couch.yaml
@@ -3,8 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-version: '3.7'
-
 networks:
   test:
     name: fabric_test

--- a/test-network/compose/compose-test-net.yaml
+++ b/test-network/compose/compose-test-net.yaml
@@ -3,8 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-version: '3.7'
-
 volumes:
   orderer.example.com:
   peer0.org1.example.com:

--- a/test-network/compose/docker/docker-compose-bft-test-net.yaml
+++ b/test-network/compose/docker/docker-compose-bft-test-net.yaml
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-version: '3.7'
 services:
   peer0.org1.example.com:
     container_name: peer0.org1.example.com

--- a/test-network/compose/docker/docker-compose-ca.yaml
+++ b/test-network/compose/docker/docker-compose-ca.yaml
@@ -2,6 +2,3 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-
-version: '3.7'
-

--- a/test-network/compose/docker/docker-compose-couch.yaml
+++ b/test-network/compose/docker/docker-compose-couch.yaml
@@ -2,5 +2,3 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-
-version: '3.7'

--- a/test-network/compose/docker/docker-compose-test-net.yaml
+++ b/test-network/compose/docker/docker-compose-test-net.yaml
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-version: '3.7'
 services:
   peer0.org1.example.com:
     container_name: peer0.org1.example.com

--- a/test-network/compose/podman/podman-compose-ca.yaml
+++ b/test-network/compose/podman/podman-compose-ca.yaml
@@ -2,5 +2,3 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-
-version: '3.7'

--- a/test-network/compose/podman/podman-compose-couch.yaml
+++ b/test-network/compose/podman/podman-compose-couch.yaml
@@ -2,5 +2,3 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-
-version: '3.7'

--- a/test-network/compose/podman/podman-compose-test-net.yaml
+++ b/test-network/compose/podman/podman-compose-test-net.yaml
@@ -3,8 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-version: '3.7'
-
 services:
   peer0.org1.example.com:
     volumes:

--- a/test-network/prometheus-grafana/docker-compose.yaml
+++ b/test-network/prometheus-grafana/docker-compose.yaml
@@ -1,8 +1,6 @@
-version: '3'
-
 volumes:
-    prometheus_data: {}
-    grafana_storage: {}
+  prometheus_data: {}
+  grafana_storage: {}
 
 services:
   prometheus:
@@ -12,13 +10,13 @@ services:
       - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
       - prometheus_data:/prometheus
     command:
-      - '--config.file=/etc/prometheus/prometheus.yml'
-      - '--storage.tsdb.path=/prometheus'
-      - '--web.console.libraries=/usr/share/prometheus/console_libraries'
-      - '--web.console.templates=/usr/share/prometheus/consoles'
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+      - "--web.console.libraries=/usr/share/prometheus/console_libraries"
+      - "--web.console.templates=/usr/share/prometheus/consoles"
     ports:
       - "9090:9090"
-    
+
   grafana:
     image: grafana/grafana:8.3.4
     container_name: grafana
@@ -54,8 +52,8 @@ services:
       - /proc:/host/proc:ro
       - /sys:/host/sys:ro
     command:
-      - '--path.procfs=/host/proc'
-      - '--path.sysfs=/host/sys'
+      - "--path.procfs=/host/proc"
+      - "--path.sysfs=/host/sys"
       - --collector.filesystem.ignored-mount-points
       - "^/(sys|proc|dev|host|etc|rootfs/var/lib/docker/containers|rootfs/var/lib/docker/overlay2|rootfs/run/docker/netns|rootfs/var/lib/docker/aufs)($$|/)"
     ports:
@@ -64,5 +62,5 @@ services:
 
 networks:
   default:
-      external: true
-      name: fabric_test
+    external: true
+    name: fabric_test

--- a/token-sdk/compose-ca.yaml
+++ b/token-sdk/compose-ca.yaml
@@ -3,8 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-version: '3.7'
-
 services:
   ca_token_network:
     image: hyperledger/fabric-ca:1.5.7

--- a/token-sdk/docker-compose.yaml
+++ b/token-sdk/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 # fabric_test is the name of the fabric-samples test network.
 # By connecting to it, we can reach the peers at their DNS names
 # (e.g. peer0.org1.example.com).
@@ -44,7 +42,7 @@ services:
     ports:
       - 9100:9000
     expose:
-      - 9101  
+      - 9101
     networks:
       - test
     depends_on:
@@ -92,10 +90,10 @@ services:
         condition: service_healthy
 
   swagger-ui:
-      image: swaggerapi/swagger-ui
-      ports:
-          - '8080:8080'
-      environment:
-          - URL=/swagger.yaml
-      volumes:
-          - ./swagger.yaml:/usr/share/nginx/html/swagger.yaml
+    image: swaggerapi/swagger-ui
+    ports:
+      - "8080:8080"
+    environment:
+      - URL=/swagger.yaml
+    volumes:
+      - ./swagger.yaml:/usr/share/nginx/html/swagger.yaml

--- a/token-sdk/explorer/docker-compose.yaml
+++ b/token-sdk/explorer/docker-compose.yaml
@@ -1,9 +1,6 @@
-
 # SPDX-License-Identifier: Apache-2.0
 
 # see https://github.com/hyperledger-labs/blockchain-explorer
-
-version: '2.1'
 
 volumes:
   pgdata:
@@ -15,7 +12,6 @@ networks:
     external: true
 
 services:
-
   explorerdb.mynetwork.com:
     image: ghcr.io/hyperledger-labs/explorer-db:latest
     container_name: explorerdb.mynetwork.com


### PR DESCRIPTION
The version element is obsolete and unused since Compose v1 was deprecated in favour of Compose v2 in 2022, and reached end-of-life in 2023. The version element generates warning messages running Docker Compose commands when bringing up and down the test-network, which adds unnecessary noise and can be confusing for users.