### PR TITLE
Add rollout diagnostics for cloud-native deployment wait failures

### DIFF
--- a/full-stack-asset-transfer-guide/infrastructure/sample-network/network
+++ b/full-stack-asset-transfer-guide/infrastructure/sample-network/network
@@ -53,7 +53,7 @@ context INGRESS_DOMAIN            localho.st
 context COREDNS_DOMAIN_OVERRIDE   true
 context LOG_FILE                  network.log
 context DEBUG_FILE                network-debug.log
-context LOG_ERROR_LINES           1
+context LOG_ERROR_LINES           200
 context USE_LOCAL_REGISTRY        true
 context LOCAL_REGISTRY_NAME       kind-registry
 context LOCAL_REGISTRY_PORT       5000

--- a/full-stack-asset-transfer-guide/infrastructure/sample-network/scripts/utils.sh
+++ b/full-stack-asset-transfer-guide/infrastructure/sample-network/scripts/utils.sh
@@ -95,7 +95,18 @@ function wait_for_deployment() {
   local name=$1
   push_fn "Waiting for deployment $name"
 
-  kubectl -n $NS rollout status deploy $name
+  if ! kubectl -n $NS rollout status deploy $name; then
+    local selector=$(kubectl -n $NS get deploy $name -o json | jq -r '.spec.selector.matchLabels | to_entries | map("\(.key)=\(.value)") | join(",")')
+    echo "----- deploy/$name did not become ready - diagnostics follow -----"
+    kubectl -n $NS describe deploy $name || true
+    kubectl -n $NS get pods -l "$selector" -o wide || true
+    kubectl -n $NS describe pods -l "$selector" || true
+    kubectl -n $NS logs -l "$selector" --all-containers --tail=200 --previous || true
+    kubectl -n $NS logs -l "$selector" --all-containers --tail=200 || true
+    echo "----- end diagnostics for deploy/$name -----"
+    pop_fn 1
+    return 1
+  fi
 
   pop_fn
 }


### PR DESCRIPTION
Refs #1438 - improves diagnostics, does not close it (the underlying CI failure is still unresolved).

The cloud/console CI jobs have been failing since early July with only one line of output: `error: deployment fabric-operator exceeded its progress deadline`. I traced why the log is that terse rather than confirming the actual root cause of the deployment not becoming ready - I couldn't reproduce the full kind/k8s environment locally to pin that down further.

Two things compound to make it a dead end right now:
- `wait_for_deployment()` only runs `kubectl rollout status`, which on a `ProgressDeadlineExceeded` failure prints nothing beyond that one summary line - no pod status, no events, no container logs.
- `LOG_ERROR_LINES` defaults to `1`, so even the debug log's own tail-on-exit only ever shows the single last line, no matter how much a failing command actually printed.

This adds a diagnostics dump (`describe deploy`, `get pods`, `describe pods`, `logs --previous` and `logs`, scoped to the deployment's own selector via `kubectl get deploy -o json | jq`) when `wait_for_deployment` fails, and bumps `LOG_ERROR_LINES` to 200 so it actually surfaces in the log instead of being clipped to one line.

Doesn't fix the underlying regression - just turns the next occurrence (including a rerun of this same job) into something a maintainer can actually diagnose from the CI log.
