### PR TITLE
Migrate rest-api-typescript to BullMQ v6

### DIFF
--- a/asset-transfer-basic/rest-api-typescript/package-lock.json
+++ b/asset-transfer-basic/rest-api-typescript/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "bullmq": "^1.47.2",
+        "bullmq": "^6.3.4",
         "cors": "^2.8.5",
         "dotenv": "^10.0.0",
         "env-var": "^7.0.1",
@@ -18,7 +18,7 @@
         "fabric-network": "^2.2.20",
         "helmet": "^4.6.0",
         "http-status-codes": "^2.1.4",
-        "ioredis": "^4.27.8",
+        "ioredis": "^5.9.0",
         "long": "^5.2.3",
         "passport": "^0.6.0",
         "passport-headerapikey": "^1.2.2",
@@ -30,7 +30,6 @@
         "@tsconfig/node12": "^12.1.0",
         "@types/cors": "^2.8.12",
         "@types/express": "^5.0.3",
-        "@types/ioredis": "^4.26.4",
         "@types/jest": "^27.4.1",
         "@types/node": "^12.20.55",
         "@types/passport": "^1.0.7",
@@ -42,7 +41,7 @@
         "eslint": "^8.49.0",
         "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-prettier": "^3.4.0",
-        "ioredis-mock": "^5.6.0",
+        "ioredis-mock": "^8.13.1",
         "jest": "^29.7.0",
         "jest-mock-extended": "^3.0.5",
         "pino-pretty": "^5.0.2",
@@ -54,7 +53,7 @@
         "typescript": "~5.2.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=20"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -709,6 +708,13 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
+    },
+    "node_modules/@ioredis/as-callback": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/as-callback/-/as-callback-3.0.0.tgz",
+      "integrity": "sha512-Kqv1rZ3WbgOrS+hgzJ5xG5WQuhvzzSTRYvNeyPMLOAM78MHSnuKI20JeJGbpuAt//LCuP0vsexZcorqW7kWhJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@ioredis/commands": {
       "version": "1.10.0",
@@ -1529,13 +1535,15 @@
       "integrity": "sha512-lPG6KlZs88gef6aD85z3HNkztpj7w2R7HmR3gygjfXCQmsLloWNARFkMuzKiiY8FGdh1XDpgBdrSf4aKDiA7Kg==",
       "dev": true
     },
-    "node_modules/@types/ioredis": {
-      "version": "4.28.10",
-      "resolved": "https://registry.npmjs.org/@types/ioredis/-/ioredis-4.28.10.tgz",
-      "integrity": "sha512-69LyhUgrXdgcNDv7ogs1qXZomnfOEnSmrmMFqKgt1XMJxmoOSG/u3wYy13yACIfKuMJ8IhKgHafDO3sx19zVQQ==",
+    "node_modules/@types/ioredis-mock": {
+      "version": "8.2.8",
+      "resolved": "https://registry.npmjs.org/@types/ioredis-mock/-/ioredis-mock-8.2.8.tgz",
+      "integrity": "sha512-Nxr1CXk8NtGVzWQ8WoGCOyo+HARd4CFc/Nt2+ITt3WWLNlj1InW38SzZwOJNqzA38iplrpBFp6Ny4KjPfeI+bA==",
       "dev": true,
-      "dependencies": {
-        "@types/node": "*"
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "ioredis": "^5"
       }
     },
     "node_modules/@types/istanbul-lib-coverage": {
@@ -2344,7 +2352,8 @@
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
     },
     "node_modules/bn.js": {
       "version": "4.12.3",
@@ -2463,60 +2472,39 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
     "node_modules/bullmq": {
-      "version": "1.91.1",
-      "resolved": "https://registry.npmjs.org/bullmq/-/bullmq-1.91.1.tgz",
-      "integrity": "sha512-u7dat9I8ZwouZ651AMZkBSvB6NVUPpnAjd4iokd9DM41whqIBnDjuL11h7+kEjcpiDKj6E+wxZiER00FqirZQg==",
+      "version": "6.3.4",
+      "resolved": "https://registry.npmjs.org/bullmq/-/bullmq-6.3.4.tgz",
+      "integrity": "sha512-DpilB5sayCB8huCp4YuzVhJjxB4ieHidzu+GPgbcjPi3kQv0gdLoLnk+I+mMACDQ88rTbSiT+B4crmhWFGL9GA==",
       "license": "MIT",
       "dependencies": {
-        "cron-parser": "^4.6.0",
-        "get-port": "6.1.2",
-        "glob": "^8.0.3",
-        "ioredis": "^5.2.2",
-        "lodash": "^4.17.21",
-        "msgpackr": "^1.6.2",
-        "semver": "^7.3.7",
-        "tslib": "^2.0.0",
-        "uuid": "^9.0.0"
-      }
-    },
-    "node_modules/bullmq/node_modules/cluster-key-slot": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.1.tgz",
-      "integrity": "sha512-rwHwUfXL40Chm1r08yrhU3qpUvdVlgkKNeyeGPOxnW8/SyVDvgRaed/Uz54AqWNaTCAThlj6QAs3TZcKI0xDEw==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/bullmq/node_modules/denque": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
-      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "node_modules/bullmq/node_modules/ioredis": {
-      "version": "5.11.1",
-      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.11.1.tgz",
-      "integrity": "sha512-ehuGcf94bQXhfagULNXrJdfnWO38v070jxSx/qE87Kjzmu2fU7ro5EFAb+OPituLqgfyuQaym5DlrNydW2sJ9A==",
-      "license": "MIT",
-      "dependencies": {
-        "@ioredis/commands": "1.10.0",
-        "cluster-key-slot": "1.1.1",
-        "debug": "4.4.3",
-        "denque": "2.1.0",
-        "redis-errors": "1.2.0",
-        "redis-parser": "3.0.0",
-        "standard-as-callback": "2.1.0"
+        "cron-parser": "5.10.0",
+        "msgpackr": "2.1.0",
+        "node-abort-controller": "3.1.1",
+        "semver": "7.8.5",
+        "tslib": "2.8.1"
       },
       "engines": {
-        "node": ">=12.22.0"
+        "node": ">=14.17.0"
       },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ioredis"
+      "peerDependencies": {
+        "bullmq-otel": ">=2.0.0",
+        "ioredis": ">=5.0.0",
+        "pg": ">=8.0.0",
+        "redis": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "bullmq-otel": {
+          "optional": true
+        },
+        "ioredis": {
+          "optional": true
+        },
+        "pg": {
+          "optional": true
+        },
+        "redis": {
+          "optional": true
+        }
       }
     },
     "node_modules/bytes": {
@@ -2663,9 +2651,10 @@
       }
     },
     "node_modules/cluster-key-slot": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
-      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.1.tgz",
+      "integrity": "sha512-rwHwUfXL40Chm1r08yrhU3qpUvdVlgkKNeyeGPOxnW8/SyVDvgRaed/Uz54AqWNaTCAThlj6QAs3TZcKI0xDEw==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2824,16 +2813,15 @@
       "dev": true
     },
     "node_modules/cron-parser": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-4.9.0.tgz",
-      "integrity": "sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==",
-      "deprecated": "v4 is no longer maintained, upgrade to v5",
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-5.10.0.tgz",
+      "integrity": "sha512-izNAxJyRWUP8ljBoDSub5WyrVOUlT4SLGShswE7eoRBpp6QUsSycYxLBMJlbshgPBMcPT/nrfgjNY2918ayv2A==",
       "license": "MIT",
       "dependencies": {
-        "luxon": "^3.2.1"
+        "luxon": "^3.7.2"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=18"
       }
     },
     "node_modules/cross-spawn": {
@@ -2922,9 +2910,10 @@
       }
     },
     "node_modules/denque": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
-      "integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=0.10"
       }
@@ -3896,7 +3885,8 @@
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -3970,18 +3960,6 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/get-port": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/get-port/-/get-port-6.1.2.tgz",
-      "integrity": "sha512-BrGGraKm2uPqurfGVj/z97/zv8dPleC6x9JBNRTrDNtCkkRF4rPwrQXFgL7+I+q8QSdU4ntLQX2D7KIxSy8nGw==",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/get-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
@@ -4007,26 +3985,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/glob": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
-      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^5.0.1",
-        "once": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -4037,27 +3995,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
-      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/glob/node_modules/minimatch": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
-      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/globals": {
@@ -4341,6 +4278,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "dev": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -4360,24 +4298,21 @@
       }
     },
     "node_modules/ioredis": {
-      "version": "4.28.5",
-      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.28.5.tgz",
-      "integrity": "sha512-3GYo0GJtLqgNXj4YhrisLaNNvWSNwSS2wS4OELGfGxH8I69+XfNdnmV1AyN+ZqMh0i7eX+SWjrwFKDBDgfBC1A==",
+      "version": "5.11.1",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.11.1.tgz",
+      "integrity": "sha512-ehuGcf94bQXhfagULNXrJdfnWO38v070jxSx/qE87Kjzmu2fU7ro5EFAb+OPituLqgfyuQaym5DlrNydW2sJ9A==",
+      "license": "MIT",
       "dependencies": {
-        "cluster-key-slot": "^1.1.0",
-        "debug": "^4.3.1",
-        "denque": "^1.1.0",
-        "lodash.defaults": "^4.2.0",
-        "lodash.flatten": "^4.4.0",
-        "lodash.isarguments": "^3.1.0",
-        "p-map": "^2.1.0",
-        "redis-commands": "1.7.0",
-        "redis-errors": "^1.2.0",
-        "redis-parser": "^3.0.0",
-        "standard-as-callback": "^2.1.0"
+        "@ioredis/commands": "1.10.0",
+        "cluster-key-slot": "1.1.1",
+        "debug": "4.4.3",
+        "denque": "2.1.0",
+        "redis-errors": "1.2.0",
+        "redis-parser": "3.0.0",
+        "standard-as-callback": "2.1.0"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=12.22.0"
       },
       "funding": {
         "type": "opencollective",
@@ -4385,22 +4320,24 @@
       }
     },
     "node_modules/ioredis-mock": {
-      "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/ioredis-mock/-/ioredis-mock-5.9.1.tgz",
-      "integrity": "sha512-ZirdGJFOqH5nP8FYXuHUJmexvtZ6r2Ybc5alaGMzt38QA0kse5/rYnBQcb4ofxkyqzhXHuaCsXiwLlfG6NyhhQ==",
+      "version": "8.13.1",
+      "resolved": "https://registry.npmjs.org/ioredis-mock/-/ioredis-mock-8.13.1.tgz",
+      "integrity": "sha512-Wsi50AU+cMiI32nAgfwpUaJVBtb4iQdVsOHl9M6R3tePCO/8vGsToCVIG82XWAxN4Se55TZoOzVseu+QngFLyw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
+        "@ioredis/as-callback": "^3.0.0",
+        "@ioredis/commands": "^1.4.0",
         "fengari": "^0.1.4",
-        "fengari-interop": "^0.1.2",
-        "lodash": "^4.17.21",
-        "standard-as-callback": "^2.1.0"
+        "fengari-interop": "^0.1.3",
+        "semver": "^7.7.2"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=12.22"
       },
       "peerDependencies": {
-        "ioredis": "4.x",
-        "redis-commands": "1.x"
+        "@types/ioredis-mock": "^8",
+        "ioredis": "^5"
       }
     },
     "node_modules/ipaddr.js": {
@@ -5690,21 +5627,6 @@
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="
     },
-    "node_modules/lodash.defaults": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
-      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="
-    },
-    "node_modules/lodash.flatten": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-      "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g=="
-    },
-    "node_modules/lodash.isarguments": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg=="
-    },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -5904,12 +5826,12 @@
       "license": "MIT"
     },
     "node_modules/msgpackr": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.12.1.tgz",
-      "integrity": "sha512-4EUH9tQHnMmEgzW/MdAP0KIfa1T9AF+htl0ffe2n5vb2EKn9y2co8ccpgWko6S52Jy1PQZKwRnx5/KkYjtd9MQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-2.1.0.tgz",
+      "integrity": "sha512-p/pBCVO63CsvvpkomUnNNag6+n38rULuDA6HHe70o2gtC8ODI52foF/4ko2qQcp6OiErJXTmrZeXmsGGHsIQNQ==",
       "license": "MIT",
       "optionalDependencies": {
-        "msgpackr-extract": "^3.0.2"
+        "msgpackr-extract": "^3.0.4"
       }
     },
     "node_modules/msgpackr-extract": {
@@ -6170,14 +6092,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-map": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
-      "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/p-try": {
@@ -6763,11 +6677,6 @@
       "engines": {
         "node": ">= 0.8.0"
       }
-    },
-    "node_modules/redis-commands": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
-      "integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ=="
     },
     "node_modules/redis-errors": {
       "version": "1.2.0",
@@ -7760,20 +7669,6 @@
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
       "engines": {
         "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {

--- a/asset-transfer-basic/rest-api-typescript/package.json
+++ b/asset-transfer-basic/rest-api-typescript/package.json
@@ -4,10 +4,10 @@
   "description": "Asset Transfer Basic REST API implemented in TypeScript",
   "main": "dist/index.js",
   "engines": {
-    "node": ">=12"
+    "node": ">=20"
   },
   "dependencies": {
-    "bullmq": "^1.47.2",
+    "bullmq": "^6.3.4",
     "cors": "^2.8.5",
     "dotenv": "^10.0.0",
     "env-var": "^7.0.1",
@@ -16,7 +16,7 @@
     "fabric-network": "^2.2.20",
     "helmet": "^4.6.0",
     "http-status-codes": "^2.1.4",
-    "ioredis": "^4.27.8",
+    "ioredis": "^5.9.0",
     "long": "^5.2.3",
     "passport": "^0.6.0",
     "passport-headerapikey": "^1.2.2",
@@ -28,7 +28,6 @@
     "@tsconfig/node12": "^12.1.0",
     "@types/cors": "^2.8.12",
     "@types/express": "^5.0.3",
-    "@types/ioredis": "^4.26.4",
     "@types/jest": "^27.4.1",
     "@types/node": "^12.20.55",
     "@types/passport": "^1.0.7",
@@ -40,7 +39,7 @@
     "eslint": "^8.49.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-prettier": "^3.4.0",
-    "ioredis-mock": "^5.6.0",
+    "ioredis-mock": "^8.13.1",
     "jest": "^29.7.0",
     "jest-mock-extended": "^3.0.5",
     "pino-pretty": "^5.0.2",

--- a/asset-transfer-basic/rest-api-typescript/src/config.spec.ts
+++ b/asset-transfer-basic/rest-api-typescript/src/config.spec.ts
@@ -192,28 +192,6 @@ describe('Config values', () => {
         });
     });
 
-    describe('submitJobQueueScheduler', () => {
-        it('defaults to "true"', () => {
-            const config = require('./config');
-            expect(config.submitJobQueueScheduler).toBe(true);
-        });
-
-        it('can be configured using the "SUBMIT_JOB_QUEUE_SCHEDULER" environment variable', () => {
-            process.env.SUBMIT_JOB_QUEUE_SCHEDULER = 'false';
-            const config = require('./config');
-            expect(config.submitJobQueueScheduler).toBe(false);
-        });
-
-        it('throws an error when the "SUBMIT_JOB_QUEUE_SCHEDULER" environment variable has an invalid boolean value', () => {
-            process.env.SUBMIT_JOB_QUEUE_SCHEDULER = '11';
-            expect(() => {
-                require('./config');
-            }).toThrow(
-                'env-var: "SUBMIT_JOB_QUEUE_SCHEDULER" should be either "true", "false", "TRUE", or "FALSE". An example of a valid value would be: true'
-            );
-        });
-    });
-
     describe('asLocalhost', () => {
         it('defaults to "true"', () => {
             const config = require('./config');

--- a/asset-transfer-basic/rest-api-typescript/src/config.ts
+++ b/asset-transfer-basic/rest-api-typescript/src/config.ts
@@ -91,17 +91,6 @@ export const maxFailedSubmitJobs = env
     .asIntPositive();
 
 /**
- * Whether to initialise a scheduler for the submit job queue
- * There must be at least on queue scheduler to handle retries and you may want
- * more than one for redundancy
- */
-export const submitJobQueueScheduler = env
-    .get('SUBMIT_JOB_QUEUE_SCHEDULER')
-    .default('true')
-    .example('true')
-    .asBoolStrict();
-
-/**
  * Whether to convert discovered host addresses to be 'localhost'
  * This should be set to 'true' when running a docker composed fabric network on the
  * local system, e.g. using the test network; otherwise should it should be 'false'

--- a/asset-transfer-basic/rest-api-typescript/src/index.ts
+++ b/asset-transfer-basic/rest-api-typescript/src/index.ts
@@ -13,19 +13,14 @@ import {
     getContracts,
     getNetwork,
 } from './fabric';
-import {
-    initJobQueue,
-    initJobQueueScheduler,
-    initJobQueueWorker,
-} from './jobs';
+import { initJobQueue, initJobQueueWorker } from './jobs';
 import { logger } from './logger';
 import { createServer } from './server';
 import { isMaxmemoryPolicyNoeviction } from './redis';
-import { Queue, QueueScheduler, Worker } from 'bullmq';
+import { Queue, Worker } from 'bullmq';
 
 let jobQueue: Queue | undefined;
 let jobQueueWorker: Worker | undefined;
-let jobQueueScheduler: QueueScheduler | undefined;
 
 async function main() {
     logger.info('Checking Redis config');
@@ -65,10 +60,6 @@ async function main() {
     logger.info('Initialising submit job queue');
     jobQueue = initJobQueue();
     jobQueueWorker = initJobQueueWorker(app);
-    if (config.submitJobQueueScheduler === true) {
-        logger.info('Initialising submit job queue scheduler');
-        jobQueueScheduler = initJobQueueScheduler();
-    }
     app.locals.jobq = jobQueue;
 
     logger.info('Starting REST server');
@@ -79,11 +70,6 @@ async function main() {
 
 main().catch(async (err) => {
     logger.error({ err }, 'Unxepected error');
-
-    if (jobQueueScheduler != undefined) {
-        logger.debug('Closing job queue scheduler');
-        await jobQueueScheduler.close();
-    }
 
     if (jobQueueWorker != undefined) {
         logger.debug('Closing job queue worker');

--- a/asset-transfer-basic/rest-api-typescript/src/jobs.spec.ts
+++ b/asset-transfer-basic/rest-api-typescript/src/jobs.spec.ts
@@ -176,8 +176,8 @@ describe('updateJobData', () => {
 
         await updateJobData(mockJob, mockTransaction);
 
-        expect(mockJob.update).toBeCalledTimes(1);
-        expect(mockJob.update).toBeCalledWith({
+        expect(mockJob.updateData).toBeCalledTimes(1);
+        expect(mockJob.updateData).toBeCalledWith({
             transactionIds: ['txn1', 'txn2'],
             transactionState: mockSavedState,
         });
@@ -186,8 +186,8 @@ describe('updateJobData', () => {
     it('removes the serialized state from the job data if a transaction is not specified', async () => {
         await updateJobData(mockJob, undefined);
 
-        expect(mockJob.update).toBeCalledTimes(1);
-        expect(mockJob.update).toBeCalledWith({
+        expect(mockJob.updateData).toBeCalledTimes(1);
+        expect(mockJob.updateData).toBeCalledWith({
             transactionIds: ['txn1'],
             transactionState: undefined,
         });

--- a/asset-transfer-basic/rest-api-typescript/src/jobs.ts
+++ b/asset-transfer-basic/rest-api-typescript/src/jobs.ts
@@ -5,7 +5,7 @@
  * retry support for failing jobs
  */
 
-import { ConnectionOptions, Job, Queue, QueueScheduler, Worker } from 'bullmq';
+import { ConnectionOptions, Job, Queue, Worker } from 'bullmq';
 import { Application } from 'express';
 import { Contract, Transaction } from 'fabric-network';
 import * as config from './config';
@@ -75,6 +75,10 @@ export const initJobQueue = (): Queue => {
 /**
  * Set up a worker to process submit jobs on the queue, using the
  * processSubmitTransactionJob function below
+ *
+ * The worker also manages stalled and delayed jobs, which is what makes
+ * retries with backoff work.  Before BullMQ v2 that was the job of a separate
+ * QueueScheduler, which no longer exists.
  */
 export const initJobQueueWorker = (app: Application): Worker => {
     const worker = new Worker<JobData, JobResult>(
@@ -210,23 +214,6 @@ export const processSubmitTransactionJob = async (
 };
 
 /**
- * Set up a scheduler for the submit job queue
- *
- * This manages stalled and delayed jobs and is required for retries with backoff
- */
-export const initJobQueueScheduler = (): QueueScheduler => {
-    const queueScheduler = new QueueScheduler(config.JOB_QUEUE_NAME, {
-        connection,
-    });
-
-    queueScheduler.on('failed', (jobId, failedReason) => {
-        logger.error({ jobId, failedReason }, 'Queue sceduler failure');
-    });
-
-    return queueScheduler;
-};
-
-/**
  * Helper to add a new submit transaction job to the queue
  */
 export const addSubmitTransactionJob = async (
@@ -271,7 +258,8 @@ export const updateJobData = async (
         newData.transactionState = undefined;
     }
 
-    await job.update(newData);
+    // BullMQ v5 renamed Job.update to Job.updateData
+    await job.updateData(newData);
 };
 
 /**

--- a/asset-transfer-basic/rest-api-typescript/src/redis.ts
+++ b/asset-transfer-basic/rest-api-typescript/src/redis.ts
@@ -28,10 +28,12 @@ export const isMaxmemoryPolicyNoeviction = async (): Promise<boolean> => {
     try {
         redis = new IORedis(redisOptions);
 
-        const maxmemoryPolicyConfig = await (redis as Redis).config(
+        // ioredis 5 types the CONFIG GET reply as unknown.  Over RESP2 it is
+        // a flat array of alternating parameter names and values.
+        const maxmemoryPolicyConfig = (await redis.config(
             'GET',
             'maxmemory-policy'
-        );
+        )) as string[];
         logger.debug({ maxmemoryPolicyConfig }, 'Got maxmemory-policy config');
 
         if (

--- a/asset-transfer-basic/rest-api-typescript/tsconfig.json
+++ b/asset-transfer-basic/rest-api-typescript/tsconfig.json
@@ -3,7 +3,8 @@
   "extends": "@tsconfig/node12/tsconfig.json",
   "compilerOptions": {
     "sourceMap": true,
-    "outDir": "./dist"
+    "outDir": "./dist",
+    "types": ["node", "jest"]
   },
   "include": [
     "src/"


### PR DESCRIPTION
bullmq@1 depends on uuid@^9, which is affected by GHSA-w5hq-g745-h8pq (missing buffer bounds check in v3/v5/v6, patched in 11.1.1).  No patched uuid is reachable while bullmq stays on v1, so move the sample to v6, which has no uuid dependency at all.

Dependabot tried the same bump in #1448 and broke CI, because it cannot be done as a dependency-only change:

- bullmq@1 vendored its own ioredis@5 under node_modules/bullmq, so it never met the root's ioredis@4.  bullmq@6 declares ioredis as a peer (>=5.0.0) instead, so it now resolves against the root, which must move to ioredis 5 along with ioredis-mock 8.  @types/ioredis goes away because ioredis 5 ships its own types.

- QueueScheduler was removed in bullmq v2, its stalled and delayed job handling folded into Worker.  Drop initJobQueueScheduler, its startup and shutdown paths, and the SUBMIT_JOB_QUEUE_SCHEDULER config option that gated it.

- Job.update was renamed Job.updateData in v5.

- ioredis 5 types the CONFIG GET reply as unknown.

engines.node moves from >=12 to >=20 to match the other maintained TypeScript samples; bullmq 6 cannot run on Node 12 anyway.

tsconfig.json now names its types explicitly.  Newer @tsconfig/node12 releases set "types": ["node"], which silently drops the jest globals: suites that import jest-mock-extended still see them through its triple-slash reference, but config.spec.ts and redis.spec.ts do not, and fail to compile the moment the lockfile re-resolves that package.

Fixes #1449