### PR TITLE
Fix Go linting in new contribution

### DIFF
--- a/full-stack-asset-transfer-guide/applications/trader-go/commands/create.go
+++ b/full-stack-asset-transfer-guide/applications/trader-go/commands/create.go
@@ -1,7 +1,7 @@
 package commands
 
 import (
-	"fmt"
+	"errors"
 
 	"github.com/hyperledger/fabric-gateway/pkg/client"
 )
@@ -10,7 +10,7 @@ import (
 // Arguments: <assetId> <ownerName> <color>
 func cmdCreate(gw *client.Gateway, args []string) error {
 	if len(args) < 3 {
-		return fmt.Errorf("arguments: <assetId> <ownerName> <color>")
+		return errors.New("arguments: <assetId> <ownerName> <color>")
 	}
 
 	network := gw.GetNetwork(channelName())

--- a/full-stack-asset-transfer-guide/applications/trader-go/commands/delete.go
+++ b/full-stack-asset-transfer-guide/applications/trader-go/commands/delete.go
@@ -1,7 +1,7 @@
 package commands
 
 import (
-	"fmt"
+	"errors"
 
 	"github.com/hyperledger/fabric-gateway/pkg/client"
 )
@@ -10,7 +10,7 @@ import (
 // Arguments: <assetId>
 func cmdDelete(gw *client.Gateway, args []string) error {
 	if len(args) < 1 {
-		return fmt.Errorf("arguments: <assetId>")
+		return errors.New("arguments: <assetId>")
 	}
 
 	network := gw.GetNetwork(channelName())

--- a/full-stack-asset-transfer-guide/applications/trader-go/commands/listen.go
+++ b/full-stack-asset-transfer-guide/applications/trader-go/commands/listen.go
@@ -57,7 +57,6 @@ func cmdListen(gw *client.Gateway, _ []string) error {
 		if simulatedFailureCount > 0 {
 			eventCount++
 			if eventCount >= simulatedFailureCount {
-				eventCount = 0
 				return &ExpectedError{Message: "Simulated write failure"}
 			}
 		}

--- a/full-stack-asset-transfer-guide/applications/trader-go/commands/read.go
+++ b/full-stack-asset-transfer-guide/applications/trader-go/commands/read.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/hyperledger/fabric-gateway/pkg/client"
@@ -11,7 +12,7 @@ import (
 // Arguments: <assetId>
 func cmdRead(gw *client.Gateway, args []string) error {
 	if len(args) < 1 {
-		return fmt.Errorf("arguments: <assetId>")
+		return errors.New("arguments: <assetId>")
 	}
 
 	network := gw.GetNetwork(channelName())

--- a/full-stack-asset-transfer-guide/applications/trader-go/commands/transfer.go
+++ b/full-stack-asset-transfer-guide/applications/trader-go/commands/transfer.go
@@ -1,7 +1,7 @@
 package commands
 
 import (
-	"fmt"
+	"errors"
 
 	"github.com/hyperledger/fabric-gateway/pkg/client"
 )
@@ -10,7 +10,7 @@ import (
 // Arguments: <assetId> <ownerName> <ownerMspId>
 func cmdTransfer(gw *client.Gateway, args []string) error {
 	if len(args) < 3 {
-		return fmt.Errorf("arguments: <assetId> <ownerName> <ownerMspId>")
+		return errors.New("arguments: <assetId> <ownerName> <ownerMspId>")
 	}
 
 	network := gw.GetNetwork(channelName())

--- a/full-stack-asset-transfer-guide/applications/trader-go/main.go
+++ b/full-stack-asset-transfer-guide/applications/trader-go/main.go
@@ -25,7 +25,7 @@ func run() error {
 	args := os.Args[1:]
 	if len(args) == 0 {
 		printUsage()
-		return fmt.Errorf("no command specified")
+		return errors.New("no command specified")
 	}
 
 	commandName := args[0]


### PR DESCRIPTION
Pull requests to add new Go linting and deliver a Go implementation of the full-stack-asset-transfer-guide application overlapped, resulting in lint failures in the new application code. This change fixes those lint failures.