### PR TITLE
fix(scripts): resolve package ID calculation path error when CC_PACKAGE_ONLY is true

### DIFF
--- a/test-network/scripts/packageCC.sh
+++ b/test-network/scripts/packageCC.sh
@@ -90,7 +90,11 @@ packageChaincode() {
   res=$?
   { set +x; } 2>/dev/null
   cat log.txt
-  PACKAGE_ID=$(peer lifecycle chaincode calculatepackageid ${CC_NAME}.tar.gz)
+  if [ ${CC_PACKAGE_ONLY} = true ] ; then
+    PACKAGE_ID=$(peer lifecycle chaincode calculatepackageid packagedChaincode/${CC_NAME}_${CC_VERSION}.tar.gz)
+  else
+    PACKAGE_ID=$(peer lifecycle chaincode calculatepackageid ${CC_NAME}.tar.gz)
+  fi
   verifyResult $res "Chaincode packaging has failed"
   successln "Chaincode is packaged"
 }


### PR DESCRIPTION
# Description

When `CC_PACKAGE_ONLY` is set to `true`, `packageCC.sh` creates the chaincode package at `packagedChaincode/${CC_NAME}_${CC_VERSION}.tar.gz`. However, the script previously attempted to calculate the Package ID using `${CC_NAME}.tar.gz` in the root directory, causing the command to fail with a file not found error.

This PR updates `packageChaincode()` to check if `CC_PACKAGE_ONLY` is set to `true` and calculate the package ID using the correct filepath.

Fixes #1404
