### PR TITLE
fix: fall back to cli delay in retry loops

### DIFF
--- a/test-network/scripts/ccutils.sh
+++ b/test-network/scripts/ccutils.sh
@@ -53,8 +53,8 @@ function checkCommitReadiness() {
   # continue to poll
   # we either get a successful response, or reach MAX RETRY
   while [ $rc -ne 0 -a $COUNTER -lt $MAX_RETRY ]; do
-    sleep $DELAY
-    infoln "Attempting to check the commit readiness of the chaincode definition on peer0.org${ORG}, Retry after $DELAY seconds."
+    sleep ${DELAY:-$CLI_DELAY}
+    infoln "Attempting to check the commit readiness of the chaincode definition on peer0.org${ORG}, Retry after ${DELAY:-$CLI_DELAY} seconds."
     set -x
     peer lifecycle chaincode checkcommitreadiness --channelID $CHANNEL_NAME --name ${CC_NAME} --version ${CC_VERSION} --sequence ${CC_SEQUENCE} ${INIT_REQUIRED} ${CC_END_POLICY} ${CC_COLL_CONFIG} --output json >&log.txt
     res=$?
@@ -102,8 +102,8 @@ function queryCommitted() {
   # continue to poll
   # we either get a successful response, or reach MAX RETRY
   while [ $rc -ne 0 -a $COUNTER -lt $MAX_RETRY ]; do
-    sleep $DELAY
-    infoln "Attempting to Query committed status on peer0.org${ORG}, Retry after $DELAY seconds."
+    sleep ${DELAY:-$CLI_DELAY}
+    infoln "Attempting to Query committed status on peer0.org${ORG}, Retry after ${DELAY:-$CLI_DELAY} seconds."
     set -x
     peer lifecycle chaincode querycommitted --channelID $CHANNEL_NAME --name ${CC_NAME} >&log.txt
     res=$?
@@ -131,7 +131,7 @@ function chaincodeInvokeInit() {
   # continue to poll
   # we either get a successful response, or reach MAX RETRY
   while [ $rc -ne 0 -a $COUNTER -lt $MAX_RETRY ]; do
-    sleep $DELAY
+    sleep ${DELAY:-$CLI_DELAY}
     # while 'peer chaincode' command can get the orderer endpoint from the
     # peer (if join was successful), let's supply it directly as we know
     # it using the "-o" option
@@ -157,8 +157,8 @@ function chaincodeQuery() {
   # continue to poll
   # we either get a successful response, or reach MAX RETRY
   while [ $rc -ne 0 -a $COUNTER -lt $MAX_RETRY ]; do
-    sleep $DELAY
-    infoln "Attempting to Query peer0.org${ORG}, Retry after $DELAY seconds."
+    sleep ${DELAY:-$CLI_DELAY}
+    infoln "Attempting to Query peer0.org${ORG}, Retry after ${DELAY:-$CLI_DELAY} seconds."
     set -x
     peer chaincode query -C $CHANNEL_NAME -n ${CC_NAME} -c '{"Args":["org.hyperledger.fabric:GetMetadata"]}' >&log.txt
     res=$?
@@ -232,8 +232,8 @@ queryInstalledOnPeer() {
   # continue to poll
   # we either get a successful response, or reach MAX RETRY
   while [ $rc -ne 0 -a $COUNTER -lt $MAX_RETRY ]; do
-    #sleep $DELAY
-    #infoln "Attempting to list on peer0.org${ORG}, Retry after $DELAY seconds."
+    #sleep ${DELAY:-$CLI_DELAY}
+    #infoln "Attempting to list on peer0.org${ORG}, Retry after ${DELAY:-$CLI_DELAY} seconds."
     peer lifecycle chaincode queryinstalled >&log.txt
     res=$?
     let rc=$res
@@ -249,8 +249,8 @@ queryCommittedOnChannel() {
   # continue to poll
   # we either get a successful response, or reach MAX RETRY
   while [ $rc -ne 0 -a $COUNTER -lt $MAX_RETRY ]; do
-    #sleep $DELAY
-    #infoln "Attempting to list on peer0.org${ORG}, Retry after $DELAY seconds."
+    #sleep ${DELAY:-$CLI_DELAY}
+    #infoln "Attempting to list on peer0.org${ORG}, Retry after ${DELAY:-$CLI_DELAY} seconds."
     peer lifecycle chaincode querycommitted -C $CHANNEL >&log.txt
     res=$?
     let rc=$res
@@ -299,8 +299,8 @@ chaincodeInvoke() {
   # continue to poll
   # we either get a successful response, or reach MAX RETRY
   while [ $rc -ne 0 -a $COUNTER -lt $MAX_RETRY ]; do
-    sleep $DELAY
-    infoln "Attempting to Invoke on peer0.org${ORG}, Retry after $DELAY seconds."
+    sleep ${DELAY:-$CLI_DELAY}
+    infoln "Attempting to Invoke on peer0.org${ORG}, Retry after ${DELAY:-$CLI_DELAY} seconds."
     set -x
     peer chaincode invoke -o localhost:7050 -C $CHANNEL_NAME -n ${CC_NAME} -c ${CC_INVOKE_CONSTRUCTOR} --tls --cafile $ORDERER_CA  --peerAddresses localhost:7051 --tlsRootCertFiles $PEER0_ORG1_CA --peerAddresses localhost:9051 --tlsRootCertFiles $PEER0_ORG2_CA  >&log.txt
     res=$?
@@ -328,8 +328,8 @@ chaincodeQuery() {
   # continue to poll
   # we either get a successful response, or reach MAX RETRY
   while [ $rc -ne 0 -a $COUNTER -lt $MAX_RETRY ]; do
-    sleep $DELAY
-    infoln "Attempting to Query peer0.org${ORG}, Retry after $DELAY seconds."
+    sleep ${DELAY:-$CLI_DELAY}
+    infoln "Attempting to Query peer0.org${ORG}, Retry after ${DELAY:-$CLI_DELAY} seconds."
     set -x
     peer chaincode query -C $CHANNEL_NAME -n ${CC_NAME} -c ${CC_QUERY_CONSTRUCTOR} >&log.txt
     res=$?


### PR DESCRIPTION
## Type of change

- Bug fix
## Description

Addresses issue #1411.

Use `CLI_DELAY` as the fallback when `DELAY` is unset in the chaincode retry loops in `test-network/scripts/ccutils.sh`. This prevents the shell from invoking `sleep` without an operand while preserving any explicitly supplied `DELAY` value.

## Additional details

The change updates retry sleeps and matching log messages in the shared helper script.

Validation:
- `bash -n test-network/scripts/ccutils.sh` passed.
- - `git diff --check` passed.
## Related issues

Closes #1411.