### PR TITLE
Fix createChannel wrongly recreating an already-running network

### DIFF
--- a/test-network/network.sh
+++ b/test-network/network.sh
@@ -334,12 +334,12 @@ function createChannel() {
   CONTAINERS=($($CONTAINER_CLI ps | grep hyperledger/ | awk '{print $2}'))
   len=$(echo ${#CONTAINERS[@]})
 
-  if [[ $len -ge 4 ]] && [[ ! -d "organizations/peerOrganizations" ]]; then
+  if [[ $len -ge 3 ]] && [[ ! -d "organizations/peerOrganizations" ]]; then
     echo "Bringing network down to sync certs with containers"
     networkDown
   fi
 
-  [[ $len -lt 4 ]] || [[ ! -d "organizations/peerOrganizations" ]] && bringUpNetwork="true" || echo "Network Running Already"
+  [[ $len -lt 3 ]] || [[ ! -d "organizations/peerOrganizations" ]] && bringUpNetwork="true" || echo "Network Running Already"
 
   if [ $bringUpNetwork == "true"  ]; then
     infoln "Bringing up network"


### PR DESCRIPTION
Fixes #1243.

`createChannel()` decides whether the network is already up by counting running `hyperledger/`-prefixed containers and treating fewer than 4 as "not running". That threshold was correct back in 2022 (#641, when a persistent `cli` container was still part of the default network) but the default network today only launches 3 (orderer + 2 peers) - the `cli` container's gone. So `createChannel` always sees 3 < 4, decides the network isn't up, and calls `networkUp()` again - which doesn't inherit `-s couchdb` from the original `up` command, so it silently overwrites the running CouchDB-backed network with a fresh LevelDB one, exactly as reported.

I verified this against real containers rather than just reasoning from the compose files: reproduced with `./network.sh up -s couchdb` followed by a separate `./network.sh createChannel -c mychannel` - confirmed the peers get `Recreate`d, `couchdb0`/`couchdb1` end up orphaned, and the log switches to `using database leveldb`. With the threshold corrected to 3, the same steps now print `Network Running Already` and leave the running containers untouched.

Fixed both occurrences of the stale `4` - the count check that decides whether to bring the network down to resync certs (line 337) has the same assumption baked in and would stay broken if only the reported line were changed.
