### PR TITLE
Remove redundant throws from Java close() methods

### DIFF
--- a/.github/workflows/test-network-k8s.yaml
+++ b/.github/workflows/test-network-k8s.yaml
@@ -22,11 +22,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Test the network
+        id: run-test
         working-directory: test-network-k8s
         run: ../ci/scripts/run-k8s-test-network-basic.sh
         env:
           CLIENT_LANGUAGE: typescript
           CHAINCODE_LANGUAGE: java
+      - name: Upload failure logs
+        if: ${{ failure() && steps.run-test.conclusion == 'failure' }}
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: ${{ github.job }}-logs
+          path: test-network-k8s/network-debug.log
 
   ccaas-external:
     runs-on: ${{ github.repository == 'hyperledger/fabric-samples' && 'fabric-ubuntu-22.04' || 'ubuntu-22.04' }}
@@ -34,11 +41,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Test the network
+        id: run-test
         working-directory: test-network-k8s
         run: ../ci/scripts/run-k8s-test-network-basic.sh
         env:
           CLIENT_LANGUAGE: typescript
           CHAINCODE_LANGUAGE: external
+      - name: Upload failure logs
+        if: ${{ failure() && steps.run-test.conclusion == 'failure' }}
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: ${{ github.job }}-logs
+          path: test-network-k8s/network-debug.log
 
   k8s-builder:
     runs-on: ${{ github.repository == 'hyperledger/fabric-samples' && 'fabric-ubuntu-22.04' || 'ubuntu-22.04' }}
@@ -46,12 +60,19 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Test the network
+        id: run-test
         working-directory: test-network-k8s
         run: ../ci/scripts/run-k8s-test-network-basic.sh
         env:
           CHAINCODE_NAME: basic
           CHAINCODE_LANGUAGE: java
           CHAINCODE_BUILDER: k8s
+      - name: Upload failure logs
+        if: ${{ failure() && steps.run-test.conclusion == 'failure' }}
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: ${{ github.job }}-logs
+          path: test-network-k8s/network-debug.log
 
   multi-namespace:
     runs-on: ${{ github.repository == 'hyperledger/fabric-samples' && 'fabric-ubuntu-22.04' || 'ubuntu-22.04' }}
@@ -59,6 +80,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Test the network
+        id: run-test
         working-directory: test-network-k8s
         run: ../ci/scripts/run-k8s-test-network-basic.sh
         env:
@@ -68,6 +90,12 @@ jobs:
           CHAINCODE_NAME: basic
           CHAINCODE_LANGUAGE: java
           CHAINCODE_BUILDER: k8s
+      - name: Upload failure logs
+        if: ${{ failure() && steps.run-test.conclusion == 'failure' }}
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: ${{ github.job }}-logs
+          path: test-network-k8s/network-debug.log
 
   bft-orderer:
     runs-on: ${{ github.repository == 'hyperledger/fabric-samples' && 'fabric-ubuntu-22.04' || 'ubuntu-22.04' }}
@@ -78,6 +106,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Test the network
+        id: run-test
         working-directory: test-network-k8s
         run: ../ci/scripts/run-k8s-test-network-basic.sh
         env:
@@ -87,3 +116,9 @@ jobs:
           # To test BFT Orderers, Fabric v3.x is explicitly specified here.
           FABRIC_VERSION: '3.1'
           ORDERER_TYPE: bft
+      - name: Upload failure logs
+        if: ${{ failure() && steps.run-test.conclusion == 'failure' }}
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: ${{ github.job }}-logs
+          path: test-network-k8s/network-debug.log

--- a/asset-transfer-basic/chaincode-java/src/test/java/org/hyperledger/fabric/samples/assettransfer/AssetTransferTest.java
+++ b/asset-transfer-basic/chaincode-java/src/test/java/org/hyperledger/fabric/samples/assettransfer/AssetTransferTest.java
@@ -83,7 +83,7 @@ public final class AssetTransferTest {
         }
 
         @Override
-        public void close() throws Exception {
+        public void close() {
             // do nothing
         }
 

--- a/asset-transfer-events/application-gateway-java/src/main/java/App.java
+++ b/asset-transfer-events/application-gateway-java/src/main/java/App.java
@@ -169,7 +169,7 @@ public final class App implements AutoCloseable {
     }
 
     @Override
-    public void close() throws Exception {
+    public void close() {
         executor.shutdownNow();
     }
 }

--- a/token-erc-721/chaincode-java/src/test/java/org/hyperledger/fabric/samples/erc721/ERC721TokenContractTest.java
+++ b/token-erc-721/chaincode-java/src/test/java/org/hyperledger/fabric/samples/erc721/ERC721TokenContractTest.java
@@ -70,7 +70,7 @@ public class ERC721TokenContractTest {
     }
 
     @Override
-    public void close() throws Exception {
+    public void close() {
       // do nothing
     }
   }


### PR DESCRIPTION
A close() imlementation that never throws an exception does not need to declare that one might be thrown, even if the corresponding method in an implemented interface does declare an exception might be thrown.