### PR TITLE
changed weak ordering implementation in sort.slice

### DIFF
--- a/token-erc-1155/chaincode-go/chaincode/contract.go
+++ b/token-erc-1155/chaincode-go/chaincode/contract.go
@@ -1113,9 +1113,9 @@ func sortedKeysToID(m map[ToID]uint64) []ToID {
 	// Sort the slice first according to ID if equal then sort by recipient ("To" field)
 	sort.Slice(keys, func(i, j int) bool {
 		if keys[i].ID != keys[j].ID {
-			return keys[i].To < keys[j].To
+			return keys[i].ID < keys[j].ID
 		}
-		return keys[i].ID < keys[j].ID
+		return keys[i].To < keys[j].To
 	})
 	return keys
 }

--- a/token-erc-1155/chaincode-go/chaincode/contract_test.go
+++ b/token-erc-1155/chaincode-go/chaincode/contract_test.go
@@ -1,0 +1,32 @@
+package chaincode
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSortedKeysToID(t *testing.T) {
+	testMap := map[ToID]uint64{
+		{To: "Alice", ID: 2}:   100,
+		{To: "Bob", ID: 1}:     200,
+		{To: "Charlie", ID: 2}: 300,
+		{To: "Alice", ID: 1}:   400,
+		{To: "Bob", ID: 2}:     500,
+		{To: "Charlie", ID: 1}: 600,
+	}
+
+	expectedResult := []ToID{
+		{To: "Alice", ID: 1},
+		{To: "Bob", ID: 1},
+		{To: "Charlie", ID: 1},
+		{To: "Alice", ID: 2},
+		{To: "Bob", ID: 2},
+		{To: "Charlie", ID: 2},
+	}
+
+	result := sortedKeysToID(testMap)
+
+	if !reflect.DeepEqual(result, expectedResult) {
+		t.Fatalf("sortedKeysToID failed.\nExpected: %v\nGot:      %v", expectedResult, result)
+	}
+}


### PR DESCRIPTION
1. The original code compared the To (recipient) strings when the numeric IDs were different, and fell back to comparing IDs when they were the same. This was completely backwards and broke Go's strict weak ordering. We fixed it to accurately compare IDs first, and properly fallback to the To string on identical IDs.
2. successfully implemented a unit test checking identical IDs for different To strings (and vice-versa) to explicitly assert that the Go map randomness is predictably flattened to an identically ordered sequence on every peer simulation.
3. Since token-erc-1155 currently only contains chaincode-go, there are no Javascript/Java/Typescript counterparts requiring this identical fix in this repository.

Closes #1413